### PR TITLE
feat: pass consignment bytes through to enclave

### DIFF
--- a/enclave/src/keys.rs
+++ b/enclave/src/keys.rs
@@ -433,9 +433,9 @@ mod tests {
             }],
             output: vec![TxOut {
                 value: Amount::from_sat(50_000),
-                script_pubkey: ScriptBuf::new_p2wpkh(
-                    &bitcoin::WPubkeyHash::from_byte_array([0xBB; 20]),
-                ),
+                script_pubkey: ScriptBuf::new_p2wpkh(&bitcoin::WPubkeyHash::from_byte_array(
+                    [0xBB; 20],
+                )),
             }],
         };
 

--- a/enclave/src/validation/evm_crosscheck.rs
+++ b/enclave/src/validation/evm_crosscheck.rs
@@ -1,5 +1,7 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use sha3::{Digest, Keccak256};
+
 use crate::error::{EnclaveError, Result};
 use crate::proto::SignEvmRequest;
 
@@ -11,6 +13,23 @@ pub fn validate_evm_request(req: &SignEvmRequest) -> Result<()> {
         return Err(EnclaveError::CrossCheck(
             "consignment not validated by Listener".into(),
         ));
+    }
+
+    // 1b. If raw consignment bytes are present, verify hash integrity.
+    //     This catches tampering between Listener and Enclave.
+    //     Full RGB validation (rgb-lib) will be added in a follow-up PR.
+    if !req.consignment.is_empty() {
+        if req.consignment_hash.is_empty() {
+            return Err(EnclaveError::CrossCheck(
+                "consignment present but consignment_hash is missing".into(),
+            ));
+        }
+        let computed = Keccak256::digest(&req.consignment);
+        if &computed[..] != req.consignment_hash.as_slice() {
+            return Err(EnclaveError::CrossCheck(
+                "consignment hash mismatch: keccak256(consignment) != consignment_hash".into(),
+            ));
+        }
     }
 
     // 2. Amount consistency: RGB amount must cover calldata amount + commission
@@ -134,6 +153,9 @@ mod tests {
             proxy_contract: vec![0xAA; 20],
             calldata_amount: amount,
             calldata_commission: commission,
+            // Empty = skip hash check (backwards compatible)
+            consignment: vec![],
+            consignment_hash: vec![],
         }
     }
 
@@ -220,5 +242,39 @@ mod tests {
         let mut data = vec![0u8; 32];
         data[0] = 1; // high byte set — exceeds u64
         assert!(extract_uint256_as_u64(&data, 0).is_err());
+    }
+
+    #[test]
+    fn accepts_valid_consignment_hash() {
+        let mut req = valid_evm_request();
+        let consignment = b"test-consignment-bytes";
+        let hash = Keccak256::digest(consignment);
+        req.consignment = consignment.to_vec();
+        req.consignment_hash = hash.to_vec();
+        assert!(validate_evm_request(&req).is_ok());
+    }
+
+    #[test]
+    fn rejects_consignment_hash_mismatch() {
+        let mut req = valid_evm_request();
+        req.consignment = b"test-consignment-bytes".to_vec();
+        req.consignment_hash = vec![0xDE; 32]; // wrong hash
+        let err = validate_evm_request(&req).unwrap_err();
+        assert!(err.to_string().contains("consignment hash mismatch"));
+    }
+
+    #[test]
+    fn rejects_consignment_without_hash() {
+        let mut req = valid_evm_request();
+        req.consignment = b"test-consignment-bytes".to_vec();
+        req.consignment_hash = vec![]; // missing hash
+        let err = validate_evm_request(&req).unwrap_err();
+        assert!(err.to_string().contains("consignment_hash is missing"));
+    }
+
+    #[test]
+    fn skips_hash_check_when_consignment_empty() {
+        // Default valid_evm_request has empty consignment — should still pass
+        assert!(validate_evm_request(&valid_evm_request()).is_ok());
     }
 }

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -49,6 +49,8 @@ fn valid_sign_evm_request(amount: u64, commission: u64) -> SignEvmRequest {
         proxy_contract: vec![0xAA; 20],
         calldata_amount: amount,
         calldata_commission: commission,
+        consignment: vec![],
+        consignment_hash: vec![],
     }
 }
 

--- a/parent/src/bin/cli.rs
+++ b/parent/src/bin/cli.rs
@@ -233,6 +233,8 @@ fn main() {
                 proxy_contract: proxy,
                 calldata_amount,
                 calldata_commission,
+                consignment: vec![],
+                consignment_hash: vec![],
             };
             match client.sign_evm(req) {
                 Ok(r) => {

--- a/parent/src/client.rs
+++ b/parent/src/client.rs
@@ -1,13 +1,13 @@
 use std::net::TcpStream;
 
-use crate::error::{ParentError, Result};
-use crate::framing;
 use crate::enclave_proto::{
     enclave_request, enclave_response, EnclaveRequest, EnclaveResponse, EvmSignatureResponse,
     GetPublicKeyRequest, InitializeKeyRequest, InitializeKeyResponse, PublicKeysResponse,
     RawSignatureResponse, SignEvmRequest, SignPsbtRequest, SignRawMessageRequest,
     SignedPsbtResponse,
 };
+use crate::error::{ParentError, Result};
+use crate::framing;
 
 pub struct EnclaveClient {
     addr: String,

--- a/parent/src/config.rs
+++ b/parent/src/config.rs
@@ -20,8 +20,7 @@ impl Config {
     pub fn from_env() -> Self {
         Self {
             grpc_port: env_or("GRPC_PORT", 5000),
-            enclave_addr: std::env::var("ENCLAVE_ADDR")
-                .unwrap_or_else(|_| "127.0.0.1:5000".into()),
+            enclave_addr: std::env::var("ENCLAVE_ADDR").unwrap_or_else(|_| "127.0.0.1:5000".into()),
             enclave_vsock_cid: env_or("ENCLAVE_VSOCK_CID", 16),
             enclave_vsock_port: env_or("ENCLAVE_VSOCK_PORT", 5000),
             use_vsock: std::env::var("USE_VSOCK")

--- a/parent/src/grpc_server.rs
+++ b/parent/src/grpc_server.rs
@@ -159,6 +159,9 @@ impl EnclaveService for ParentAdapterService {
                             nonce: evm_flow.nonce,
                             deadline: evm_flow.deadline,
                             consignment_valid: evm_flow.consignment_valid,
+                            // Raw consignment bytes — passed through for enclave-side validation.
+                            consignment: evm_flow.consignment,
+                            consignment_hash: evm_flow.consignment_hash,
                             // Fields the Go Listener doesn't send yet — defaults.
                             rgb_amount: 0,
                             rgb_asset_id: String::new(),

--- a/parent/src/grpc_server.rs
+++ b/parent/src/grpc_server.rs
@@ -18,7 +18,10 @@ use crate::grpc_proto::{
 pub enum EnclaveTarget {
     Tcp(String),
     #[cfg(target_os = "linux")]
-    Vsock { cid: u32, port: u32 },
+    Vsock {
+        cid: u32,
+        port: u32,
+    },
 }
 
 /// gRPC server that translates parentadapter.proto RPCs into enclave.proto
@@ -45,13 +48,10 @@ impl ParentAdapterService {
 
                 match target {
                     EnclaveTarget::Tcp(addr) => {
-                        let mut stream =
-                            std::net::TcpStream::connect(&addr).map_err(|e| {
-                                Status::unavailable(format!("enclave connection failed: {e}"))
-                            })?;
-                        stream
-                            .set_read_timeout(Some(ENCLAVE_TIMEOUT))
-                            .ok();
+                        let mut stream = std::net::TcpStream::connect(&addr).map_err(|e| {
+                            Status::unavailable(format!("enclave connection failed: {e}"))
+                        })?;
+                        stream.set_read_timeout(Some(ENCLAVE_TIMEOUT)).ok();
                         framing::write_message(&mut stream, &req)
                             .map_err(|e| Status::internal(format!("enclave write failed: {e}")))?;
                         let resp: EnclaveResponse = framing::read_message(&mut stream)
@@ -60,11 +60,9 @@ impl ParentAdapterService {
                     }
                     #[cfg(target_os = "linux")]
                     EnclaveTarget::Vsock { cid, port } => {
-                        let mut stream =
-                            vsock::VsockStream::connect_with_cid_port(cid, port).map_err(|e| {
-                                Status::unavailable(format!(
-                                    "enclave vsock connection failed: {e}"
-                                ))
+                        let mut stream = vsock::VsockStream::connect_with_cid_port(cid, port)
+                            .map_err(|e| {
+                                Status::unavailable(format!("enclave vsock connection failed: {e}"))
                             })?;
                         framing::write_message(&mut stream, &req)
                             .map_err(|e| Status::internal(format!("enclave write failed: {e}")))?;
@@ -88,7 +86,10 @@ impl ParentAdapterService {
     fn enclave_error_to_status(err: &enclave_proto::ErrorResponse) -> Status {
         match err.code {
             3 => Status::failed_precondition(err.message.clone()),
-            _ => Status::internal(format!("enclave error (code {}): {}", err.code, err.message)),
+            _ => Status::internal(format!(
+                "enclave error (code {}): {}",
+                err.code, err.message
+            )),
         }
     }
 }
@@ -113,12 +114,9 @@ impl EnclaveService for ParentAdapterService {
                 let evm_tx_hash = if psbt_flow.validated_tx_hash.is_empty() {
                     vec![]
                 } else {
-                    let decoded =
-                        hex::decode(&psbt_flow.validated_tx_hash).map_err(|e| {
-                            Status::invalid_argument(format!(
-                                "validated_tx_hash is not valid hex: {e}"
-                            ))
-                        })?;
+                    let decoded = hex::decode(&psbt_flow.validated_tx_hash).map_err(|e| {
+                        Status::invalid_argument(format!("validated_tx_hash is not valid hex: {e}"))
+                    })?;
                     if decoded.len() != 32 {
                         return Err(Status::invalid_argument(format!(
                             "validated_tx_hash must be 32 bytes, got {}",
@@ -181,24 +179,18 @@ impl EnclaveService for ParentAdapterService {
             Some(enclave_response::Response::SignedPsbt(r)) => {
                 Ok(Response::new(EnclaveSignResponse {
                     result: Some(
-                        crate::grpc_proto::enclave_sign_response::Result::SignedPsbt(
-                            r.signed_psbt,
-                        ),
+                        crate::grpc_proto::enclave_sign_response::Result::SignedPsbt(r.signed_psbt),
                     ),
                 }))
             }
             Some(enclave_response::Response::EvmSignature(r)) => {
                 Ok(Response::new(EnclaveSignResponse {
                     result: Some(
-                        crate::grpc_proto::enclave_sign_response::Result::EvmSignature(
-                            r.signature,
-                        ),
+                        crate::grpc_proto::enclave_sign_response::Result::EvmSignature(r.signature),
                     ),
                 }))
             }
-            Some(enclave_response::Response::Error(e)) => {
-                Err(Self::enclave_error_to_status(&e))
-            }
+            Some(enclave_response::Response::Error(e)) => Err(Self::enclave_error_to_status(&e)),
             other => Err(Status::internal(format!(
                 "unexpected enclave response for Sign: {:?}",
                 other
@@ -230,9 +222,7 @@ impl EnclaveService for ParentAdapterService {
                 }
                 Ok(Response::new(GetPublicKeysResponse { public_keys: keys }))
             }
-            Some(enclave_response::Response::Error(e)) => {
-                Err(Self::enclave_error_to_status(&e))
-            }
+            Some(enclave_response::Response::Error(e)) => Err(Self::enclave_error_to_status(&e)),
             other => Err(Status::internal(format!(
                 "unexpected enclave response for GetPublicKeys: {:?}",
                 other

--- a/proto/enclave.proto
+++ b/proto/enclave.proto
@@ -78,6 +78,11 @@ message SignEvmRequest {
   // Pre-extracted from call_data by Listener (avoids ABI parsing in enclave)
   uint64 calldata_amount    = 9;
   uint64 calldata_commission = 10;
+
+  // Raw RGB consignment for in-enclave validation (PR2 will add full rgb-lib validation).
+  // For now the enclave verifies keccak256(consignment) == consignment_hash as integrity check.
+  bytes consignment         = 11;  // Raw RGB consignment bytes (from Go Listener via Parent Adapter)
+  bytes consignment_hash    = 12;  // keccak256(consignment) — integrity check
 }
 
 message EvmSignatureResponse {

--- a/proto/enriched-payload.proto
+++ b/proto/enriched-payload.proto
@@ -37,4 +37,7 @@ message EnrichedEvmPayload {
   bytes proxy_contract        = 8;
   uint64 calldata_amount      = 9;
   uint64 calldata_commission  = 10;
+
+  bytes consignment           = 11;
+  bytes consignment_hash      = 12;
 }


### PR DESCRIPTION
## Summary

- Adds `consignment` (field 11) and `consignment_hash` (field 12) to `SignEvmRequest` in `enclave.proto` and `EnrichedEvmPayload` in `enriched-payload.proto`
- Parent Adapter now maps `EVMSigningFlow.consignment` and `.consignment_hash` from the Go proto through to the enclave (previously dropped)
- Enclave verifies `keccak256(consignment) == consignment_hash` when bytes are present (skipped when empty for backwards compatibility)

## Why

The Go Listener sends raw consignment bytes and their keccak256 hash in `EVMSigningFlow`, but our enclave.proto had no fields to receive them — they were silently dropped at the Parent Adapter. This PR adds the plumbing so the bytes flow all the way through.

The hash integrity check catches tampering between the Listener and Enclave. This is a stepping stone — full RGB consignment validation via rgb-lib inside the TEE will follow in a separate PR.

## Changed files

| File | What |
|------|------|
| `proto/enclave.proto` | Added `consignment` + `consignment_hash` to `SignEvmRequest` |
| `proto/enriched-payload.proto` | Added same fields to `EnrichedEvmPayload` |
| `parent/src/grpc_server.rs` | Map fields through instead of dropping them |
| `parent/src/bin/cli.rs` | Add default empty fields to CLI struct init |
| `enclave/src/validation/evm_crosscheck.rs` | keccak256 hash integrity check + 4 new tests |
| `enclave/tests/test_signing.rs` | Add new fields to test helper |

## What's next (separate PR)

Full in-enclave RGB consignment validation using rgb-lib/rgb-consensus with a vsock-proxy for Esplora indexer access from inside the Nitro enclave. The consignment bytes plumbed here will be validated there.

## Test plan

- [x] `cargo build --workspace` — zero warnings
- [x] `cargo test --workspace` — all 65 tests pass (4 new)
- [x] Backwards compatible: empty consignment = hash check skipped