### PR TITLE
feat: EVM signing, PSBT signing, and signRawMessage

### DIFF
--- a/enclave/src/keys.rs
+++ b/enclave/src/keys.rs
@@ -3,8 +3,12 @@ use std::sync::Mutex;
 
 use bip39::Mnemonic;
 use bitcoin::bip32::{DerivationPath, Xpriv, Xpub};
-use bitcoin::secp256k1::{PublicKey, Secp256k1};
+use bitcoin::hashes::Hash;
+use bitcoin::psbt::Psbt;
+use bitcoin::secp256k1::{Message, PublicKey, Secp256k1, SecretKey};
+use bitcoin::sighash::{EcdsaSighashType, SighashCache};
 use bitcoin::Network;
+use k256::ecdsa::SigningKey as K256SigningKey;
 use secrecy::{ExposeSecret, SecretBox};
 use sha3::{Digest, Keccak256};
 use zeroize::Zeroize;
@@ -20,7 +24,6 @@ pub struct KeyInfo {
 
 /// Holds HD wallet keys in memory. Secrets are wrapped in SecretBox for
 /// zeroize-on-drop. Public keys are stored in plain form.
-#[allow(dead_code)] // evm_secret, btc_secret used in T3 (signing)
 pub struct KeyManager {
     seed: SecretBox<[u8; 64]>,
     evm_secret: SecretBox<[u8; 32]>,
@@ -121,6 +124,73 @@ impl KeyManager {
     pub fn expose_seed(&self) -> &[u8; 64] {
         self.seed.expose_secret()
     }
+
+    /// Sign a 32-byte message hash with the EVM secp256k1 key.
+    /// Returns 65 bytes: r(32) + s(32) + v(1) — Ethereum `ecrecover` convention.
+    pub fn sign_evm(&self, message_hash: &[u8; 32]) -> Result<[u8; 65]> {
+        let signing_key = K256SigningKey::from_slice(self.evm_secret.expose_secret())
+            .map_err(|e| EnclaveError::Signing(format!("evm key: {e}")))?;
+
+        let (signature, recovery_id) = signing_key
+            .sign_prehash_recoverable(message_hash)
+            .map_err(|e| EnclaveError::Signing(format!("ecdsa sign: {e}")))?;
+
+        let mut result = [0u8; 65];
+        result[..64].copy_from_slice(&signature.to_bytes());
+        result[64] = recovery_id.to_byte();
+        Ok(result)
+    }
+
+    /// Sign PSBT inputs matching our BTC key (SegWit v0 P2WSH multisig).
+    /// Returns the modified PSBT bytes and count of inputs signed.
+    pub fn sign_psbt(&self, psbt_bytes: &[u8]) -> Result<(Vec<u8>, usize)> {
+        let secp = Secp256k1::new();
+        let secret_key = SecretKey::from_slice(self.btc_secret.expose_secret())
+            .map_err(|e| EnclaveError::Signing(format!("btc key: {e}")))?;
+        let our_pubkey = secret_key.public_key(&secp);
+
+        let mut psbt = Psbt::deserialize(psbt_bytes)
+            .map_err(|e| EnclaveError::Signing(format!("psbt deserialize: {e}")))?;
+
+        let unsigned_tx = psbt.unsigned_tx.clone();
+        let mut sighash_cache = SighashCache::new(&unsigned_tx);
+        let mut signed_count = 0usize;
+
+        for i in 0..psbt.inputs.len() {
+            if !crate::signing::psbt::should_sign_segwit_input(&psbt, i, &our_pubkey) {
+                continue;
+            }
+
+            // SegWit v0 P2WSH: need witness_utxo (for value) and witness_script
+            let witness_utxo = psbt.inputs[i].witness_utxo.as_ref().ok_or_else(|| {
+                EnclaveError::Signing(format!("missing witness_utxo for input {i}"))
+            })?;
+            let witness_script = psbt.inputs[i].witness_script.as_ref().ok_or_else(|| {
+                EnclaveError::Signing(format!("missing witness_script for input {i}"))
+            })?;
+
+            // BIP-143 sighash for SegWit v0
+            let sighash = sighash_cache
+                .p2wsh_signature_hash(i, witness_script, witness_utxo.value, EcdsaSighashType::All)
+                .map_err(|e| EnclaveError::Signing(format!("sighash: {e}")))?;
+
+            let msg = Message::from_digest(sighash.to_byte_array());
+            let sig = secp.sign_ecdsa(&msg, &secret_key);
+
+            // Insert partial signature into PSBT
+            let bitcoin_sig = bitcoin::ecdsa::Signature {
+                signature: sig,
+                sighash_type: EcdsaSighashType::All,
+            };
+            psbt.inputs[i]
+                .partial_sigs
+                .insert(bitcoin::PublicKey::new(our_pubkey), bitcoin_sig);
+            signed_count += 1;
+        }
+
+        let signed_bytes = psbt.serialize();
+        Ok((signed_bytes, signed_count))
+    }
 }
 
 /// Thread-safe enclave state holding an optional KeyManager behind a Mutex.
@@ -181,6 +251,30 @@ impl EnclaveState {
 
     pub fn is_initialized(&self) -> bool {
         self.inner.lock().map(|g| g.is_some()).unwrap_or(false)
+    }
+
+    /// Sign a 32-byte EVM message hash. Returns 65-byte signature.
+    pub fn sign_evm(&self, message_hash: &[u8; 32]) -> Result<[u8; 65]> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|e| EnclaveError::Internal(format!("lock poisoned: {}", e)))?;
+        match guard.as_ref() {
+            Some(km) => km.sign_evm(message_hash),
+            None => Err(EnclaveError::KeyNotInitialized),
+        }
+    }
+
+    /// Sign PSBT inputs matching our BTC key. Returns (signed_psbt_bytes, inputs_signed).
+    pub fn sign_psbt(&self, psbt_bytes: &[u8]) -> Result<(Vec<u8>, usize)> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|e| EnclaveError::Internal(format!("lock poisoned: {}", e)))?;
+        match guard.as_ref() {
+            Some(km) => km.sign_psbt(psbt_bytes),
+            None => Err(EnclaveError::KeyNotInitialized),
+        }
     }
 }
 
@@ -249,5 +343,161 @@ mod tests {
         let state = EnclaveState::new();
         let result = state.get_keys();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_sign_evm_produces_65_bytes() {
+        let seed = [0x42u8; 64];
+        let km = KeyManager::from_seed(seed).unwrap();
+        let hash = [0xABu8; 32];
+        let sig = km.sign_evm(&hash).unwrap();
+        assert_eq!(sig.len(), 65);
+        // recovery_id should be 0 or 1
+        assert!(sig[64] <= 1);
+    }
+
+    #[test]
+    fn test_sign_evm_deterministic() {
+        let seed = [0x42u8; 64];
+        let km = KeyManager::from_seed(seed).unwrap();
+        let hash = [0xABu8; 32];
+        let sig1 = km.sign_evm(&hash).unwrap();
+        let sig2 = km.sign_evm(&hash).unwrap();
+        assert_eq!(sig1, sig2); // k256 uses RFC 6979 deterministic nonces
+    }
+
+    #[test]
+    fn test_sign_evm_recoverable() {
+        use k256::ecdsa::{RecoveryId, Signature as K256Signature, VerifyingKey};
+
+        let seed = [0x42u8; 64];
+        let km = KeyManager::from_seed(seed).unwrap();
+        let hash = [0xABu8; 32];
+        let sig_bytes = km.sign_evm(&hash).unwrap();
+
+        let signature = K256Signature::from_slice(&sig_bytes[..64]).unwrap();
+        let recovery_id = RecoveryId::from_byte(sig_bytes[64]).unwrap();
+        let recovered_key =
+            VerifyingKey::recover_from_prehash(&hash, &signature, recovery_id).unwrap();
+
+        // Derive address from recovered key and compare
+        let pubkey_bytes = recovered_key.to_encoded_point(false);
+        let pubkey_hash = Keccak256::digest(&pubkey_bytes.as_bytes()[1..]);
+        let recovered_address: [u8; 20] = pubkey_hash[12..].try_into().unwrap();
+
+        assert_eq!(&recovered_address, km.evm_address());
+    }
+
+    /// Build a minimal 2-of-3 multisig PSBT for testing.
+    fn build_test_multisig_psbt(our_pubkey: &bitcoin::PublicKey) -> Vec<u8> {
+        use bitcoin::blockdata::opcodes::all::*;
+        use bitcoin::blockdata::script::Builder as ScriptBuilder;
+        use bitcoin::{Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid};
+
+        let secp = Secp256k1::new();
+
+        let sk2 = SecretKey::from_slice(&[0x02; 32]).unwrap();
+        let pk2 = bitcoin::PublicKey::new(sk2.public_key(&secp));
+        let sk3 = SecretKey::from_slice(&[0x03; 32]).unwrap();
+        let pk3 = bitcoin::PublicKey::new(sk3.public_key(&secp));
+
+        let mut pubkeys = vec![*our_pubkey, pk2, pk3];
+        pubkeys.sort_by_key(|k| k.to_bytes());
+
+        let witness_script = ScriptBuilder::new()
+            .push_int(2)
+            .push_key(&pubkeys[0])
+            .push_key(&pubkeys[1])
+            .push_key(&pubkeys[2])
+            .push_int(3)
+            .push_opcode(OP_CHECKMULTISIG)
+            .into_script();
+
+        let unsigned_tx = Transaction {
+            version: bitcoin::transaction::Version(2),
+            lock_time: bitcoin::blockdata::locktime::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([0xAA; 32]),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: bitcoin::Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: ScriptBuf::new_p2wpkh(
+                    &bitcoin::WPubkeyHash::from_byte_array([0xBB; 20]),
+                ),
+            }],
+        };
+
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+
+        let witness_script_hash = bitcoin::WScriptHash::hash(witness_script.as_bytes());
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey: ScriptBuf::new_p2wsh(&witness_script_hash),
+        });
+        psbt.inputs[0].witness_script = Some(witness_script);
+
+        psbt.serialize()
+    }
+
+    #[test]
+    fn test_sign_psbt_one_input() {
+        let seed = [0x42u8; 64];
+        let km = KeyManager::from_seed(seed).unwrap();
+
+        let our_pubkey = bitcoin::PublicKey::from_slice(km.btc_compressed_pubkey()).unwrap();
+        let psbt_bytes = build_test_multisig_psbt(&our_pubkey);
+
+        let (signed_bytes, count) = km.sign_psbt(&psbt_bytes).unwrap();
+        assert_eq!(count, 1);
+
+        let signed_psbt = Psbt::deserialize(&signed_bytes).unwrap();
+        assert!(signed_psbt.inputs[0].partial_sigs.contains_key(&our_pubkey));
+    }
+
+    #[test]
+    fn test_sign_psbt_skip_already_signed() {
+        let seed = [0x42u8; 64];
+        let km = KeyManager::from_seed(seed).unwrap();
+
+        let our_pubkey = bitcoin::PublicKey::from_slice(km.btc_compressed_pubkey()).unwrap();
+        let psbt_bytes = build_test_multisig_psbt(&our_pubkey);
+
+        let (signed_bytes, count1) = km.sign_psbt(&psbt_bytes).unwrap();
+        assert_eq!(count1, 1);
+
+        // Sign the already-signed PSBT again — should skip
+        let (_, count2) = km.sign_psbt(&signed_bytes).unwrap();
+        assert_eq!(count2, 0);
+    }
+
+    #[test]
+    fn test_sign_psbt_invalid_bytes() {
+        let mut entropy = [0u8; 32];
+        getrandom::fill(&mut entropy).unwrap();
+        let (km, _mnemonic) = KeyManager::generate(&mut entropy).unwrap();
+
+        let result = km.sign_psbt(&[0xFF, 0xFF, 0xFF]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_sign_psbt_no_matching_inputs() {
+        let mut entropy = [0u8; 32];
+        getrandom::fill(&mut entropy).unwrap();
+        let (km, _mnemonic) = KeyManager::generate(&mut entropy).unwrap();
+
+        let secp = Secp256k1::new();
+        let other_sk = SecretKey::from_slice(&[0x99; 32]).unwrap();
+        let other_pk = bitcoin::PublicKey::new(other_sk.public_key(&secp));
+        let psbt_bytes = build_test_multisig_psbt(&other_pk);
+
+        let (_, count) = km.sign_psbt(&psbt_bytes).unwrap();
+        assert_eq!(count, 0);
     }
 }

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -6,6 +6,7 @@ use crate::keys::EnclaveState;
 use crate::proto::enclave_request::Request;
 use crate::proto::enclave_response::Response;
 use crate::proto::*;
+use crate::signing::evm::{sign_request_digest, Eip712Domain};
 
 /// Handle a single connection: read one request, dispatch, write one response, close.
 pub fn handle_connection(stream: impl Read + Write, state: &EnclaveState) {
@@ -39,6 +40,18 @@ fn dispatch(request: EnclaveRequest, state: &EnclaveState) -> EnclaveResponse {
         Some(Request::GetPublicKey(req)) => {
             tracing::info!("request: GetPublicKey");
             handle_get_public_key(state, req)
+        }
+        Some(Request::SignEvm(req)) => {
+            tracing::info!("request: SignEvm");
+            handle_sign_evm(state, req)
+        }
+        Some(Request::SignPsbt(req)) => {
+            tracing::info!("request: SignPsbt");
+            handle_sign_psbt(state, req)
+        }
+        Some(Request::SignRawMessage(req)) => {
+            tracing::info!("request: SignRawMessage");
+            handle_sign_raw_message(state, req)
         }
         None => {
             tracing::warn!("received empty request (no oneof variant set)");
@@ -123,6 +136,69 @@ fn handle_get_public_key(
             evm_address: keys.evm_address.to_vec(),
             btc_compressed_pub: keys.btc_compressed_pubkey.to_vec(),
             btc_xpub: keys.btc_xpub,
+        })),
+    })
+}
+
+fn handle_sign_evm(state: &EnclaveState, req: SignEvmRequest) -> Result<EnclaveResponse> {
+    // TODO: load from config
+    let domain = Eip712Domain {
+        name: "Tricorn".to_string(),
+        version: "1".to_string(),
+        chain_id: 1,
+        verifying_contract: [0u8; 20],
+    };
+
+    let digest = sign_request_digest(&domain, &req.call_data, req.nonce, req.deadline);
+    let signature = state.sign_evm(&digest)?;
+
+    tracing::info!(
+        sig_hex = %hex::encode(signature),
+        "EVM signature produced"
+    );
+
+    Ok(EnclaveResponse {
+        response: Some(Response::EvmSignature(EvmSignatureResponse {
+            signature: signature.to_vec(),
+        })),
+    })
+}
+
+fn handle_sign_psbt(state: &EnclaveState, req: SignPsbtRequest) -> Result<EnclaveResponse> {
+    let (signed_psbt, inputs_signed) = state.sign_psbt(&req.psbt_bytes)?;
+
+    tracing::info!(inputs_signed, "PSBT signed");
+
+    Ok(EnclaveResponse {
+        response: Some(Response::SignedPsbt(SignedPsbtResponse {
+            signed_psbt,
+            inputs_signed: inputs_signed as u32,
+        })),
+    })
+}
+
+fn handle_sign_raw_message(
+    state: &EnclaveState,
+    req: SignRawMessageRequest,
+) -> Result<EnclaveResponse> {
+    if req.message.is_empty() {
+        return Err(EnclaveError::InvalidRequest("message is empty".into()));
+    }
+
+    // Hash the raw message with keccak256 to produce a 32-byte digest
+    use sha3::{Digest, Keccak256};
+    let hash: [u8; 32] = Keccak256::digest(&req.message).into();
+    let signature = state.sign_evm(&hash)?;
+
+    tracing::info!(
+        sig_hex = %hex::encode(signature),
+        msg_len = req.message.len(),
+        "raw message signature produced"
+    );
+
+    Ok(EnclaveResponse {
+        response: Some(Response::RawSignature(RawSignatureResponse {
+            signature: signature.to_vec(),
         })),
     })
 }

--- a/enclave/src/signing/evm.rs
+++ b/enclave/src/signing/evm.rs
@@ -1,0 +1,171 @@
+use sha3::{Digest, Keccak256};
+
+// TODO: align with final MultisigProxy.sol — may need selector field
+const DOMAIN_TYPE_HASH_STR: &str =
+    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)";
+const SIGN_REQUEST_TYPE_HASH_STR: &str =
+    "SignRequest(bytes callData,uint256 nonce,uint256 deadline)";
+
+/// EIP-712 domain separator components.
+/// Must match the deployed MultisigProxy contract exactly.
+pub struct Eip712Domain {
+    pub name: String,
+    pub version: String,
+    pub chain_id: u64,
+    pub verifying_contract: [u8; 20],
+}
+
+impl Eip712Domain {
+    /// Compute the domain separator hash per EIP-712.
+    pub fn separator_hash(&self) -> [u8; 32] {
+        let type_hash = Keccak256::digest(DOMAIN_TYPE_HASH_STR.as_bytes());
+        let name_hash = Keccak256::digest(self.name.as_bytes());
+        let version_hash = Keccak256::digest(self.version.as_bytes());
+
+        let mut buf = Vec::with_capacity(32 * 5);
+        buf.extend_from_slice(&type_hash);
+        buf.extend_from_slice(&name_hash);
+        buf.extend_from_slice(&version_hash);
+        buf.extend_from_slice(&abi_encode_u256(self.chain_id));
+        buf.extend_from_slice(&abi_encode_address(&self.verifying_contract));
+
+        Keccak256::digest(&buf).into()
+    }
+}
+
+/// Build the EIP-712 digest for: SignRequest(bytes callData, uint256 nonce, uint256 deadline)
+/// Returns the 32-byte hash ready to be signed with ECDSA.
+pub fn sign_request_digest(
+    domain: &Eip712Domain,
+    call_data: &[u8],
+    nonce: u64,
+    deadline: u64,
+) -> [u8; 32] {
+    let struct_hash = {
+        let type_hash = Keccak256::digest(SIGN_REQUEST_TYPE_HASH_STR.as_bytes());
+        let call_data_hash = Keccak256::digest(call_data);
+
+        let mut buf = Vec::with_capacity(32 * 4);
+        buf.extend_from_slice(&type_hash);
+        buf.extend_from_slice(&call_data_hash);
+        buf.extend_from_slice(&abi_encode_u256(nonce));
+        buf.extend_from_slice(&abi_encode_u256(deadline));
+
+        let hash: [u8; 32] = Keccak256::digest(&buf).into();
+        hash
+    };
+
+    let domain_separator = domain.separator_hash();
+
+    let mut buf = Vec::with_capacity(2 + 32 + 32);
+    buf.extend_from_slice(&[0x19, 0x01]);
+    buf.extend_from_slice(&domain_separator);
+    buf.extend_from_slice(&struct_hash);
+
+    Keccak256::digest(&buf).into()
+}
+
+/// ABI-encode a u64 as a uint256 (32 bytes, big-endian, right-aligned).
+fn abi_encode_u256(val: u64) -> [u8; 32] {
+    let mut buf = [0u8; 32];
+    buf[24..].copy_from_slice(&val.to_be_bytes());
+    buf
+}
+
+/// ABI-encode an address (20 bytes, left-padded to 32 bytes).
+fn abi_encode_address(addr: &[u8; 20]) -> [u8; 32] {
+    let mut buf = [0u8; 32];
+    buf[12..].copy_from_slice(addr);
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_abi_encode_u256() {
+        let encoded = abi_encode_u256(42);
+        assert_eq!(encoded[31], 42);
+        assert!(encoded[..31].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn test_abi_encode_u256_large() {
+        let encoded = abi_encode_u256(u64::MAX);
+        assert_eq!(&encoded[24..], &u64::MAX.to_be_bytes());
+        assert!(encoded[..24].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn test_abi_encode_address() {
+        let addr = [0xAA; 20];
+        let encoded = abi_encode_address(&addr);
+        assert!(encoded[..12].iter().all(|&b| b == 0));
+        assert_eq!(&encoded[12..], &[0xAA; 20]);
+    }
+
+    #[test]
+    fn test_domain_separator_deterministic() {
+        let domain = Eip712Domain {
+            name: "Tricorn".to_string(),
+            version: "1".to_string(),
+            chain_id: 1,
+            verifying_contract: [0u8; 20],
+        };
+        let hash1 = domain.separator_hash();
+        let hash2 = domain.separator_hash();
+        assert_eq!(hash1, hash2);
+        assert_ne!(hash1, [0u8; 32]);
+    }
+
+    #[test]
+    fn test_sign_request_digest_deterministic() {
+        let domain = Eip712Domain {
+            name: "Tricorn".to_string(),
+            version: "1".to_string(),
+            chain_id: 1,
+            verifying_contract: [0u8; 20],
+        };
+        let call_data = hex::decode(
+            "a9059cbb000000000000000000000000abcdefabcdefabcdefabcdefabcdefabcdefabcd\
+             0000000000000000000000000000000000000000000000000000000000000064",
+        )
+        .unwrap();
+        let digest1 = sign_request_digest(&domain, &call_data, 0, 1_700_000_000);
+        let digest2 = sign_request_digest(&domain, &call_data, 0, 1_700_000_000);
+        assert_eq!(digest1, digest2);
+        assert_ne!(digest1, [0u8; 32]);
+    }
+
+    #[test]
+    fn test_different_nonce_different_digest() {
+        let domain = Eip712Domain {
+            name: "Tricorn".to_string(),
+            version: "1".to_string(),
+            chain_id: 1,
+            verifying_contract: [0u8; 20],
+        };
+        let call_data = b"test";
+        let d1 = sign_request_digest(&domain, call_data, 0, 1_700_000_000);
+        let d2 = sign_request_digest(&domain, call_data, 1, 1_700_000_000);
+        assert_ne!(d1, d2);
+    }
+
+    #[test]
+    fn test_different_chain_id_different_domain() {
+        let d1 = Eip712Domain {
+            name: "Tricorn".to_string(),
+            version: "1".to_string(),
+            chain_id: 1,
+            verifying_contract: [0u8; 20],
+        };
+        let d2 = Eip712Domain {
+            name: "Tricorn".to_string(),
+            version: "1".to_string(),
+            chain_id: 137,
+            verifying_contract: [0u8; 20],
+        };
+        assert_ne!(d1.separator_hash(), d2.separator_hash());
+    }
+}

--- a/enclave/src/signing/mod.rs
+++ b/enclave/src/signing/mod.rs
@@ -1,1 +1,2 @@
-// Future: evm.rs (EIP-712 + ECDSA), psbt.rs (SegWit v0 multisig)
+pub mod evm;
+pub mod psbt;

--- a/enclave/src/signing/psbt.rs
+++ b/enclave/src/signing/psbt.rs
@@ -1,0 +1,35 @@
+use bitcoin::psbt::Psbt;
+use bitcoin::secp256k1::PublicKey;
+
+/// Determine whether we should sign a specific PSBT input.
+/// Checks (in order):
+/// 1. If our pubkey already has a partial_sig — skip (already signed)
+/// 2. If our pubkey is in bip32_derivation — sign
+/// 3. If the witness_script contains our compressed pubkey bytes — sign
+/// 4. Otherwise — skip
+pub fn should_sign_segwit_input(psbt: &Psbt, input_index: usize, our_pubkey: &PublicKey) -> bool {
+    let input = &psbt.inputs[input_index];
+    let our_bitcoin_pubkey = bitcoin::PublicKey::new(*our_pubkey);
+
+    // Already signed? Skip.
+    if input.partial_sigs.contains_key(&our_bitcoin_pubkey) {
+        return false;
+    }
+
+    // In BIP-32 derivation map? Sign.
+    // Note: bip32_derivation uses secp256k1::PublicKey as key type
+    if input.bip32_derivation.contains_key(our_pubkey) {
+        return true;
+    }
+
+    // In witness script? Sign (sliding window over script bytes for 33-byte compressed pubkey).
+    if let Some(script) = &input.witness_script {
+        let script_bytes = script.as_bytes();
+        let pubkey_bytes = our_pubkey.serialize(); // 33-byte compressed
+        if script_bytes.windows(33).any(|w| w == pubkey_bytes) {
+            return true;
+        }
+    }
+
+    false
+}

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -1,0 +1,260 @@
+mod common;
+
+use utexo_bridge_enclave::proto::enclave_request::Request;
+use utexo_bridge_enclave::proto::enclave_response::Response;
+use utexo_bridge_enclave::proto::*;
+
+/// Build a minimal 2-of-3 multisig PSBT for testing with a known pubkey.
+#[cfg(feature = "allow-seed-import")]
+fn build_test_multisig_psbt(our_pubkey: &bitcoin::PublicKey) -> Vec<u8> {
+    use bitcoin::blockdata::opcodes::all::*;
+    use bitcoin::blockdata::script::Builder as ScriptBuilder;
+    use bitcoin::hashes::Hash;
+    use bitcoin::psbt::Psbt;
+    use bitcoin::secp256k1::{Secp256k1, SecretKey};
+    use bitcoin::{Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid};
+    let secp = Secp256k1::new();
+
+    let sk2 = SecretKey::from_slice(&[0x02; 32]).unwrap();
+    let pk2 = bitcoin::PublicKey::new(sk2.public_key(&secp));
+    let sk3 = SecretKey::from_slice(&[0x03; 32]).unwrap();
+    let pk3 = bitcoin::PublicKey::new(sk3.public_key(&secp));
+
+    let mut pubkeys = vec![*our_pubkey, pk2, pk3];
+    pubkeys.sort_by_key(|k| k.to_bytes());
+
+    let witness_script = ScriptBuilder::new()
+        .push_int(2)
+        .push_key(&pubkeys[0])
+        .push_key(&pubkeys[1])
+        .push_key(&pubkeys[2])
+        .push_int(3)
+        .push_opcode(OP_CHECKMULTISIG)
+        .into_script();
+
+    let unsigned_tx = Transaction {
+        version: bitcoin::transaction::Version(2),
+        lock_time: bitcoin::blockdata::locktime::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: Txid::from_byte_array([0xAA; 32]),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: bitcoin::Witness::default(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: ScriptBuf::new_p2wpkh(
+                &bitcoin::WPubkeyHash::from_byte_array([0xBB; 20]),
+            ),
+        }],
+    };
+
+    let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+
+    let witness_script_hash = bitcoin::WScriptHash::hash(witness_script.as_bytes());
+    psbt.inputs[0].witness_utxo = Some(TxOut {
+        value: Amount::from_sat(100_000),
+        script_pubkey: ScriptBuf::new_p2wsh(&witness_script_hash),
+    });
+    psbt.inputs[0].witness_script = Some(witness_script);
+
+    psbt.serialize()
+}
+
+#[test]
+fn test_sign_evm_roundtrip() {
+    let port = common::start_test_server();
+
+    // Initialize keys first
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+        })),
+    };
+    let init_resp = common::send_request(port, &init_req);
+    assert!(
+        matches!(&init_resp.response, Some(Response::InitializeKey(_))),
+        "init should succeed"
+    );
+
+    // Sign EVM
+    let call_data =
+        hex::decode("a9059cbb00000000000000000000000012345678901234567890123456789012345678900000000000000000000000000000000000000000000000000000000000000064")
+            .unwrap();
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignEvm(SignEvmRequest {
+            call_data,
+            nonce: 0,
+            deadline: 1_700_000_000,
+        })),
+    };
+    let sign_resp = common::send_request(port, &sign_req);
+
+    match &sign_resp.response {
+        Some(Response::EvmSignature(r)) => {
+            assert_eq!(r.signature.len(), 65, "EVM signature must be 65 bytes");
+            eprintln!("--- test_sign_evm_roundtrip ---");
+            eprintln!("  signature: {}", hex::encode(&r.signature));
+        }
+        other => panic!("expected EvmSignatureResponse, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_sign_evm_before_init() {
+    let port = common::start_test_server();
+
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignEvm(SignEvmRequest {
+            call_data: vec![0xAB; 4],
+            nonce: 0,
+            deadline: 1_700_000_000,
+        })),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    assert!(
+        matches!(&resp.response, Some(Response::Error(_))),
+        "sign before init should return error"
+    );
+}
+
+#[test]
+#[cfg(feature = "allow-seed-import")]
+fn test_sign_psbt_roundtrip() {
+    let port = common::start_test_server();
+
+    // Initialize with known seed so we know the BTC pubkey
+    let seed = [0x42u8; 64];
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: seed.to_vec(),
+        })),
+    };
+    let init_resp = common::send_request(port, &init_req);
+
+    let btc_pubkey_bytes = match &init_resp.response {
+        Some(Response::InitializeKey(r)) => r.btc_compressed_pub.clone(),
+        other => panic!("expected InitializeKeyResponse, got {:?}", other),
+    };
+
+    let our_pubkey = bitcoin::PublicKey::from_slice(&btc_pubkey_bytes).unwrap();
+    let psbt_bytes = build_test_multisig_psbt(&our_pubkey);
+
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignPsbt(SignPsbtRequest {
+            evm_tx_hash: vec![],
+            operation_idx: 0,
+            psbt_bytes,
+        })),
+    };
+    let sign_resp = common::send_request(port, &sign_req);
+
+    match &sign_resp.response {
+        Some(Response::SignedPsbt(r)) => {
+            assert!(r.inputs_signed > 0, "should have signed at least one input");
+            assert!(
+                !r.signed_psbt.is_empty(),
+                "signed PSBT bytes should not be empty"
+            );
+            eprintln!("--- test_sign_psbt_roundtrip ---");
+            eprintln!("  inputs_signed: {}", r.inputs_signed);
+        }
+        other => panic!("expected SignedPsbtResponse, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_sign_psbt_before_init() {
+    let port = common::start_test_server();
+
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignPsbt(SignPsbtRequest {
+            evm_tx_hash: vec![],
+            operation_idx: 0,
+            psbt_bytes: vec![0xFF; 10],
+        })),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    assert!(
+        matches!(&resp.response, Some(Response::Error(_))),
+        "sign before init should return error"
+    );
+}
+
+#[test]
+fn test_sign_raw_message_roundtrip() {
+    let port = common::start_test_server();
+
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+        })),
+    };
+    let init_resp = common::send_request(port, &init_req);
+    assert!(
+        matches!(&init_resp.response, Some(Response::InitializeKey(_))),
+        "init should succeed"
+    );
+
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignRawMessage(SignRawMessageRequest {
+            message: b"fundsIn authorization payload".to_vec(),
+        })),
+    };
+    let sign_resp = common::send_request(port, &sign_req);
+
+    match &sign_resp.response {
+        Some(Response::RawSignature(r)) => {
+            assert_eq!(r.signature.len(), 65, "raw signature must be 65 bytes");
+            eprintln!("--- test_sign_raw_message_roundtrip ---");
+            eprintln!("  signature: {}", hex::encode(&r.signature));
+        }
+        other => panic!("expected RawSignatureResponse, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_sign_raw_message_before_init() {
+    let port = common::start_test_server();
+
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignRawMessage(SignRawMessageRequest {
+            message: b"test".to_vec(),
+        })),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    assert!(
+        matches!(&resp.response, Some(Response::Error(_))),
+        "sign before init should return error"
+    );
+}
+
+#[test]
+fn test_sign_raw_message_empty() {
+    let port = common::start_test_server();
+
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+        })),
+    };
+    common::send_request(port, &init_req);
+
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignRawMessage(SignRawMessageRequest {
+            message: vec![],
+        })),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    assert!(
+        matches!(&resp.response, Some(Response::Error(_))),
+        "empty message should return error"
+    );
+}

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -258,3 +258,128 @@ fn test_sign_raw_message_empty() {
         "empty message should return error"
     );
 }
+
+#[test]
+fn test_sign_raw_message_deterministic() {
+    let port = common::start_test_server();
+
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+        })),
+    };
+    common::send_request(port, &init_req);
+
+    let msg = b"deterministic test payload".to_vec();
+
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignRawMessage(SignRawMessageRequest {
+            message: msg.clone(),
+        })),
+    };
+    let resp1 = common::send_request(port, &sign_req);
+
+    let sign_req2 = EnclaveRequest {
+        request: Some(Request::SignRawMessage(SignRawMessageRequest {
+            message: msg,
+        })),
+    };
+    let resp2 = common::send_request(port, &sign_req2);
+
+    let sig1 = match &resp1.response {
+        Some(Response::RawSignature(r)) => &r.signature,
+        other => panic!("expected RawSignatureResponse, got {:?}", other),
+    };
+    let sig2 = match &resp2.response {
+        Some(Response::RawSignature(r)) => &r.signature,
+        other => panic!("expected RawSignatureResponse, got {:?}", other),
+    };
+
+    assert_eq!(sig1, sig2, "same message must produce same signature (RFC 6979)");
+}
+
+#[test]
+fn test_sign_raw_message_different_messages_differ() {
+    let port = common::start_test_server();
+
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+        })),
+    };
+    common::send_request(port, &init_req);
+
+    let req1 = EnclaveRequest {
+        request: Some(Request::SignRawMessage(SignRawMessageRequest {
+            message: b"message A".to_vec(),
+        })),
+    };
+    let req2 = EnclaveRequest {
+        request: Some(Request::SignRawMessage(SignRawMessageRequest {
+            message: b"message B".to_vec(),
+        })),
+    };
+
+    let sig1 = match common::send_request(port, &req1).response {
+        Some(Response::RawSignature(r)) => r.signature,
+        other => panic!("expected RawSignatureResponse, got {:?}", other),
+    };
+    let sig2 = match common::send_request(port, &req2).response {
+        Some(Response::RawSignature(r)) => r.signature,
+        other => panic!("expected RawSignatureResponse, got {:?}", other),
+    };
+
+    assert_ne!(sig1, sig2, "different messages must produce different signatures");
+}
+
+#[test]
+#[cfg(feature = "allow-seed-import")]
+fn test_sign_raw_message_recoverable() {
+    use k256::ecdsa::{RecoveryId, Signature as K256Signature, VerifyingKey};
+    use sha3::{Digest, Keccak256};
+
+    let port = common::start_test_server();
+
+    let seed = [0x42u8; 64];
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: seed.to_vec(),
+        })),
+    };
+    let init_resp = common::send_request(port, &init_req);
+
+    let evm_address = match &init_resp.response {
+        Some(Response::InitializeKey(r)) => r.evm_address.clone(),
+        other => panic!("expected InitializeKeyResponse, got {:?}", other),
+    };
+
+    let message = b"fundsIn authorization test".to_vec();
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignRawMessage(SignRawMessageRequest {
+            message: message.clone(),
+        })),
+    };
+    let sign_resp = common::send_request(port, &sign_req);
+
+    let sig_bytes = match &sign_resp.response {
+        Some(Response::RawSignature(r)) => &r.signature,
+        other => panic!("expected RawSignatureResponse, got {:?}", other),
+    };
+
+    // Recover the signer's public key from the signature
+    let msg_hash: [u8; 32] = Keccak256::digest(&message).into();
+    let signature = K256Signature::from_slice(&sig_bytes[..64]).unwrap();
+    let recovery_id = RecoveryId::from_byte(sig_bytes[64]).unwrap();
+    let recovered_key =
+        VerifyingKey::recover_from_prehash(&msg_hash, &signature, recovery_id).unwrap();
+
+    // Derive address from recovered key
+    let pubkey_bytes = recovered_key.to_encoded_point(false);
+    let pubkey_hash = Keccak256::digest(&pubkey_bytes.as_bytes()[1..]);
+    let recovered_address: Vec<u8> = pubkey_hash[12..].to_vec();
+
+    assert_eq!(
+        recovered_address, evm_address,
+        "recovered address must match the enclave's EVM address"
+    );
+}

--- a/parent/src/client.rs
+++ b/parent/src/client.rs
@@ -3,8 +3,10 @@ use std::net::TcpStream;
 use crate::error::{ParentError, Result};
 use crate::framing;
 use crate::proto::{
-    enclave_request, enclave_response, EnclaveRequest, EnclaveResponse, GetPublicKeyRequest,
-    InitializeKeyRequest, InitializeKeyResponse, PublicKeysResponse,
+    enclave_request, enclave_response, EnclaveRequest, EnclaveResponse, EvmSignatureResponse,
+    GetPublicKeyRequest, InitializeKeyRequest, InitializeKeyResponse, PublicKeysResponse,
+    RawSignatureResponse, SignEvmRequest, SignPsbtRequest, SignRawMessageRequest,
+    SignedPsbtResponse,
 };
 
 pub struct EnclaveClient {
@@ -67,6 +69,75 @@ impl EnclaveClient {
         let resp = self.send_request(&req)?;
         match resp.response {
             Some(enclave_response::Response::PublicKeys(r)) => Ok(r),
+            Some(enclave_response::Response::Error(e)) => Err(ParentError::EnclaveError {
+                code: e.code,
+                message: e.message,
+            }),
+            other => Err(ParentError::Connection(format!(
+                "unexpected response variant: {:?}",
+                other
+            ))),
+        }
+    }
+
+    pub fn sign_evm(
+        &self,
+        call_data: Vec<u8>,
+        nonce: u64,
+        deadline: u64,
+    ) -> Result<EvmSignatureResponse> {
+        let req = EnclaveRequest {
+            request: Some(enclave_request::Request::SignEvm(SignEvmRequest {
+                call_data,
+                nonce,
+                deadline,
+            })),
+        };
+        let resp = self.send_request(&req)?;
+        match resp.response {
+            Some(enclave_response::Response::EvmSignature(r)) => Ok(r),
+            Some(enclave_response::Response::Error(e)) => Err(ParentError::EnclaveError {
+                code: e.code,
+                message: e.message,
+            }),
+            other => Err(ParentError::Connection(format!(
+                "unexpected response variant: {:?}",
+                other
+            ))),
+        }
+    }
+
+    pub fn sign_psbt(&self, psbt_bytes: Vec<u8>) -> Result<SignedPsbtResponse> {
+        let req = EnclaveRequest {
+            request: Some(enclave_request::Request::SignPsbt(SignPsbtRequest {
+                evm_tx_hash: vec![],
+                operation_idx: 0,
+                psbt_bytes,
+            })),
+        };
+        let resp = self.send_request(&req)?;
+        match resp.response {
+            Some(enclave_response::Response::SignedPsbt(r)) => Ok(r),
+            Some(enclave_response::Response::Error(e)) => Err(ParentError::EnclaveError {
+                code: e.code,
+                message: e.message,
+            }),
+            other => Err(ParentError::Connection(format!(
+                "unexpected response variant: {:?}",
+                other
+            ))),
+        }
+    }
+
+    pub fn sign_raw_message(&self, message: Vec<u8>) -> Result<RawSignatureResponse> {
+        let req = EnclaveRequest {
+            request: Some(enclave_request::Request::SignRawMessage(
+                SignRawMessageRequest { message },
+            )),
+        };
+        let resp = self.send_request(&req)?;
+        match resp.response {
+            Some(enclave_response::Response::RawSignature(r)) => Ok(r),
             Some(enclave_response::Response::Error(e)) => Err(ParentError::EnclaveError {
                 code: e.code,
                 message: e.message,

--- a/parent/src/main.rs
+++ b/parent/src/main.rs
@@ -32,6 +32,30 @@ enum Command {
     },
     /// Get public keys from the enclave
     GetKeys,
+    /// Sign an EVM transaction (EIP-712 typed data)
+    SignEvm {
+        /// Hex-encoded ABI call data
+        #[arg(long)]
+        call_data: String,
+        /// Per-selector sequential nonce
+        #[arg(long)]
+        nonce: u64,
+        /// Unix timestamp deadline
+        #[arg(long)]
+        deadline: u64,
+    },
+    /// Sign a PSBT (SegWit v0 P2WSH multisig)
+    SignPsbt {
+        /// Hex-encoded PSBT bytes
+        #[arg(long)]
+        psbt: String,
+    },
+    /// Sign a raw message (fundsIn authorization, 1-of-n)
+    SignRawMessage {
+        /// Hex-encoded message bytes
+        #[arg(long)]
+        message: String,
+    },
     /// Enter interactive REPL mode
     Interactive,
 }
@@ -131,6 +155,65 @@ fn main() {
                 process::exit(1);
             }
         },
+        Command::SignEvm {
+            call_data,
+            nonce,
+            deadline,
+        } => {
+            let data = match hex::decode(&call_data) {
+                Ok(d) => d,
+                Err(e) => {
+                    eprintln!("Invalid hex call_data: {}", e);
+                    process::exit(1);
+                }
+            };
+            match client.sign_evm(data, nonce, deadline) {
+                Ok(r) => {
+                    println!("EVM signature (65 bytes): {}", hex::encode(&r.signature));
+                }
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    process::exit(1);
+                }
+            }
+        }
+        Command::SignPsbt { psbt } => {
+            let psbt_bytes = match hex::decode(&psbt) {
+                Ok(d) => d,
+                Err(e) => {
+                    eprintln!("Invalid hex PSBT: {}", e);
+                    process::exit(1);
+                }
+            };
+            match client.sign_psbt(psbt_bytes) {
+                Ok(r) => {
+                    println!("Signed PSBT: {}", hex::encode(&r.signed_psbt));
+                    println!("Inputs signed: {}", r.inputs_signed);
+                }
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    process::exit(1);
+                }
+            }
+        }
+        Command::SignRawMessage { message } => {
+            let msg_bytes = match hex::decode(&message) {
+                Ok(d) => d,
+                Err(e) => {
+                    eprintln!("Invalid hex message: {}", e);
+                    process::exit(1);
+                }
+            };
+            match client.sign_raw_message(msg_bytes) {
+                Ok(r) => {
+                    println!("Signature (65 bytes): {}", hex::encode(&r.signature));
+                }
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    process::exit(1);
+                }
+            }
+        }
         Command::Interactive => run_interactive(&client),
     }
 }

--- a/proto/enclave.proto
+++ b/proto/enclave.proto
@@ -8,10 +8,11 @@ message EnclaveRequest {
   oneof request {
     InitializeKeyRequest   initialize_key   = 1;
     GetPublicKeyRequest    get_public_key   = 2;
+    SignEvmRequest         sign_evm         = 3;
+    SignPsbtRequest        sign_psbt        = 4;
+    SignRawMessageRequest  sign_raw_message = 5;
     // Reserved for future:
-    // SignEvmRequest       sign_evm         = 3;
-    // SignPsbtRequest      sign_psbt        = 4;
-    // GetAttestationRequest get_attestation = 5;
+    // GetAttestationRequest get_attestation = 6;
     // CloneRequest         clone_request    = 6;
     // HealthCheckRequest   health_check     = 9;
   }
@@ -21,9 +22,10 @@ message EnclaveResponse {
   oneof response {
     InitializeKeyResponse  initialize_key   = 1;
     PublicKeysResponse     public_keys      = 2;
+    EvmSignatureResponse   evm_signature    = 3;
+    SignedPsbtResponse     signed_psbt      = 4;
+    RawSignatureResponse   raw_signature    = 5;
     // Reserved for future:
-    // EvmSignatureResponse evm_signature    = 3;
-    // SignedPsbtResponse   signed_psbt      = 4;
     // HealthCheckResponse  health_check     = 7;
     ErrorResponse          error            = 15;
   }
@@ -52,6 +54,44 @@ message PublicKeysResponse {
   bytes evm_address         = 1;
   bytes btc_compressed_pub  = 2;
   string btc_xpub           = 3;
+}
+
+// === EVM Signing (RGB→EVM direction) ===
+
+message SignEvmRequest {
+  bytes call_data     = 1;  // Raw ABI-encoded function call (e.g., fundsOut selector + params)
+  uint64 nonce        = 2;  // Per-selector sequential nonce (matches on-chain MultisigProxy nonce)
+  uint64 deadline     = 3;  // Unix timestamp — signature invalid after this time
+  // Future: bytes consignment = 4; (RGB consignment for Listener validation)
+}
+
+message EvmSignatureResponse {
+  bytes signature = 1;      // 65 bytes: r(32) + s(32) + v(1), Ethereum ECDSA convention
+}
+
+// === PSBT Signing (EVM→RGB direction) ===
+
+message SignPsbtRequest {
+  bytes evm_tx_hash    = 1;  // 32 bytes — for Listener validation (not used yet)
+  uint64 operation_idx = 2;  // For Listener query (not used yet)
+  bytes psbt_bytes     = 3;  // Temporary: direct PSBT bytes until Listener is wired up
+}
+
+message SignedPsbtResponse {
+  bytes signed_psbt    = 1; // Serialized PSBT with our partial signature(s) added
+  uint32 inputs_signed = 2; // Number of inputs we signed
+}
+
+// === Raw Message Signing (fundsIn authorization) ===
+// Single TEE signature (1-of-n) to prove the smart contract was called
+// through the Tricorn backend. Used for fundsIn parameter authorization.
+
+message SignRawMessageRequest {
+  bytes message = 1;  // Arbitrary message bytes to sign (will be keccak256-hashed then signed)
+}
+
+message RawSignatureResponse {
+  bytes signature = 1;  // 65 bytes: r(32) + s(32) + v(1), Ethereum ECDSA convention
 }
 
 // === Error ===


### PR DESCRIPTION
## Summary

- **EVM signing (fundsOut):** EIP-712 typed data hashing (`SignRequest(callData, nonce, deadline)`) + ECDSA with recovery ID. Returns 65-byte `r+s+v` signature compatible with Ethereum `ecrecover`.
- **PSBT signing (EVM→RGB):** SegWit v0 P2WSH multisig partial signing. Detects matching inputs via `partial_sigs`, `bip32_derivation`, and `witness_script`, computes BIP-143 sighash, inserts partial signatures.
- **signRawMessage (fundsIn authorization):** Simple keccak256 + ECDSA endpoint for 1-of-n TEE signature. Authorizes fundsIn operations to prove the smart contract was called through the Tricorn backend.

## Changes

- `proto/enclave.proto` — Added `SignEvmRequest`, `SignPsbtRequest` (with reserved `evm_tx_hash`/`operation_idx` fields), `SignRawMessageRequest` and their responses
- `enclave/src/signing/evm.rs` — `Eip712Domain` + `sign_request_digest()` implementing the EIP-712 hashing scheme
- `enclave/src/signing/psbt.rs` — `should_sign_segwit_input()` input detection helper
- `enclave/src/keys.rs` — `KeyManager::sign_evm()` and `KeyManager::sign_psbt()` methods + `EnclaveState` delegation
- `enclave/src/server.rs` — Dispatch handlers for all three signing endpoints
- `parent/src/client.rs` + `parent/src/main.rs` — CLI subcommands: `sign-evm`, `sign-psbt`, `sign-raw-message`

## Test plan

- [x] EIP-712 hashing unit tests (ABI encoding, domain separator, digest determinism, chain ID differentiation)
- [x] EVM signing unit tests (65-byte output, determinism, `ecrecover` roundtrip)
- [x] PSBT signing unit tests (sign one input, skip already-signed, reject invalid bytes, skip non-matching inputs)
- [x] signRawMessage integration tests (roundtrip, before-init error, empty message rejection, determinism, different-message uniqueness, `ecrecover` recovery)
- [x] Integration tests for all endpoints through wire protocol (roundtrip + before-init error cases)
- [x] `cargo build` — no warnings
- [x] `cargo test` — 37 tests pass
- [x] `cargo test --features allow-seed-import` — 40 tests pass (includes deterministic seed tests)