### PR TITLE
feat: enriched payload deserialization + cross-check logic

### DIFF
--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -56,6 +56,8 @@ default = []
 vsock = []
 # DANGER: allows importing a raw seed over the wire. Testing only.
 allow-seed-import = []
+# Skips cross-check validation on signing requests. Development/testing only.
+dev-mode = []
 
 [dev-dependencies]
 rand = "0.10.0"

--- a/enclave/build.rs
+++ b/enclave/build.rs
@@ -1,4 +1,10 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    prost_build::compile_protos(&["../proto/enclave.proto"], &["../proto/"])?;
+    prost_build::compile_protos(
+        &[
+            "../proto/enclave.proto",
+            "../proto/enriched-payload.proto",
+        ],
+        &["../proto/"],
+    )?;
     Ok(())
 }

--- a/enclave/src/error.rs
+++ b/enclave/src/error.rs
@@ -26,8 +26,21 @@ pub enum EnclaveError {
     #[error("signing error: {0}")]
     Signing(String),
 
+    #[error("cross-check failed: {0}")]
+    CrossCheck(String),
+
     #[error("internal error: {0}")]
     Internal(String),
+}
+
+impl EnclaveError {
+    /// Map error to a proto error code.
+    pub fn error_code(&self) -> u32 {
+        match self {
+            EnclaveError::CrossCheck(_) => 3, // ERROR_CODE_VALIDATION_FAILED
+            _ => 1,
+        }
+    }
 }
 
 pub type Result<T> = std::result::Result<T, EnclaveError>;

--- a/enclave/src/keys.rs
+++ b/enclave/src/keys.rs
@@ -198,6 +198,12 @@ pub struct EnclaveState {
     inner: Mutex<Option<KeyManager>>,
 }
 
+impl Default for EnclaveState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl EnclaveState {
     pub fn new() -> Self {
         Self {
@@ -401,7 +407,7 @@ mod tests {
         let sk3 = SecretKey::from_slice(&[0x03; 32]).unwrap();
         let pk3 = bitcoin::PublicKey::new(sk3.public_key(&secp));
 
-        let mut pubkeys = vec![*our_pubkey, pk2, pk3];
+        let mut pubkeys = [*our_pubkey, pk2, pk3];
         pubkeys.sort_by_key(|k| k.to_bytes());
 
         let witness_script = ScriptBuilder::new()

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -5,7 +5,12 @@ pub mod framing;
 pub mod keys;
 pub mod server;
 pub mod signing;
+pub mod validation;
 
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/utexo_bridge.enclave.rs"));
+}
+
+pub mod enriched {
+    include!(concat!(env!("OUT_DIR"), "/tricorn.enriched.rs"));
 }

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -7,6 +7,8 @@ use crate::proto::enclave_request::Request;
 use crate::proto::enclave_response::Response;
 use crate::proto::*;
 use crate::signing::evm::{sign_request_digest, Eip712Domain};
+#[cfg(not(feature = "dev-mode"))]
+use crate::validation;
 
 /// Handle a single connection: read one request, dispatch, write one response, close.
 pub fn handle_connection(stream: impl Read + Write, state: &EnclaveState) {
@@ -53,6 +55,10 @@ fn dispatch(request: EnclaveRequest, state: &EnclaveState) -> EnclaveResponse {
             tracing::info!("request: SignRawMessage");
             handle_sign_raw_message(state, req)
         }
+        Some(Request::ProxyFederation(req)) => {
+            tracing::info!("request: ProxyFederation");
+            handle_proxy_federation(state, req)
+        }
         None => {
             tracing::warn!("received empty request (no oneof variant set)");
             return EnclaveResponse {
@@ -70,7 +76,7 @@ fn dispatch(request: EnclaveRequest, state: &EnclaveState) -> EnclaveResponse {
             tracing::warn!("handler error: {}", e);
             EnclaveResponse {
                 response: Some(Response::Error(ErrorResponse {
-                    code: 1,
+                    code: e.error_code(),
                     message: e.to_string(),
                 })),
             }
@@ -141,13 +147,12 @@ fn handle_get_public_key(
 }
 
 fn handle_sign_evm(state: &EnclaveState, req: SignEvmRequest) -> Result<EnclaveResponse> {
-    // TODO: load from config
-    let domain = Eip712Domain {
-        name: "Tricorn".to_string(),
-        version: "1".to_string(),
-        chain_id: 1,
-        verifying_contract: [0u8; 20],
-    };
+    // Cross-check enriched fields before signing (skipped in dev-mode)
+    #[cfg(not(feature = "dev-mode"))]
+    validation::evm_crosscheck::validate_evm_request(&req)?;
+
+    // TODO: confirm domain name/version with contract team
+    let domain = build_evm_domain(&req)?;
 
     let digest = sign_request_digest(&domain, &req.call_data, req.nonce, req.deadline);
     let signature = state.sign_evm(&digest)?;
@@ -165,6 +170,10 @@ fn handle_sign_evm(state: &EnclaveState, req: SignEvmRequest) -> Result<EnclaveR
 }
 
 fn handle_sign_psbt(state: &EnclaveState, req: SignPsbtRequest) -> Result<EnclaveResponse> {
+    // Cross-check enriched fields before signing (skipped in dev-mode)
+    #[cfg(not(feature = "dev-mode"))]
+    validation::psbt_crosscheck::validate_psbt_request(&req)?;
+
     let (signed_psbt, inputs_signed) = state.sign_psbt(&req.psbt_bytes)?;
 
     tracing::info!(inputs_signed, "PSBT signed");
@@ -199,6 +208,62 @@ fn handle_sign_raw_message(
     Ok(EnclaveResponse {
         response: Some(Response::RawSignature(RawSignatureResponse {
             signature: signature.to_vec(),
+        })),
+    })
+}
+
+/// Build EIP-712 domain from enriched request fields.
+/// In dev-mode, falls back to defaults if fields are missing.
+fn build_evm_domain(req: &SignEvmRequest) -> Result<Eip712Domain> {
+    let chain_id = if req.chain_id > 0 {
+        req.chain_id
+    } else {
+        #[cfg(feature = "dev-mode")]
+        {
+            1
+        }
+        #[cfg(not(feature = "dev-mode"))]
+        {
+            return Err(EnclaveError::CrossCheck("chain_id must be > 0".into()));
+        }
+    };
+
+    let verifying_contract: [u8; 20] = if req.proxy_contract.len() == 20 {
+        req.proxy_contract
+            .as_slice()
+            .try_into()
+            .map_err(|_| EnclaveError::CrossCheck("proxy_contract must be 20 bytes".into()))?
+    } else {
+        #[cfg(feature = "dev-mode")]
+        {
+            [0u8; 20]
+        }
+        #[cfg(not(feature = "dev-mode"))]
+        {
+            return Err(EnclaveError::CrossCheck(format!(
+                "proxy_contract must be 20 bytes, got {}",
+                req.proxy_contract.len()
+            )));
+        }
+    };
+
+    Ok(Eip712Domain {
+        name: "Tricorn".to_string(),
+        version: "1".to_string(),
+        chain_id,
+        verifying_contract,
+    })
+}
+
+fn handle_proxy_federation(
+    _state: &EnclaveState,
+    _req: ProxyFederationRequest,
+) -> Result<EnclaveResponse> {
+    // Stub: federation proxy requires Listener integration (not yet wired)
+    Ok(EnclaveResponse {
+        response: Some(Response::Error(ErrorResponse {
+            code: 2, // NOT_READY
+            message: "federation proxy not yet connected to Listener".into(),
         })),
     })
 }

--- a/enclave/src/validation/evm_crosscheck.rs
+++ b/enclave/src/validation/evm_crosscheck.rs
@@ -1,0 +1,224 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::error::{EnclaveError, Result};
+use crate::proto::SignEvmRequest;
+
+/// Validate enriched SignEvmRequest before signing.
+/// Returns Ok(()) if all cross-checks pass, Err(EnclaveError::CrossCheck) if any fail.
+pub fn validate_evm_request(req: &SignEvmRequest) -> Result<()> {
+    // 1. Consignment must be validated by Listener
+    if !req.consignment_valid {
+        return Err(EnclaveError::CrossCheck(
+            "consignment not validated by Listener".into(),
+        ));
+    }
+
+    // 2. Amount consistency: RGB amount must cover calldata amount + commission
+    let required = req
+        .calldata_amount
+        .checked_add(req.calldata_commission)
+        .ok_or_else(|| EnclaveError::CrossCheck("calldata amount + commission overflow".into()))?;
+    if req.rgb_amount < required {
+        return Err(EnclaveError::CrossCheck(format!(
+            "amount mismatch: rgb_amount ({}) < calldata_amount ({}) + calldata_commission ({})",
+            req.rgb_amount, req.calldata_amount, req.calldata_commission
+        )));
+    }
+
+    // 3. Calldata verification: verify pre-extracted amounts match raw call_data bytes
+    //    fundsOut(address token, address recipient, uint256 amount, uint256 commission, ...)
+    //    Layout: [4 selector][32 token][32 recipient][32 amount][32 commission]...
+    //    amount at offset 68, commission at offset 100
+    let cd_amount = extract_uint256_as_u64(&req.call_data, 68)?;
+    if cd_amount != req.calldata_amount {
+        return Err(EnclaveError::CrossCheck(format!(
+            "calldata amount mismatch: extracted {} != declared {}",
+            cd_amount, req.calldata_amount
+        )));
+    }
+    let cd_commission = extract_uint256_as_u64(&req.call_data, 100)?;
+    if cd_commission != req.calldata_commission {
+        return Err(EnclaveError::CrossCheck(format!(
+            "calldata commission mismatch: extracted {} != declared {}",
+            cd_commission, req.calldata_commission
+        )));
+    }
+
+    // 4. Chain/domain present
+    if req.chain_id == 0 {
+        return Err(EnclaveError::CrossCheck("chain_id must be > 0".into()));
+    }
+    if req.proxy_contract.len() != 20 {
+        return Err(EnclaveError::CrossCheck(format!(
+            "proxy_contract must be 20 bytes, got {}",
+            req.proxy_contract.len()
+        )));
+    }
+
+    // 5. Deadline not expired
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| EnclaveError::Internal(format!("system time error: {}", e)))?
+        .as_secs();
+    if req.deadline <= now {
+        return Err(EnclaveError::CrossCheck("request deadline expired".into()));
+    }
+
+    Ok(())
+}
+
+/// Lightweight ABI extraction: read a uint256 from call_data at a given byte offset.
+/// Returns the value as u64. Fails if call_data is too short or the value exceeds u64.
+fn extract_uint256_as_u64(call_data: &[u8], offset: usize) -> Result<u64> {
+    let end = offset + 32;
+    if call_data.len() < end {
+        return Err(EnclaveError::CrossCheck(format!(
+            "call_data too short: need {} bytes, got {}",
+            end,
+            call_data.len()
+        )));
+    }
+    let slot = &call_data[offset..end];
+    // High 24 bytes must be zero for value to fit in u64
+    if slot[..24].iter().any(|&b| b != 0) {
+        return Err(EnclaveError::CrossCheck(
+            "uint256 value exceeds u64 range".into(),
+        ));
+    }
+    let mut buf = [0u8; 8];
+    buf.copy_from_slice(&slot[24..32]);
+    Ok(u64::from_be_bytes(buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a mock fundsOut calldata with the given amount and commission.
+    fn mock_funds_out_calldata(amount: u64, commission: u64) -> Vec<u8> {
+        let mut data = Vec::with_capacity(4 + 7 * 32);
+        // 4-byte selector (placeholder)
+        data.extend_from_slice(&[0xab, 0xcd, 0xef, 0x12]);
+        // address token (32 bytes, left-padded)
+        let mut padded = [0u8; 32];
+        padded[12..].copy_from_slice(&[0x11; 20]);
+        data.extend_from_slice(&padded);
+        // address recipient (32 bytes, left-padded)
+        let mut padded = [0u8; 32];
+        padded[12..].copy_from_slice(&[0x22; 20]);
+        data.extend_from_slice(&padded);
+        // uint256 amount
+        let mut padded = [0u8; 32];
+        padded[24..].copy_from_slice(&amount.to_be_bytes());
+        data.extend_from_slice(&padded);
+        // uint256 commission
+        let mut padded = [0u8; 32];
+        padded[24..].copy_from_slice(&commission.to_be_bytes());
+        data.extend_from_slice(&padded);
+        // remaining params — zero-fill
+        data.extend_from_slice(&[0u8; 32 * 3]);
+        data
+    }
+
+    fn valid_evm_request() -> SignEvmRequest {
+        let amount = 1000u64;
+        let commission = 50u64;
+        SignEvmRequest {
+            call_data: mock_funds_out_calldata(amount, commission),
+            nonce: 1,
+            deadline: u64::MAX, // far future
+            consignment_valid: true,
+            rgb_amount: 1100, // >= amount + commission
+            rgb_asset_id: "rgb:test-asset".into(),
+            chain_id: 1,
+            proxy_contract: vec![0xAA; 20],
+            calldata_amount: amount,
+            calldata_commission: commission,
+        }
+    }
+
+    #[test]
+    fn valid_request_passes() {
+        assert!(validate_evm_request(&valid_evm_request()).is_ok());
+    }
+
+    #[test]
+    fn rejects_invalid_consignment() {
+        let mut req = valid_evm_request();
+        req.consignment_valid = false;
+        let err = validate_evm_request(&req).unwrap_err();
+        assert!(err.to_string().contains("consignment not validated"));
+    }
+
+    #[test]
+    fn rejects_amount_mismatch_rgb_less_than_calldata() {
+        let mut req = valid_evm_request();
+        req.rgb_amount = 1049; // 1000 + 50 = 1050, so 1049 is insufficient
+        let err = validate_evm_request(&req).unwrap_err();
+        assert!(err.to_string().contains("amount mismatch"));
+    }
+
+    #[test]
+    fn rejects_calldata_extraction_mismatch() {
+        let mut req = valid_evm_request();
+        // Declare a different amount than what's in the actual call_data bytes
+        req.calldata_amount = 9999;
+        // Bump rgb_amount so we pass the consignment amount check first
+        req.rgb_amount = 99999;
+        let err = validate_evm_request(&req).unwrap_err();
+        assert!(err.to_string().contains("calldata amount mismatch"));
+    }
+
+    #[test]
+    fn rejects_expired_deadline() {
+        let mut req = valid_evm_request();
+        req.deadline = 1; // Unix timestamp 1 is long expired
+        let err = validate_evm_request(&req).unwrap_err();
+        assert!(err.to_string().contains("deadline expired"));
+    }
+
+    #[test]
+    fn rejects_missing_proxy_contract() {
+        let mut req = valid_evm_request();
+        req.proxy_contract = vec![];
+        let err = validate_evm_request(&req).unwrap_err();
+        assert!(err.to_string().contains("proxy_contract must be 20 bytes"));
+    }
+
+    #[test]
+    fn rejects_zero_chain_id() {
+        let mut req = valid_evm_request();
+        req.chain_id = 0;
+        let err = validate_evm_request(&req).unwrap_err();
+        assert!(err.to_string().contains("chain_id must be > 0"));
+    }
+
+    #[test]
+    fn accepts_exact_amount_match() {
+        let mut req = valid_evm_request();
+        // rgb_amount == calldata_amount + calldata_commission exactly
+        req.rgb_amount = req.calldata_amount + req.calldata_commission;
+        assert!(validate_evm_request(&req).is_ok());
+    }
+
+    #[test]
+    fn extract_uint256_works() {
+        let mut data = vec![0u8; 40];
+        // Put value 42 at offset 8 (bytes 8..40)
+        data[39] = 42;
+        assert_eq!(extract_uint256_as_u64(&data, 8).unwrap(), 42);
+    }
+
+    #[test]
+    fn extract_uint256_rejects_short_data() {
+        let data = vec![0u8; 10];
+        assert!(extract_uint256_as_u64(&data, 0).is_err());
+    }
+
+    #[test]
+    fn extract_uint256_rejects_overflow() {
+        let mut data = vec![0u8; 32];
+        data[0] = 1; // high byte set — exceeds u64
+        assert!(extract_uint256_as_u64(&data, 0).is_err());
+    }
+}

--- a/enclave/src/validation/mod.rs
+++ b/enclave/src/validation/mod.rs
@@ -1,0 +1,2 @@
+pub mod evm_crosscheck;
+pub mod psbt_crosscheck;

--- a/enclave/src/validation/psbt_crosscheck.rs
+++ b/enclave/src/validation/psbt_crosscheck.rs
@@ -1,0 +1,124 @@
+use crate::error::{EnclaveError, Result};
+use crate::proto::SignPsbtRequest;
+
+/// Validate enriched SignPsbtRequest before signing.
+/// Returns Ok(()) if all cross-checks pass, Err(EnclaveError::CrossCheck) if any fail.
+pub fn validate_psbt_request(req: &SignPsbtRequest) -> Result<()> {
+    // 1. EVM event must be valid
+    if !req.evm_event_valid {
+        return Err(EnclaveError::CrossCheck(
+            "EVM event not validated by Listener".into(),
+        ));
+    }
+
+    // 2. EVM event must be finalized
+    if !req.evm_event_finalized {
+        return Err(EnclaveError::CrossCheck(
+            "EVM event not yet finalized".into(),
+        ));
+    }
+
+    // 3. Amount consistency: EVM deposit must cover PSBT output + commission
+    let required = req
+        .psbt_output_amount
+        .checked_add(req.evm_commission)
+        .ok_or_else(|| {
+            EnclaveError::CrossCheck("psbt_output_amount + evm_commission overflow".into())
+        })?;
+    if req.evm_amount < required {
+        return Err(EnclaveError::CrossCheck(format!(
+            "amount mismatch: evm_amount ({}) < psbt_output_amount ({}) + evm_commission ({})",
+            req.evm_amount, req.psbt_output_amount, req.evm_commission
+        )));
+    }
+
+    // 4. PSBT must be present
+    if req.psbt_bytes.is_empty() {
+        return Err(EnclaveError::CrossCheck("psbt_bytes is empty".into()));
+    }
+
+    // 5. Tx hash must be exactly 32 bytes
+    if req.evm_tx_hash.len() != 32 {
+        return Err(EnclaveError::CrossCheck(format!(
+            "evm_tx_hash must be 32 bytes, got {}",
+            req.evm_tx_hash.len()
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_psbt_request() -> SignPsbtRequest {
+        SignPsbtRequest {
+            evm_tx_hash: vec![0xAA; 32],
+            operation_idx: 0,
+            evm_event_valid: true,
+            evm_event_finalized: true,
+            evm_token: vec![0x11; 20],
+            evm_amount: 1000,
+            evm_recipient: vec![0x22; 20],
+            evm_commission: 50,
+            psbt_bytes: vec![0xFF; 100], // placeholder, not a real PSBT
+            psbt_output_amount: 900,
+            rgb_asset_id: "rgb:test-asset".into(),
+        }
+    }
+
+    #[test]
+    fn valid_request_passes() {
+        assert!(validate_psbt_request(&valid_psbt_request()).is_ok());
+    }
+
+    #[test]
+    fn rejects_invalid_evm_event() {
+        let mut req = valid_psbt_request();
+        req.evm_event_valid = false;
+        let err = validate_psbt_request(&req).unwrap_err();
+        assert!(err.to_string().contains("EVM event not validated"));
+    }
+
+    #[test]
+    fn rejects_unfinalized_event() {
+        let mut req = valid_psbt_request();
+        req.evm_event_finalized = false;
+        let err = validate_psbt_request(&req).unwrap_err();
+        assert!(err.to_string().contains("not yet finalized"));
+    }
+
+    #[test]
+    fn rejects_amount_mismatch() {
+        let mut req = valid_psbt_request();
+        req.evm_amount = 100;
+        req.psbt_output_amount = 90;
+        req.evm_commission = 20; // 90 + 20 = 110 > 100
+        let err = validate_psbt_request(&req).unwrap_err();
+        assert!(err.to_string().contains("amount mismatch"));
+    }
+
+    #[test]
+    fn rejects_empty_psbt() {
+        let mut req = valid_psbt_request();
+        req.psbt_bytes = vec![];
+        let err = validate_psbt_request(&req).unwrap_err();
+        assert!(err.to_string().contains("psbt_bytes is empty"));
+    }
+
+    #[test]
+    fn rejects_invalid_tx_hash_length() {
+        let mut req = valid_psbt_request();
+        req.evm_tx_hash = vec![0xAA; 16]; // wrong length
+        let err = validate_psbt_request(&req).unwrap_err();
+        assert!(err.to_string().contains("evm_tx_hash must be 32 bytes"));
+    }
+
+    #[test]
+    fn accepts_exact_amount_match() {
+        let mut req = valid_psbt_request();
+        req.evm_amount = req.psbt_output_amount + req.evm_commission;
+        assert!(validate_psbt_request(&req).is_ok());
+    }
+}

--- a/enclave/tests/test_keygen.rs
+++ b/enclave/tests/test_keygen.rs
@@ -1,6 +1,5 @@
 mod common;
 
-use hex;
 use utexo_bridge_enclave::proto::enclave_request::Request;
 use utexo_bridge_enclave::proto::enclave_response::Response;
 use utexo_bridge_enclave::proto::*;

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -4,6 +4,54 @@ use utexo_bridge_enclave::proto::enclave_request::Request;
 use utexo_bridge_enclave::proto::enclave_response::Response;
 use utexo_bridge_enclave::proto::*;
 
+/// Build a mock fundsOut calldata with the given amount and commission.
+/// fundsOut(address token, address recipient, uint256 amount, uint256 commission, ...)
+fn mock_funds_out_calldata(
+    token: [u8; 20],
+    recipient: [u8; 20],
+    amount: u64,
+    commission: u64,
+) -> Vec<u8> {
+    let mut data = Vec::with_capacity(4 + 7 * 32);
+    // 4-byte selector (placeholder)
+    data.extend_from_slice(&[0xab, 0xcd, 0xef, 0x12]);
+    // address token (padded to 32 bytes)
+    let mut padded = [0u8; 32];
+    padded[12..].copy_from_slice(&token);
+    data.extend_from_slice(&padded);
+    // address recipient (padded to 32 bytes)
+    let mut padded = [0u8; 32];
+    padded[12..].copy_from_slice(&recipient);
+    data.extend_from_slice(&padded);
+    // uint256 amount
+    let mut padded = [0u8; 32];
+    padded[24..].copy_from_slice(&amount.to_be_bytes());
+    data.extend_from_slice(&padded);
+    // uint256 commission
+    let mut padded = [0u8; 32];
+    padded[24..].copy_from_slice(&commission.to_be_bytes());
+    data.extend_from_slice(&padded);
+    // remaining params (transactionId, sourceChain, sourceAddress) — zero-fill
+    data.extend_from_slice(&[0u8; 32 * 3]);
+    data
+}
+
+/// Build a valid enriched SignEvmRequest for testing.
+fn valid_sign_evm_request(amount: u64, commission: u64) -> SignEvmRequest {
+    SignEvmRequest {
+        call_data: mock_funds_out_calldata([0x11; 20], [0x22; 20], amount, commission),
+        nonce: 1,
+        deadline: u64::MAX,
+        consignment_valid: true,
+        rgb_amount: amount + commission + 100, // plenty of headroom
+        rgb_asset_id: "rgb:test".into(),
+        chain_id: 1,
+        proxy_contract: vec![0xAA; 20],
+        calldata_amount: amount,
+        calldata_commission: commission,
+    }
+}
+
 /// Build a minimal 2-of-3 multisig PSBT for testing with a known pubkey.
 #[cfg(feature = "allow-seed-import")]
 fn build_test_multisig_psbt(our_pubkey: &bitcoin::PublicKey) -> Vec<u8> {
@@ -64,11 +112,32 @@ fn build_test_multisig_psbt(our_pubkey: &bitcoin::PublicKey) -> Vec<u8> {
     psbt.serialize()
 }
 
+/// Build a valid enriched SignPsbtRequest for testing.
+#[cfg(feature = "allow-seed-import")]
+fn valid_sign_psbt_request(psbt_bytes: Vec<u8>) -> SignPsbtRequest {
+    SignPsbtRequest {
+        evm_tx_hash: vec![0xCC; 32],
+        operation_idx: 0,
+        evm_event_valid: true,
+        evm_event_finalized: true,
+        evm_token: vec![0x11; 20],
+        evm_amount: 100_000,
+        evm_recipient: vec![0x22; 20],
+        evm_commission: 1_000,
+        psbt_bytes,
+        psbt_output_amount: 50_000,
+        rgb_asset_id: "rgb:test".into(),
+    }
+}
+
+// =============================================================================
+// EVM signing tests
+// =============================================================================
+
 #[test]
 fn test_sign_evm_roundtrip() {
     let port = common::start_test_server();
 
-    // Initialize keys first
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: vec![],
@@ -80,24 +149,14 @@ fn test_sign_evm_roundtrip() {
         "init should succeed"
     );
 
-    // Sign EVM
-    let call_data =
-        hex::decode("a9059cbb00000000000000000000000012345678901234567890123456789012345678900000000000000000000000000000000000000000000000000000000000000064")
-            .unwrap();
     let sign_req = EnclaveRequest {
-        request: Some(Request::SignEvm(SignEvmRequest {
-            call_data,
-            nonce: 0,
-            deadline: 1_700_000_000,
-        })),
+        request: Some(Request::SignEvm(valid_sign_evm_request(1000, 50))),
     };
     let sign_resp = common::send_request(port, &sign_req);
 
     match &sign_resp.response {
         Some(Response::EvmSignature(r)) => {
             assert_eq!(r.signature.len(), 65, "EVM signature must be 65 bytes");
-            eprintln!("--- test_sign_evm_roundtrip ---");
-            eprintln!("  signature: {}", hex::encode(&r.signature));
         }
         other => panic!("expected EvmSignatureResponse, got {:?}", other),
     }
@@ -108,11 +167,7 @@ fn test_sign_evm_before_init() {
     let port = common::start_test_server();
 
     let sign_req = EnclaveRequest {
-        request: Some(Request::SignEvm(SignEvmRequest {
-            call_data: vec![0xAB; 4],
-            nonce: 0,
-            deadline: 1_700_000_000,
-        })),
+        request: Some(Request::SignEvm(valid_sign_evm_request(1000, 50))),
     };
     let resp = common::send_request(port, &sign_req);
 
@@ -122,12 +177,105 @@ fn test_sign_evm_before_init() {
     );
 }
 
+// =============================================================================
+// EVM enriched cross-check tests
+// =============================================================================
+
+#[test]
+fn test_sign_evm_rejects_invalid_consignment() {
+    let port = common::start_test_server();
+
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+        })),
+    };
+    common::send_request(port, &init_req);
+
+    let mut req = valid_sign_evm_request(1000, 50);
+    req.consignment_valid = false;
+
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignEvm(req)),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    match &resp.response {
+        Some(Response::Error(e)) => {
+            assert_eq!(e.code, 3, "cross-check failures should use code 3");
+            assert!(e.message.contains("consignment"));
+        }
+        other => panic!("expected ErrorResponse, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_sign_evm_rejects_amount_mismatch() {
+    let port = common::start_test_server();
+
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+        })),
+    };
+    common::send_request(port, &init_req);
+
+    let mut req = valid_sign_evm_request(90, 20);
+    req.rgb_amount = 100; // 90 + 20 = 110 > 100 => should fail
+
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignEvm(req)),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    match &resp.response {
+        Some(Response::Error(e)) => {
+            assert_eq!(e.code, 3);
+            assert!(e.message.contains("amount mismatch"));
+        }
+        other => panic!("expected ErrorResponse, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_sign_evm_rejects_calldata_extraction_mismatch() {
+    let port = common::start_test_server();
+
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+        })),
+    };
+    common::send_request(port, &init_req);
+
+    let mut req = valid_sign_evm_request(1000, 50);
+    // Lie about the calldata amount — doesn't match what's in the raw bytes
+    req.calldata_amount = 9999;
+    req.rgb_amount = 99999; // make sure the amount check passes first
+
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignEvm(req)),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    match &resp.response {
+        Some(Response::Error(e)) => {
+            assert_eq!(e.code, 3);
+            assert!(e.message.contains("calldata amount mismatch"));
+        }
+        other => panic!("expected ErrorResponse, got {:?}", other),
+    }
+}
+
+// =============================================================================
+// PSBT signing tests
+// =============================================================================
+
 #[test]
 #[cfg(feature = "allow-seed-import")]
 fn test_sign_psbt_roundtrip() {
     let port = common::start_test_server();
 
-    // Initialize with known seed so we know the BTC pubkey
     let seed = [0x42u8; 64];
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
@@ -145,11 +293,7 @@ fn test_sign_psbt_roundtrip() {
     let psbt_bytes = build_test_multisig_psbt(&our_pubkey);
 
     let sign_req = EnclaveRequest {
-        request: Some(Request::SignPsbt(SignPsbtRequest {
-            evm_tx_hash: vec![],
-            operation_idx: 0,
-            psbt_bytes,
-        })),
+        request: Some(Request::SignPsbt(valid_sign_psbt_request(psbt_bytes))),
     };
     let sign_resp = common::send_request(port, &sign_req);
 
@@ -160,8 +304,6 @@ fn test_sign_psbt_roundtrip() {
                 !r.signed_psbt.is_empty(),
                 "signed PSBT bytes should not be empty"
             );
-            eprintln!("--- test_sign_psbt_roundtrip ---");
-            eprintln!("  inputs_signed: {}", r.inputs_signed);
         }
         other => panic!("expected SignedPsbtResponse, got {:?}", other),
     }
@@ -173,9 +315,17 @@ fn test_sign_psbt_before_init() {
 
     let sign_req = EnclaveRequest {
         request: Some(Request::SignPsbt(SignPsbtRequest {
-            evm_tx_hash: vec![],
+            evm_tx_hash: vec![0xAA; 32],
             operation_idx: 0,
+            evm_event_valid: true,
+            evm_event_finalized: true,
+            evm_token: vec![],
+            evm_amount: 1000,
+            evm_recipient: vec![],
+            evm_commission: 0,
             psbt_bytes: vec![0xFF; 10],
+            psbt_output_amount: 500,
+            rgb_asset_id: String::new(),
         })),
     };
     let resp = common::send_request(port, &sign_req);
@@ -185,6 +335,88 @@ fn test_sign_psbt_before_init() {
         "sign before init should return error"
     );
 }
+
+// =============================================================================
+// PSBT enriched cross-check tests
+// =============================================================================
+
+#[test]
+fn test_sign_psbt_rejects_unfinalized() {
+    let port = common::start_test_server();
+
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+        })),
+    };
+    common::send_request(port, &init_req);
+
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignPsbt(SignPsbtRequest {
+            evm_tx_hash: vec![0xAA; 32],
+            operation_idx: 0,
+            evm_event_valid: true,
+            evm_event_finalized: false,
+            evm_token: vec![],
+            evm_amount: 1000,
+            evm_recipient: vec![],
+            evm_commission: 0,
+            psbt_bytes: vec![0xFF; 10],
+            psbt_output_amount: 500,
+            rgb_asset_id: String::new(),
+        })),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    match &resp.response {
+        Some(Response::Error(e)) => {
+            assert_eq!(e.code, 3);
+            assert!(e.message.contains("not yet finalized"));
+        }
+        other => panic!("expected ErrorResponse, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_sign_psbt_rejects_amount_mismatch() {
+    let port = common::start_test_server();
+
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+        })),
+    };
+    common::send_request(port, &init_req);
+
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignPsbt(SignPsbtRequest {
+            evm_tx_hash: vec![0xAA; 32],
+            operation_idx: 0,
+            evm_event_valid: true,
+            evm_event_finalized: true,
+            evm_token: vec![],
+            evm_amount: 100,
+            evm_recipient: vec![],
+            evm_commission: 20,
+            psbt_bytes: vec![0xFF; 10],
+            psbt_output_amount: 90, // 90 + 20 = 110 > 100
+            rgb_asset_id: String::new(),
+        })),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    match &resp.response {
+        Some(Response::Error(e)) => {
+            assert_eq!(e.code, 3);
+            assert!(e.message.contains("amount mismatch"));
+        }
+        other => panic!("expected ErrorResponse, got {:?}", other),
+    }
+}
+
+// =============================================================================
+// Raw message signing tests
+// =============================================================================
 
 #[test]
 fn test_sign_raw_message_roundtrip() {
@@ -211,8 +443,6 @@ fn test_sign_raw_message_roundtrip() {
     match &sign_resp.response {
         Some(Response::RawSignature(r)) => {
             assert_eq!(r.signature.len(), 65, "raw signature must be 65 bytes");
-            eprintln!("--- test_sign_raw_message_roundtrip ---");
-            eprintln!("  signature: {}", hex::encode(&r.signature));
         }
         other => panic!("expected RawSignatureResponse, got {:?}", other),
     }
@@ -366,14 +596,12 @@ fn test_sign_raw_message_recoverable() {
         other => panic!("expected RawSignatureResponse, got {:?}", other),
     };
 
-    // Recover the signer's public key from the signature
     let msg_hash: [u8; 32] = Keccak256::digest(&message).into();
     let signature = K256Signature::from_slice(&sig_bytes[..64]).unwrap();
     let recovery_id = RecoveryId::from_byte(sig_bytes[64]).unwrap();
     let recovered_key =
         VerifyingKey::recover_from_prehash(&msg_hash, &signature, recovery_id).unwrap();
 
-    // Derive address from recovered key
     let pubkey_bytes = recovered_key.to_encoded_point(false);
     let pubkey_hash = Keccak256::digest(&pubkey_bytes.as_bytes()[1..]);
     let recovered_address: Vec<u8> = pubkey_hash[12..].to_vec();
@@ -382,4 +610,28 @@ fn test_sign_raw_message_recoverable() {
         recovered_address, evm_address,
         "recovered address must match the enclave's EVM address"
     );
+}
+
+// =============================================================================
+// Federation proxy test
+// =============================================================================
+
+#[test]
+fn test_proxy_federation_returns_not_ready() {
+    let port = common::start_test_server();
+
+    let req = EnclaveRequest {
+        request: Some(Request::ProxyFederation(ProxyFederationRequest {
+            message_hash: vec![0xAA; 32],
+        })),
+    };
+    let resp = common::send_request(port, &req);
+
+    match &resp.response {
+        Some(Response::Error(e)) => {
+            assert_eq!(e.code, 2, "federation proxy should return NOT_READY (code 2)");
+            assert!(e.message.contains("federation proxy"));
+        }
+        other => panic!("expected ErrorResponse, got {:?}", other),
+    }
 }

--- a/parent/build.rs
+++ b/parent/build.rs
@@ -1,4 +1,7 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    prost_build::compile_protos(&["../proto/enclave.proto"], &["../proto/"])?;
+    prost_build::compile_protos(
+        &["../proto/enclave.proto", "../proto/enriched-payload.proto"],
+        &["../proto/"],
+    )?;
     Ok(())
 }

--- a/parent/src/client.rs
+++ b/parent/src/client.rs
@@ -80,18 +80,9 @@ impl EnclaveClient {
         }
     }
 
-    pub fn sign_evm(
-        &self,
-        call_data: Vec<u8>,
-        nonce: u64,
-        deadline: u64,
-    ) -> Result<EvmSignatureResponse> {
+    pub fn sign_evm(&self, req: SignEvmRequest) -> Result<EvmSignatureResponse> {
         let req = EnclaveRequest {
-            request: Some(enclave_request::Request::SignEvm(SignEvmRequest {
-                call_data,
-                nonce,
-                deadline,
-            })),
+            request: Some(enclave_request::Request::SignEvm(req)),
         };
         let resp = self.send_request(&req)?;
         match resp.response {
@@ -107,13 +98,9 @@ impl EnclaveClient {
         }
     }
 
-    pub fn sign_psbt(&self, psbt_bytes: Vec<u8>) -> Result<SignedPsbtResponse> {
+    pub fn sign_psbt(&self, req: SignPsbtRequest) -> Result<SignedPsbtResponse> {
         let req = EnclaveRequest {
-            request: Some(enclave_request::Request::SignPsbt(SignPsbtRequest {
-                evm_tx_hash: vec![],
-                operation_idx: 0,
-                psbt_bytes,
-            })),
+            request: Some(enclave_request::Request::SignPsbt(req)),
         };
         let resp = self.send_request(&req)?;
         match resp.response {

--- a/parent/src/lib.rs
+++ b/parent/src/lib.rs
@@ -5,3 +5,7 @@ pub mod framing;
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/utexo_bridge.enclave.rs"));
 }
+
+pub mod enriched {
+    include!(concat!(env!("OUT_DIR"), "/tricorn.enriched.rs"));
+}

--- a/parent/src/main.rs
+++ b/parent/src/main.rs
@@ -5,7 +5,9 @@ use clap::{Parser, Subcommand};
 use tracing_subscriber::EnvFilter;
 
 use utexo_bridge_parent::client::EnclaveClient;
-use utexo_bridge_parent::proto::{InitializeKeyResponse, PublicKeysResponse};
+use utexo_bridge_parent::proto::{
+    InitializeKeyResponse, PublicKeysResponse, SignEvmRequest, SignPsbtRequest,
+};
 
 #[derive(Parser)]
 #[command(
@@ -43,12 +45,51 @@ enum Command {
         /// Unix timestamp deadline
         #[arg(long)]
         deadline: u64,
+        /// Chain ID for EIP-712 domain
+        #[arg(long, default_value = "1")]
+        chain_id: u64,
+        /// Hex-encoded proxy contract address (20 bytes)
+        #[arg(long, default_value = "0000000000000000000000000000000000000000")]
+        proxy_contract: String,
+        /// RGB consignment amount (smallest unit)
+        #[arg(long, default_value = "0")]
+        rgb_amount: u64,
+        /// RGB asset identifier
+        #[arg(long, default_value = "")]
+        rgb_asset_id: String,
+        /// Pre-extracted calldata amount
+        #[arg(long, default_value = "0")]
+        calldata_amount: u64,
+        /// Pre-extracted calldata commission
+        #[arg(long, default_value = "0")]
+        calldata_commission: u64,
+        /// Mark consignment as valid (required unless enclave is in dev-mode)
+        #[arg(long)]
+        consignment_valid: bool,
     },
     /// Sign a PSBT (SegWit v0 P2WSH multisig)
     SignPsbt {
         /// Hex-encoded PSBT bytes
         #[arg(long)]
         psbt: String,
+        /// Hex-encoded EVM tx hash (32 bytes)
+        #[arg(long, default_value = "")]
+        evm_tx_hash: String,
+        /// EVM deposit amount
+        #[arg(long, default_value = "0")]
+        evm_amount: u64,
+        /// EVM commission
+        #[arg(long, default_value = "0")]
+        evm_commission: u64,
+        /// PSBT total non-change output amount
+        #[arg(long, default_value = "0")]
+        psbt_output_amount: u64,
+        /// Mark EVM event as valid
+        #[arg(long)]
+        evm_event_valid: bool,
+        /// Mark EVM event as finalized
+        #[arg(long)]
+        evm_event_finalized: bool,
     },
     /// Sign a raw message (fundsIn authorization, 1-of-n)
     SignRawMessage {
@@ -159,6 +200,13 @@ fn main() {
             call_data,
             nonce,
             deadline,
+            chain_id,
+            proxy_contract,
+            rgb_amount,
+            rgb_asset_id,
+            calldata_amount,
+            calldata_commission,
+            consignment_valid,
         } => {
             let data = match hex::decode(&call_data) {
                 Ok(d) => d,
@@ -167,7 +215,26 @@ fn main() {
                     process::exit(1);
                 }
             };
-            match client.sign_evm(data, nonce, deadline) {
+            let proxy = match hex::decode(&proxy_contract) {
+                Ok(d) => d,
+                Err(e) => {
+                    eprintln!("Invalid hex proxy_contract: {}", e);
+                    process::exit(1);
+                }
+            };
+            let req = SignEvmRequest {
+                call_data: data,
+                nonce,
+                deadline,
+                consignment_valid,
+                rgb_amount,
+                rgb_asset_id,
+                chain_id,
+                proxy_contract: proxy,
+                calldata_amount,
+                calldata_commission,
+            };
+            match client.sign_evm(req) {
                 Ok(r) => {
                     println!("EVM signature (65 bytes): {}", hex::encode(&r.signature));
                 }
@@ -177,7 +244,15 @@ fn main() {
                 }
             }
         }
-        Command::SignPsbt { psbt } => {
+        Command::SignPsbt {
+            psbt,
+            evm_tx_hash,
+            evm_amount,
+            evm_commission,
+            psbt_output_amount,
+            evm_event_valid,
+            evm_event_finalized,
+        } => {
             let psbt_bytes = match hex::decode(&psbt) {
                 Ok(d) => d,
                 Err(e) => {
@@ -185,7 +260,31 @@ fn main() {
                     process::exit(1);
                 }
             };
-            match client.sign_psbt(psbt_bytes) {
+            let tx_hash = if evm_tx_hash.is_empty() {
+                vec![]
+            } else {
+                match hex::decode(&evm_tx_hash) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        eprintln!("Invalid hex evm_tx_hash: {}", e);
+                        process::exit(1);
+                    }
+                }
+            };
+            let req = SignPsbtRequest {
+                evm_tx_hash: tx_hash,
+                operation_idx: 0,
+                evm_event_valid,
+                evm_event_finalized,
+                evm_token: vec![],
+                evm_amount,
+                evm_recipient: vec![],
+                evm_commission,
+                psbt_bytes,
+                psbt_output_amount,
+                rgb_asset_id: String::new(),
+            };
+            match client.sign_psbt(req) {
                 Ok(r) => {
                     println!("Signed PSBT: {}", hex::encode(&r.signed_psbt));
                     println!("Inputs signed: {}", r.inputs_signed);

--- a/proto/enclave.proto
+++ b/proto/enclave.proto
@@ -11,9 +11,10 @@ message EnclaveRequest {
     SignEvmRequest         sign_evm         = 3;
     SignPsbtRequest        sign_psbt        = 4;
     SignRawMessageRequest  sign_raw_message = 5;
+    ProxyFederationRequest proxy_federation = 6;
     // Reserved for future:
-    // GetAttestationRequest get_attestation = 6;
-    // CloneRequest         clone_request    = 6;
+    // GetAttestationRequest get_attestation = 7;
+    // CloneRequest         clone_request    = 8;
     // HealthCheckRequest   health_check     = 9;
   }
 }
@@ -25,6 +26,7 @@ message EnclaveResponse {
     EvmSignatureResponse   evm_signature    = 3;
     SignedPsbtResponse     signed_psbt      = 4;
     RawSignatureResponse   raw_signature    = 5;
+    FederationSignatureResponse federation_sig = 6;
     // Reserved for future:
     // HealthCheckResponse  health_check     = 7;
     ErrorResponse          error            = 15;
@@ -59,10 +61,23 @@ message PublicKeysResponse {
 // === EVM Signing (RGB→EVM direction) ===
 
 message SignEvmRequest {
-  bytes call_data     = 1;  // Raw ABI-encoded function call (e.g., fundsOut selector + params)
-  uint64 nonce        = 2;  // Per-selector sequential nonce (matches on-chain MultisigProxy nonce)
-  uint64 deadline     = 3;  // Unix timestamp — signature invalid after this time
-  // Future: bytes consignment = 4; (RGB consignment for Listener validation)
+  // Original fields (sent by Orchestrator → Listener → Parent → Enclave)
+  bytes call_data       = 1;  // Raw ABI-encoded function call (e.g., fundsOut selector + params)
+  uint64 nonce          = 2;  // Per-selector sequential nonce (matches on-chain MultisigProxy nonce)
+  uint64 deadline       = 3;  // Unix timestamp — signature invalid after this time
+
+  // Enriched by Listener (validation results)
+  bool consignment_valid    = 4;   // Listener validated the RGB consignment
+  uint64 rgb_amount         = 5;   // Amount from validated consignment (smallest unit)
+  string rgb_asset_id       = 6;   // RGB asset identifier from consignment
+
+  // For EIP-712 domain (Listener reads from config/chain)
+  uint64 chain_id           = 7;
+  bytes proxy_contract      = 8;   // 20 bytes — verifying contract address
+
+  // Pre-extracted from call_data by Listener (avoids ABI parsing in enclave)
+  uint64 calldata_amount    = 9;
+  uint64 calldata_commission = 10;
 }
 
 message EvmSignatureResponse {
@@ -72,9 +87,22 @@ message EvmSignatureResponse {
 // === PSBT Signing (EVM→RGB direction) ===
 
 message SignPsbtRequest {
-  bytes evm_tx_hash    = 1;  // 32 bytes — for Listener validation (not used yet)
-  uint64 operation_idx = 2;  // For Listener query (not used yet)
-  bytes psbt_bytes     = 3;  // Temporary: direct PSBT bytes until Listener is wired up
+  // Original fields
+  bytes evm_tx_hash       = 1;   // 32 bytes — for Listener validation
+  uint64 operation_idx    = 2;   // For Listener query
+
+  // Enriched by Listener (EVM event validation)
+  bool evm_event_valid       = 3;
+  bool evm_event_finalized   = 4;
+  bytes evm_token            = 5;   // 20 bytes — ERC-20 address (empty for native)
+  uint64 evm_amount          = 6;   // Deposit amount from FundsIn event
+  bytes evm_recipient        = 7;   // 20 bytes
+  uint64 evm_commission      = 8;
+
+  // Enriched by Listener (PSBT data from rgb-multisig-bridge)
+  bytes psbt_bytes           = 9;   // Raw PSBT fetched by Listener
+  uint64 psbt_output_amount  = 10;  // Total non-change output amount from PSBT
+  string rgb_asset_id        = 11;
 }
 
 message SignedPsbtResponse {
@@ -92,6 +120,16 @@ message SignRawMessageRequest {
 
 message RawSignatureResponse {
   bytes signature = 1;  // 65 bytes: r(32) + s(32) + v(1), Ethereum ECDSA convention
+}
+
+// === Federation Proxy ===
+
+message ProxyFederationRequest {
+  bytes message_hash = 1;     // 32 bytes — keccak256 of published message
+}
+
+message FederationSignatureResponse {
+  bytes signature = 1;        // 65-byte ECDSA from Listener's federation key
 }
 
 // === Error ===

--- a/proto/enriched-payload.proto
+++ b/proto/enriched-payload.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+package tricorn.enriched;
+
+// Enriched payloads for SignRequest.data field.
+// Listener repacks SignRequest.data before forwarding to Enclave.
+// Dispatch: network_id + data_type determines which message to decode.
+// Both Listener (Go) and Enclave (Rust) generate from this file.
+
+// EVM → RGB direction (FundsIn on EVM, PSBT signing)
+message EnrichedPsbtPayload {
+  bytes evm_tx_hash           = 1;
+  uint64 operation_idx        = 2;
+
+  bool evm_event_valid        = 3;
+  bool evm_event_finalized    = 4;
+  bytes evm_token             = 5;
+  uint64 evm_amount           = 6;
+  bytes evm_recipient         = 7;
+  uint64 evm_commission       = 8;
+
+  bytes psbt_bytes            = 9;
+  uint64 psbt_output_amount   = 10;
+  string rgb_asset_id         = 11;
+}
+
+// RGB → EVM direction (FundsIn on RGB, EVM signing)
+message EnrichedEvmPayload {
+  bytes call_data             = 1;
+  uint64 nonce                = 2;
+  uint64 deadline             = 3;
+
+  bool consignment_valid      = 4;
+  uint64 rgb_amount           = 5;
+  string rgb_asset_id         = 6;
+
+  uint64 chain_id             = 7;
+  bytes proxy_contract        = 8;
+  uint64 calldata_amount      = 9;
+  uint64 calldata_commission  = 10;
+}


### PR DESCRIPTION
## Summary

- Extend `SignEvmRequest` and `SignPsbtRequest` protos with enriched fields from the Listener (consignment validation, EVM event status, amounts, chain/domain info)
- Create `enriched-payload.proto` as the canonical shared definitions for Go Listener interop
- Add `validation/` module with cross-check logic for both signing directions (RGB→EVM and EVM→RGB)
- Wire cross-checks into `handle_sign_evm` and `handle_sign_psbt` — the enclave now independently verifies amount consistency before signing
- Add `ProxyFederationRequest` handler (stub, returns NOT_READY until Listener integration)
- Update parent CLI with all enriched field flags for interactive testing
- Add `dev-mode` feature flag to skip cross-checks during development

### Cross-check rules

**EVM signing (RGB->EVM):** consignment valid, `rgb_amount >= calldata_amount + commission`, calldata ABI extraction verification, chain/domain present, deadline not expired

**PSBT signing (EVM->RGB):** EVM event valid + finalized, `evm_amount >= psbt_output_amount + commission`, PSBT bytes present, tx hash 32 bytes

## Test plan

- [x] All 41 unit tests pass (including 18 new validation tests)
- [x] All 16 integration tests pass with `allow-seed-import` (including 6 new cross-check rejection tests)
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] Production build (no `dev-mode`) compiles and unit tests pass
- [x] Existing T1-T4 tests still pass with `dev-mode` feature