### PR TITLE
feat: in-enclave RGB consignment validation via rgbstd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "amplify"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a9d7cb29f1d4c6ec8650abbee35948b8bdefb7f0750a26445ff593eb9bf7fcf"
+dependencies = [
+ "amplify_apfloat",
+ "amplify_derive",
+ "amplify_num",
+ "amplify_syn",
+ "ascii",
+ "rand 0.8.5",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "amplify_apfloat"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695e433882668b55b3d7fb0ba22bf9be66a91abe30d7ca1f1a774f8b90b4db4c"
+dependencies = [
+ "amplify_num",
+ "bitflags",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "amplify_derive"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a6309e6b8d89b36b9f959b7a8fa093583b94922a0f6438a24fb08936de4d428"
+dependencies = [
+ "amplify_syn",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "amplify_num"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99bcb75a2982047f733547042fc3968c0f460dfcf7d90b90dea3b2744580e9ad"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "amplify_syn"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7736fb8d473c0d83098b5bac44df6a561e20470375cd8bcae30516dc889fd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,10 +135,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "async-stream"
@@ -92,7 +171,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -103,7 +182,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -166,6 +245,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "baid64"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb4a8b2f1afee4ef00a190b260ad871842b93206177b59631fecd325d48d538"
+dependencies = [
+ "amplify",
+ "base64",
+ "mnemonic",
+ "sha2",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,6 +283,15 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "base85"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36915bbaca237c626689b5bd14d02f2ba7a5a359d30a2a08be697392e3718079"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "bech32"
@@ -226,6 +326,7 @@ dependencies = [
  "hex-conservative",
  "hex_lit",
  "secp256k1",
+ "serde",
 ]
 
 [[package]]
@@ -233,6 +334,9 @@ name = "bitcoin-internals"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitcoin-io"
@@ -247,6 +351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
 dependencies = [
  "bitcoin-internals",
+ "serde",
 ]
 
 [[package]]
@@ -257,6 +362,7 @@ checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
+ "serde",
 ]
 
 [[package]]
@@ -266,6 +372,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "blake3"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +393,18 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -314,6 +446,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,7 +489,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -366,6 +511,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +539,12 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -403,6 +566,16 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "daggy"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804169db156b21258a2545757336922d93dfa229892c75911a0ad141aa0ff241"
+dependencies = [
+ "petgraph 0.8.3",
+ "serde",
 ]
 
 [[package]]
@@ -483,6 +656,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "esplora-client"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f19e3ea99dbfbef0c1ec26d83e69de0c579f6aa6aaac4f44597805fcc27e97af"
+dependencies = [
+ "bitcoin",
+ "hex-conservative",
+ "log",
+ "minreq",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "fast32"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a35a73237400bde66c82e38387343f90d7182a2f2f22729e096a2abd57d75db9"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +702,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+]
 
 [[package]]
 name = "fnv"
@@ -579,8 +782,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -591,7 +810,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
@@ -625,6 +844,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -786,6 +1016,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,6 +1087,16 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "k256"
@@ -933,6 +1197,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minreq"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05015102dad0f7d61691ca347e9d9d9006685a64aefb3d79eecf62665de2153d"
+dependencies = [
+ "base64",
+ "rustls",
+ "rustls-webpki",
+ "serde",
+ "serde_json",
+ "webpki-roots",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,6 +1220,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "mnemonic"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b8f3a258db515d5e91a904ce4ae3f73e091149b90cadbdb93d210bee07f63b"
 
 [[package]]
 name = "multimap"
@@ -963,12 +1247,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonasync"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f7335a3fa37124e24461d6164485760d4c056dd92a81a70c23fc28c2b63c8"
+dependencies = [
+ "amplify",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1007,6 +1309,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1339,8 @@ dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1050,7 +1360,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1091,7 +1401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1139,7 +1449,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -1158,7 +1468,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",
  "regex",
- "syn",
+ "syn 2.0.117",
  "tempfile",
 ]
 
@@ -1172,7 +1482,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1185,7 +1495,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1217,6 +1527,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1228,8 +1544,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1254,12 +1580,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1275,6 +1620,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1317,6 +1682,165 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb-aluvm"
+version = "0.11.1-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b9e41006564b48551e52e001181898982b11732348100216097033b3e536a2"
+dependencies = [
+ "amplify",
+ "baid64",
+ "blake3",
+ "getrandom 0.3.4",
+ "half",
+ "paste",
+ "rgb-ascii-armor",
+ "rgb-strict-encoding",
+ "rgb-strict-types",
+ "ripemd",
+ "sha2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "rgb-ascii-armor"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe59d42597231134da1a7b51e5e380b2e1cf7441c27f2a8c23c6c27ea206888"
+dependencies = [
+ "amplify",
+ "baid64",
+ "base85",
+ "rgb-strict-encoding",
+ "sha2",
+]
+
+[[package]]
+name = "rgb-consensus"
+version = "0.11.1-rc.8"
+source = "git+https://github.com/rgb-protocol/rgb-consensus?branch=master#da8a7d68746f87679dc7ad3826fd90b1454a6be3"
+dependencies = [
+ "amplify",
+ "baid64",
+ "base85",
+ "bitcoin",
+ "chrono",
+ "daggy",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "hex-conservative",
+ "mime",
+ "rand 0.9.2",
+ "rgb-aluvm",
+ "rgb-strict-encoding",
+ "rgb-strict-types",
+ "ripemd",
+ "secp256k1",
+ "sha2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "rgb-invoicing"
+version = "0.11.1-rc.8"
+source = "git+https://github.com/rgb-protocol/rgb-ops?branch=master#e8613ce04c10980b4b1f43cb634725e82c426837"
+dependencies = [
+ "amplify",
+ "baid64",
+ "fast32",
+ "fluent-uri",
+ "indexmap 2.13.0",
+ "percent-encoding",
+ "rand 0.9.2",
+ "rgb-consensus",
+ "rgb-strict-encoding",
+ "rgb-strict-types",
+]
+
+[[package]]
+name = "rgb-ops"
+version = "0.11.1-rc.8"
+source = "git+https://github.com/rgb-protocol/rgb-ops?branch=master#e8613ce04c10980b4b1f43cb634725e82c426837"
+dependencies = [
+ "amplify",
+ "baid64",
+ "base85",
+ "chrono",
+ "esplora-client",
+ "getrandom 0.3.4",
+ "indexmap 2.13.0",
+ "nonasync",
+ "rand 0.9.2",
+ "rgb-aluvm",
+ "rgb-ascii-armor",
+ "rgb-consensus",
+ "rgb-invoicing",
+ "rgb-strict-encoding",
+ "rgb-strict-types",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "rgb-strict-encoding"
+version = "1.0.1"
+source = "git+https://github.com/rgb-protocol/rgb-strict-encoding?branch=master#ddeae3b546b9668cda8fb11efa9eafd0c61ef467"
+dependencies = [
+ "amplify",
+ "bitcoin",
+ "rgb-strict-encoding-derive",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "rgb-strict-encoding-derive"
+version = "1.0.1"
+source = "git+https://github.com/rgb-protocol/rgb-strict-encoding?branch=master#ddeae3b546b9668cda8fb11efa9eafd0c61ef467"
+dependencies = [
+ "amplify_syn",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rgb-strict-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dfaa85981472cf64009d0bc605891917b320b4f735644c2940c2574f525354"
+dependencies = [
+ "amplify",
+ "baid64",
+ "indexmap 2.13.0",
+ "rgb-ascii-armor",
+ "rgb-strict-encoding",
+ "sha2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,6 +1854,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1886,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sec1"
@@ -1362,7 +1918,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "bitcoin_hashes",
+ "rand 0.8.5",
  "secp256k1-sys",
+ "serde",
 ]
 
 [[package]]
@@ -1396,6 +1954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1415,7 +1974,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1543,6 +2102,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -1573,11 +2143,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1588,7 +2178,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1640,7 +2230,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1708,7 +2298,7 @@ dependencies = [
  "prost-build 0.13.5",
  "prost-types 0.13.5",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1776,7 +2366,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1852,6 +2442,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "utexo-bridge-enclave"
 version = "0.1.0"
 dependencies = [
@@ -1864,9 +2460,10 @@ dependencies = [
  "prost 0.14.3",
  "prost-build 0.14.3",
  "rand 0.10.0",
+ "rgb-ops",
  "secrecy",
  "sha3",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
  "vsock",
@@ -1882,7 +2479,7 @@ dependencies = [
  "hex",
  "prost 0.13.5",
  "prost-build 0.13.5",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tonic",
  "tonic-build",
@@ -1953,6 +2550,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1987,10 +2629,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2104,7 +2805,7 @@ dependencies = [
  "heck",
  "indexmap 2.13.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2120,7 +2821,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2179,7 +2880,7 @@ checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2199,7 +2900,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,10 @@ lto = true
 strip = true
 panic = "abort"
 codegen-units = 1
+
+# RGB ecosystem crates — pinned to git master for consignment validation.
+[patch.crates-io]
+rgb-consensus = { git = "https://github.com/rgb-protocol/rgb-consensus", branch = "master" }
+rgb-ops = { git = "https://github.com/rgb-protocol/rgb-ops", branch = "master" }
+rgb-invoicing = { git = "https://github.com/rgb-protocol/rgb-ops", branch = "master" }
+rgb-strict-encoding = { git = "https://github.com/rgb-protocol/rgb-strict-encoding", branch = "master" }

--- a/build/Dockerfile.enclave
+++ b/build/Dockerfile.enclave
@@ -8,7 +8,7 @@ WORKDIR /build
 COPY . /build/
 
 WORKDIR /build/enclave
-RUN cargo build --release --features vsock
+RUN cargo build --release --features vsock,rgb-validation
 
 # --- Runtime ---
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal AS runtime

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -44,6 +44,9 @@ hex = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# RGB consignment validation (optional, behind rgb-validation feature)
+rgb-ops = { version = "0.11.1-rc.7", features = ["esplora_blocking"], optional = true }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 vsock = "0.5"
 nix = { version = "0.31.2", features = ["socket"] }
@@ -58,6 +61,8 @@ vsock = []
 allow-seed-import = []
 # Skips cross-check validation on signing requests. Development/testing only.
 dev-mode = []
+# In-enclave RGB consignment validation via rgbstd + Esplora.
+rgb-validation = ["rgb-ops"]
 
 [dev-dependencies]
 rand = "0.10.0"

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -6,6 +6,8 @@ pub mod keys;
 pub mod server;
 pub mod signing;
 pub mod validation;
+#[cfg(all(feature = "vsock", target_os = "linux"))]
+pub mod vsock_forwarder;
 
 pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/utexo_bridge.enclave.rs"));

--- a/enclave/src/main.rs
+++ b/enclave/src/main.rs
@@ -20,6 +20,10 @@ fn main() {
             .ok()
             .and_then(|s| s.parse().ok())
             .unwrap_or(8001);
+        tracing::info!(
+            vsock_port,
+            "starting Esplora vsock forwarder (host must run: vsock-proxy {vsock_port} <esplora-host> <esplora-port>)"
+        );
         if let Err(e) = utexo_bridge_enclave::vsock_forwarder::start_forwarder(3443, vsock_port) {
             tracing::error!("failed to start vsock forwarder: {e}");
         }

--- a/enclave/src/main.rs
+++ b/enclave/src/main.rs
@@ -1,7 +1,7 @@
 use std::net::TcpListener;
 
 use utexo_bridge_enclave::keys::EnclaveState;
-use utexo_bridge_enclave::server;
+use utexo_bridge_enclave::server::{self, ServerContext};
 
 fn main() {
     tracing_subscriber::fmt()
@@ -11,6 +11,44 @@ fn main() {
     tracing::info!("starting utexo-bridge-enclave");
 
     let state = EnclaveState::new();
+
+    // Start vsock-to-TCP forwarder for Esplora access (production only).
+    // The host must run: vsock-proxy <ESPLORA_VSOCK_PORT> <esplora-host> <esplora-port>
+    #[cfg(all(feature = "vsock", target_os = "linux"))]
+    {
+        let vsock_port: u32 = std::env::var("ESPLORA_VSOCK_PORT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(8001);
+        if let Err(e) = utexo_bridge_enclave::vsock_forwarder::start_forwarder(3443, vsock_port) {
+            tracing::error!("failed to start vsock forwarder: {e}");
+        }
+    }
+
+    // Build RGB consignment validator (when feature enabled).
+    #[cfg(feature = "rgb-validation")]
+    let rgb_validator = {
+        let esplora_url = std::env::var("ESPLORA_URL")
+            .unwrap_or_else(|_| "http://127.0.0.1:3443".into());
+        let network = std::env::var("BITCOIN_NETWORK")
+            .unwrap_or_else(|_| "bitcoin".into());
+        match utexo_bridge_enclave::validation::rgb::RgbValidator::new(esplora_url, &network) {
+            Ok(v) => {
+                tracing::info!("RGB validator initialized");
+                Some(v)
+            }
+            Err(e) => {
+                tracing::error!("failed to create RGB validator: {e}");
+                None
+            }
+        }
+    };
+
+    let ctx = ServerContext {
+        state,
+        #[cfg(feature = "rgb-validation")]
+        rgb_validator,
+    };
 
     #[cfg(all(feature = "vsock", target_os = "linux"))]
     {
@@ -24,7 +62,7 @@ fn main() {
             match stream {
                 Ok(stream) => {
                     tracing::debug!("accepted vsock connection");
-                    server::handle_connection(stream, &state);
+                    server::handle_connection(stream, &ctx);
                 }
                 Err(e) => tracing::error!("accept error: {}", e),
             }
@@ -45,7 +83,7 @@ fn main() {
                         .map(|a| a.to_string())
                         .unwrap_or_else(|_| "unknown".into());
                     tracing::debug!(%peer, "accepted TCP connection");
-                    server::handle_connection(stream, &state);
+                    server::handle_connection(stream, &ctx);
                 }
                 Err(e) => tracing::error!("accept error: {}", e),
             }

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -10,25 +10,32 @@ use crate::signing::evm::{sign_request_digest, Eip712Domain};
 #[cfg(not(feature = "dev-mode"))]
 use crate::validation;
 
+/// Shared context passed to every request handler.
+pub struct ServerContext {
+    pub state: EnclaveState,
+    #[cfg(feature = "rgb-validation")]
+    pub rgb_validator: Option<crate::validation::rgb::RgbValidator>,
+}
+
 /// Handle a single connection: read one request, dispatch, write one response, close.
-pub fn handle_connection(stream: impl Read + Write, state: &EnclaveState) {
-    if let Err(e) = process_connection(stream, state) {
+pub fn handle_connection(stream: impl Read + Write, ctx: &ServerContext) {
+    if let Err(e) = process_connection(stream, ctx) {
         tracing::error!("connection error: {}", e);
     }
 }
 
-fn process_connection(mut stream: impl Read + Write, state: &EnclaveState) -> Result<()> {
+fn process_connection(mut stream: impl Read + Write, ctx: &ServerContext) -> Result<()> {
     tracing::debug!("reading request");
     let request: EnclaveRequest = framing::read_message(&mut stream)?;
 
-    let response = dispatch(request, state);
+    let response = dispatch(request, ctx);
 
     framing::write_message(&mut stream, &response)?;
     tracing::debug!("response written");
     Ok(())
 }
 
-fn dispatch(request: EnclaveRequest, state: &EnclaveState) -> EnclaveResponse {
+fn dispatch(request: EnclaveRequest, ctx: &ServerContext) -> EnclaveResponse {
     let result = match request.request {
         Some(Request::InitializeKey(req)) => {
             let path = if req.seed.is_empty() {
@@ -37,27 +44,27 @@ fn dispatch(request: EnclaveRequest, state: &EnclaveState) -> EnclaveResponse {
                 "seed-import"
             };
             tracing::info!("request: InitializeKey ({})", path);
-            handle_initialize(state, req)
+            handle_initialize(&ctx.state, req)
         }
         Some(Request::GetPublicKey(req)) => {
             tracing::info!("request: GetPublicKey");
-            handle_get_public_key(state, req)
+            handle_get_public_key(&ctx.state, req)
         }
         Some(Request::SignEvm(req)) => {
             tracing::info!("request: SignEvm");
-            handle_sign_evm(state, req)
+            handle_sign_evm(ctx, req)
         }
         Some(Request::SignPsbt(req)) => {
             tracing::info!("request: SignPsbt");
-            handle_sign_psbt(state, req)
+            handle_sign_psbt(&ctx.state, req)
         }
         Some(Request::SignRawMessage(req)) => {
             tracing::info!("request: SignRawMessage");
-            handle_sign_raw_message(state, req)
+            handle_sign_raw_message(&ctx.state, req)
         }
         Some(Request::ProxyFederation(req)) => {
             tracing::info!("request: ProxyFederation");
-            handle_proxy_federation(state, req)
+            handle_proxy_federation(req)
         }
         None => {
             tracing::warn!("received empty request (no oneof variant set)");
@@ -146,7 +153,29 @@ fn handle_get_public_key(
     })
 }
 
-fn handle_sign_evm(state: &EnclaveState, req: SignEvmRequest) -> Result<EnclaveResponse> {
+fn handle_sign_evm(ctx: &ServerContext, req: SignEvmRequest) -> Result<EnclaveResponse> {
+    // In-enclave RGB consignment validation (when feature enabled and bytes present).
+    // This replaces trusting the Listener's consignment_valid boolean.
+    #[cfg(feature = "rgb-validation")]
+    if !req.consignment.is_empty() {
+        if let Some(ref validator) = ctx.rgb_validator {
+            let validated = validator.validate_consignment(&req.consignment)?;
+            tracing::info!(
+                contract_id = %validated.contract_id,
+                "RGB consignment validated in-enclave"
+            );
+            // Cross-check contract_id against declared rgb_asset_id if present
+            if !req.rgb_asset_id.is_empty() && validated.contract_id != req.rgb_asset_id {
+                return Err(EnclaveError::CrossCheck(format!(
+                    "contract_id mismatch: consignment has {} but request declares {}",
+                    validated.contract_id, req.rgb_asset_id
+                )));
+            }
+        } else {
+            tracing::warn!("RGB validator not configured, skipping in-enclave validation");
+        }
+    }
+
     // Cross-check enriched fields before signing (skipped in dev-mode)
     #[cfg(not(feature = "dev-mode"))]
     validation::evm_crosscheck::validate_evm_request(&req)?;
@@ -155,7 +184,7 @@ fn handle_sign_evm(state: &EnclaveState, req: SignEvmRequest) -> Result<EnclaveR
     let domain = build_evm_domain(&req)?;
 
     let digest = sign_request_digest(&domain, &req.call_data, req.nonce, req.deadline);
-    let signature = state.sign_evm(&digest)?;
+    let signature = ctx.state.sign_evm(&digest)?;
 
     tracing::info!(
         sig_hex = %hex::encode(signature),
@@ -255,10 +284,7 @@ fn build_evm_domain(req: &SignEvmRequest) -> Result<Eip712Domain> {
     })
 }
 
-fn handle_proxy_federation(
-    _state: &EnclaveState,
-    _req: ProxyFederationRequest,
-) -> Result<EnclaveResponse> {
+fn handle_proxy_federation(_req: ProxyFederationRequest) -> Result<EnclaveResponse> {
     // Stub: federation proxy requires Listener integration (not yet wired)
     Ok(EnclaveResponse {
         response: Some(Response::Error(ErrorResponse {

--- a/enclave/src/validation/evm_crosscheck.rs
+++ b/enclave/src/validation/evm_crosscheck.rs
@@ -8,11 +8,28 @@ use crate::proto::SignEvmRequest;
 /// Validate enriched SignEvmRequest before signing.
 /// Returns Ok(()) if all cross-checks pass, Err(EnclaveError::CrossCheck) if any fail.
 pub fn validate_evm_request(req: &SignEvmRequest) -> Result<()> {
-    // 1. Consignment must be validated by Listener
+    // 1. Consignment validation check.
+    //    When rgb-validation feature is enabled AND raw consignment bytes are present,
+    //    in-enclave validation already ran in handle_sign_evm — the Listener's boolean
+    //    is not authoritative. When consignment is empty (legacy callers), we still
+    //    require the Listener's attestation.
     if !req.consignment_valid {
-        return Err(EnclaveError::CrossCheck(
-            "consignment not validated by Listener".into(),
-        ));
+        #[cfg(feature = "rgb-validation")]
+        {
+            if req.consignment.is_empty() {
+                return Err(EnclaveError::CrossCheck(
+                    "consignment not validated: no consignment bytes and Listener says invalid"
+                        .into(),
+                ));
+            }
+            // else: in-enclave validation already passed in handle_sign_evm, proceed
+        }
+        #[cfg(not(feature = "rgb-validation"))]
+        {
+            return Err(EnclaveError::CrossCheck(
+                "consignment not validated by Listener".into(),
+            ));
+        }
     }
 
     // 1b. If raw consignment bytes are present, verify hash integrity.

--- a/enclave/src/validation/mod.rs
+++ b/enclave/src/validation/mod.rs
@@ -1,2 +1,4 @@
 pub mod evm_crosscheck;
 pub mod psbt_crosscheck;
+#[cfg(feature = "rgb-validation")]
+pub mod rgb;

--- a/enclave/src/validation/rgb.rs
+++ b/enclave/src/validation/rgb.rs
@@ -62,17 +62,33 @@ impl RgbValidator {
         &self,
         consignment_bytes: &[u8],
     ) -> Result<ValidatedConsignment> {
+        let start = std::time::Instant::now();
+        let bytes_len = consignment_bytes.len();
+        tracing::info!(
+            bytes_len,
+            esplora_url = %self.esplora_url,
+            "starting RGB consignment validation"
+        );
+
         // 1. Deserialize the consignment from its file format (magic + strict-encoded).
         let transfer = Transfer::load(Cursor::new(consignment_bytes)).map_err(|e| {
+            tracing::warn!(bytes_len, "consignment deserialization failed: {e}");
             EnclaveError::CrossCheck(format!("consignment deserialization failed: {e}"))
         })?;
 
         let contract_id = transfer.contract_id().to_string();
-        tracing::debug!(%contract_id, "deserialized RGB transfer");
+        let bundles_count = transfer.bundles.len();
+        tracing::info!(
+            %contract_id,
+            bundles_count,
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            "deserialized RGB transfer"
+        );
 
         // 2. Create an Esplora-backed resolver.
         let builder = esplora_client::Builder::new(&self.esplora_url);
         let mut resolver = AnyResolver::esplora_blocking(builder).map_err(|e| {
+            tracing::error!(esplora_url = %self.esplora_url, "esplora resolver creation failed: {e}");
             EnclaveError::CrossCheck(format!("esplora resolver creation failed: {e}"))
         })?;
 
@@ -89,11 +105,21 @@ impl RgbValidator {
         };
 
         // 4. Run full RGB validation (makes blocking HTTP calls to Esplora).
+        tracing::debug!(%contract_id, "calling rgbstd validate (this may block on Esplora)");
         let _valid = transfer.validate(&resolver, &config).map_err(|e| {
+            tracing::warn!(
+                %contract_id,
+                elapsed_ms = start.elapsed().as_millis() as u64,
+                "RGB validation failed: {e}"
+            );
             EnclaveError::CrossCheck(format!("RGB consignment validation failed: {e}"))
         })?;
 
-        tracing::info!(%contract_id, "RGB consignment validated successfully");
+        tracing::info!(
+            %contract_id,
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            "RGB consignment validated successfully"
+        );
 
         Ok(ValidatedConsignment { contract_id })
     }

--- a/enclave/src/validation/rgb.rs
+++ b/enclave/src/validation/rgb.rs
@@ -1,0 +1,122 @@
+//! In-enclave RGB consignment validation using rgbstd + Esplora resolver.
+//!
+//! Validates raw consignment bytes by deserializing them into an RGB `Transfer`,
+//! connecting to an Esplora indexer to resolve witness transactions, and running
+//! the full rgbstd validation pipeline. This replaces trusting the Listener's
+//! `consignment_valid` boolean.
+
+use std::io::Cursor;
+
+use rgbstd::containers::{ConsignmentExt, FileContent, Transfer};
+use rgbstd::indexers::esplora_blocking::esplora_client;
+use rgbstd::indexers::AnyResolver;
+use rgbstd::validation::ValidationConfig;
+use rgbstd::ChainNet;
+
+use crate::error::{EnclaveError, Result};
+
+/// Data extracted from a successfully validated RGB consignment.
+#[derive(Debug)]
+pub struct ValidatedConsignment {
+    /// RGB contract identifier (e.g., "rgb:2TGhRyP3-...")
+    pub contract_id: String,
+    // TODO: extract rgb_amount from state transitions in a future PR.
+    // For now, rely on Listener's rgb_amount + existing calldata cross-checks.
+}
+
+/// Validates RGB consignments using rgbstd and an Esplora-backed resolver.
+#[derive(Debug)]
+pub struct RgbValidator {
+    esplora_url: String,
+    chain_net: ChainNet,
+}
+
+impl RgbValidator {
+    /// Create a new validator.
+    ///
+    /// - `esplora_url`: HTTP URL for the Esplora API (e.g., `http://127.0.0.1:3443`
+    ///   when using the vsock forwarder, or a direct URL in dev mode).
+    /// - `bitcoin_network`: One of "bitcoin", "testnet", "signet", "regtest".
+    pub fn new(esplora_url: String, bitcoin_network: &str) -> Result<Self> {
+        let chain_net = match bitcoin_network {
+            "bitcoin" | "mainnet" => ChainNet::BitcoinMainnet,
+            "testnet" | "testnet3" => ChainNet::BitcoinTestnet3,
+            "signet" => ChainNet::BitcoinSignet,
+            "regtest" => ChainNet::BitcoinRegtest,
+            other => {
+                return Err(EnclaveError::Internal(format!(
+                    "unknown bitcoin network: {other}"
+                )))
+            }
+        };
+        tracing::info!(%esplora_url, %bitcoin_network, "RGB validator configured");
+        Ok(Self {
+            esplora_url,
+            chain_net,
+        })
+    }
+
+    /// Validate raw consignment bytes. Returns extracted data on success,
+    /// or a `CrossCheck` error if validation fails.
+    pub fn validate_consignment(
+        &self,
+        consignment_bytes: &[u8],
+    ) -> Result<ValidatedConsignment> {
+        // 1. Deserialize the consignment from its file format (magic + strict-encoded).
+        let transfer = Transfer::load(Cursor::new(consignment_bytes)).map_err(|e| {
+            EnclaveError::CrossCheck(format!("consignment deserialization failed: {e}"))
+        })?;
+
+        let contract_id = transfer.contract_id().to_string();
+        tracing::debug!(%contract_id, "deserialized RGB transfer");
+
+        // 2. Create an Esplora-backed resolver.
+        let builder = esplora_client::Builder::new(&self.esplora_url);
+        let mut resolver = AnyResolver::esplora_blocking(builder).map_err(|e| {
+            EnclaveError::CrossCheck(format!("esplora resolver creation failed: {e}"))
+        })?;
+
+        // Register transactions bundled in the consignment so the resolver
+        // treats them as tentative witnesses (not yet mined).
+        resolver.add_consignment_txes(&transfer);
+
+        // 3. Build validation config.
+        let config = ValidationConfig {
+            chain_net: self.chain_net,
+            trusted_typesystem: transfer.types.clone(),
+            build_opouts_dag: true,
+            ..Default::default()
+        };
+
+        // 4. Run full RGB validation (makes blocking HTTP calls to Esplora).
+        let _valid = transfer.validate(&resolver, &config).map_err(|e| {
+            EnclaveError::CrossCheck(format!("RGB consignment validation failed: {e}"))
+        })?;
+
+        tracing::info!(%contract_id, "RGB consignment validated successfully");
+
+        Ok(ValidatedConsignment { contract_id })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_invalid_bytes() {
+        let validator =
+            RgbValidator::new("http://localhost:1".to_string(), "regtest").unwrap();
+        let err = validator.validate_consignment(b"not-a-consignment").unwrap_err();
+        assert!(
+            err.to_string().contains("deserialization failed"),
+            "expected deserialization error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_network() {
+        let err = RgbValidator::new("http://localhost:1".to_string(), "foonet").unwrap_err();
+        assert!(err.to_string().contains("unknown bitcoin network"));
+    }
+}

--- a/enclave/src/validation/rgb.rs
+++ b/enclave/src/validation/rgb.rs
@@ -58,10 +58,7 @@ impl RgbValidator {
 
     /// Validate raw consignment bytes. Returns extracted data on success,
     /// or a `CrossCheck` error if validation fails.
-    pub fn validate_consignment(
-        &self,
-        consignment_bytes: &[u8],
-    ) -> Result<ValidatedConsignment> {
+    pub fn validate_consignment(&self, consignment_bytes: &[u8]) -> Result<ValidatedConsignment> {
         let start = std::time::Instant::now();
         let bytes_len = consignment_bytes.len();
         tracing::info!(
@@ -131,9 +128,10 @@ mod tests {
 
     #[test]
     fn rejects_invalid_bytes() {
-        let validator =
-            RgbValidator::new("http://localhost:1".to_string(), "regtest").unwrap();
-        let err = validator.validate_consignment(b"not-a-consignment").unwrap_err();
+        let validator = RgbValidator::new("http://localhost:1".to_string(), "regtest").unwrap();
+        let err = validator
+            .validate_consignment(b"not-a-consignment")
+            .unwrap_err();
         assert!(
             err.to_string().contains("deserialization failed"),
             "expected deserialization error, got: {err}"

--- a/enclave/src/vsock_forwarder.rs
+++ b/enclave/src/vsock_forwarder.rs
@@ -1,0 +1,66 @@
+//! TCP-to-vsock forwarder for reaching external services (e.g., Esplora) from
+//! inside a Nitro enclave. Listens on localhost TCP and forwards each connection
+//! to the parent instance via vsock, where `vsock-proxy` relays to the real endpoint.
+
+use std::io;
+use std::net::TcpListener;
+
+use vsock::VsockStream;
+
+const PARENT_CID: u32 = 3;
+
+/// Start a background forwarder thread that bridges `127.0.0.1:{local_port}`
+/// to vsock CID 3 (parent instance), port `vsock_port`.
+///
+/// The forwarder is fire-and-forget — it logs errors but never crashes the enclave.
+pub fn start_forwarder(local_port: u16, vsock_port: u32) -> io::Result<()> {
+    let listener = TcpListener::bind(format!("127.0.0.1:{local_port}"))?;
+    tracing::info!(local_port, vsock_port, "vsock forwarder started");
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let tcp = match stream {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!("forwarder accept error: {e}");
+                    continue;
+                }
+            };
+
+            let vsock = match VsockStream::connect_with_cid_port(PARENT_CID, vsock_port) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!("forwarder vsock connect failed: {e}");
+                    continue;
+                }
+            };
+
+            // Bidirectional copy: two threads per connection.
+            let mut tcp_r = tcp;
+            let mut vsock_w = match vsock.try_clone() {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!("forwarder vsock clone failed: {e}");
+                    continue;
+                }
+            };
+            let mut vsock_r = vsock;
+            let mut tcp_w = match tcp_r.try_clone() {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!("forwarder tcp clone failed: {e}");
+                    continue;
+                }
+            };
+
+            std::thread::spawn(move || {
+                let _ = io::copy(&mut tcp_r, &mut vsock_w);
+            });
+            std::thread::spawn(move || {
+                let _ = io::copy(&mut vsock_r, &mut tcp_w);
+            });
+        }
+    });
+
+    Ok(())
+}

--- a/enclave/src/vsock_forwarder.rs
+++ b/enclave/src/vsock_forwarder.rs
@@ -7,6 +7,7 @@ use std::net::TcpListener;
 
 use vsock::VsockStream;
 
+/// Parent instance CID in Nitro enclaves is always 3.
 const PARENT_CID: u32 = 3;
 
 /// Start a background forwarder thread that bridges `127.0.0.1:{local_port}`
@@ -15,22 +16,44 @@ const PARENT_CID: u32 = 3;
 /// The forwarder is fire-and-forget — it logs errors but never crashes the enclave.
 pub fn start_forwarder(local_port: u16, vsock_port: u32) -> io::Result<()> {
     let listener = TcpListener::bind(format!("127.0.0.1:{local_port}"))?;
-    tracing::info!(local_port, vsock_port, "vsock forwarder started");
+    tracing::info!(
+        local_port,
+        vsock_port,
+        parent_cid = PARENT_CID,
+        "vsock forwarder started: 127.0.0.1:{} -> vsock CID {}:{}",
+        local_port,
+        PARENT_CID,
+        vsock_port
+    );
 
     std::thread::spawn(move || {
         for stream in listener.incoming() {
             let tcp = match stream {
                 Ok(s) => s,
                 Err(e) => {
-                    tracing::warn!("forwarder accept error: {e}");
+                    tracing::warn!("forwarder: TCP accept error: {e}");
                     continue;
                 }
             };
 
+            tracing::debug!(
+                "forwarder: new connection, opening vsock to CID {}:{}",
+                PARENT_CID,
+                vsock_port
+            );
+
             let vsock = match VsockStream::connect_with_cid_port(PARENT_CID, vsock_port) {
-                Ok(s) => s,
+                Ok(s) => {
+                    tracing::debug!("forwarder: vsock connected to CID {}:{}", PARENT_CID, vsock_port);
+                    s
+                }
                 Err(e) => {
-                    tracing::warn!("forwarder vsock connect failed: {e}");
+                    tracing::error!(
+                        "forwarder: vsock connect to CID {}:{} failed: {e} \
+                         (is vsock-proxy running on the host?)",
+                        PARENT_CID,
+                        vsock_port
+                    );
                     continue;
                 }
             };
@@ -40,7 +63,7 @@ pub fn start_forwarder(local_port: u16, vsock_port: u32) -> io::Result<()> {
             let mut vsock_w = match vsock.try_clone() {
                 Ok(s) => s,
                 Err(e) => {
-                    tracing::warn!("forwarder vsock clone failed: {e}");
+                    tracing::warn!("forwarder: vsock clone failed: {e}");
                     continue;
                 }
             };
@@ -48,16 +71,22 @@ pub fn start_forwarder(local_port: u16, vsock_port: u32) -> io::Result<()> {
             let mut tcp_w = match tcp_r.try_clone() {
                 Ok(s) => s,
                 Err(e) => {
-                    tracing::warn!("forwarder tcp clone failed: {e}");
+                    tracing::warn!("forwarder: TCP clone failed: {e}");
                     continue;
                 }
             };
 
             std::thread::spawn(move || {
-                let _ = io::copy(&mut tcp_r, &mut vsock_w);
+                match io::copy(&mut tcp_r, &mut vsock_w) {
+                    Ok(bytes) => tracing::debug!("forwarder: tcp→vsock closed ({bytes} bytes)"),
+                    Err(e) => tracing::debug!("forwarder: tcp→vsock error: {e}"),
+                }
             });
             std::thread::spawn(move || {
-                let _ = io::copy(&mut vsock_r, &mut tcp_w);
+                match io::copy(&mut vsock_r, &mut tcp_w) {
+                    Ok(bytes) => tracing::debug!("forwarder: vsock→tcp closed ({bytes} bytes)"),
+                    Err(e) => tracing::debug!("forwarder: vsock→tcp error: {e}"),
+                }
             });
         }
     });

--- a/enclave/tests/common/mod.rs
+++ b/enclave/tests/common/mod.rs
@@ -5,7 +5,7 @@ use std::thread;
 use utexo_bridge_enclave::framing;
 use utexo_bridge_enclave::keys::EnclaveState;
 use utexo_bridge_enclave::proto::*;
-use utexo_bridge_enclave::server;
+use utexo_bridge_enclave::server::{self, ServerContext};
 
 /// Start a test server on a random TCP port. Returns the port number.
 /// The server runs in a background thread and handles connections until
@@ -13,12 +13,16 @@ use utexo_bridge_enclave::server;
 pub fn start_test_server() -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let port = listener.local_addr().unwrap().port();
-    let state = Arc::new(EnclaveState::new());
+    let ctx = Arc::new(ServerContext {
+        state: EnclaveState::new(),
+        #[cfg(feature = "rgb-validation")]
+        rgb_validator: None,
+    });
 
     thread::spawn(move || {
         for stream in listener.incoming() {
             match stream {
-                Ok(stream) => server::handle_connection(stream, &state),
+                Ok(stream) => server::handle_connection(stream, &ctx),
                 Err(e) => eprintln!("test server accept error: {}", e),
             }
         }

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -417,6 +417,106 @@ fn test_sign_psbt_rejects_amount_mismatch() {
 }
 
 // =============================================================================
+// Consignment hash integrity tests (wire protocol integration)
+// =============================================================================
+
+#[test]
+fn test_sign_evm_rejects_consignment_hash_mismatch() {
+    let port = common::start_test_server();
+
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+        })),
+    };
+    common::send_request(port, &init_req);
+
+    let mut req = valid_sign_evm_request(1000, 50);
+    req.consignment = b"some-consignment-bytes".to_vec();
+    req.consignment_hash = vec![0xDE; 32]; // wrong hash
+
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignEvm(req)),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    match &resp.response {
+        Some(Response::Error(e)) => {
+            assert_eq!(e.code, 3, "hash mismatch should be cross-check error (code 3)");
+            assert!(
+                e.message.contains("consignment hash mismatch"),
+                "error should mention hash mismatch: {}",
+                e.message
+            );
+        }
+        other => panic!("expected ErrorResponse for hash mismatch, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_sign_evm_rejects_consignment_without_hash() {
+    let port = common::start_test_server();
+
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+        })),
+    };
+    common::send_request(port, &init_req);
+
+    let mut req = valid_sign_evm_request(1000, 50);
+    req.consignment = b"some-consignment-bytes".to_vec();
+    req.consignment_hash = vec![]; // missing hash
+
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignEvm(req)),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    match &resp.response {
+        Some(Response::Error(e)) => {
+            assert_eq!(e.code, 3);
+            assert!(e.message.contains("consignment_hash is missing"));
+        }
+        other => panic!("expected ErrorResponse for missing hash, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_sign_evm_accepts_valid_consignment_hash() {
+    use sha3::{Digest, Keccak256};
+
+    let port = common::start_test_server();
+
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+        })),
+    };
+    common::send_request(port, &init_req);
+
+    let consignment = b"test-consignment-bytes";
+    let hash = Keccak256::digest(consignment);
+
+    let mut req = valid_sign_evm_request(1000, 50);
+    req.consignment = consignment.to_vec();
+    req.consignment_hash = hash.to_vec();
+
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignEvm(req)),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    // Should succeed (hash is valid, cross-checks pass in dev-mode)
+    match &resp.response {
+        Some(Response::EvmSignature(r)) => {
+            assert_eq!(r.signature.len(), 65);
+        }
+        other => panic!("expected EvmSignature, got {:?}", other),
+    }
+}
+
+// =============================================================================
 // Raw message signing tests
 // =============================================================================
 

--- a/parent/src/grpc_server.rs
+++ b/parent/src/grpc_server.rs
@@ -104,10 +104,20 @@ impl EnclaveService for ParentAdapterService {
 
         let flow = inner
             .flow
-            .ok_or_else(|| Status::invalid_argument("missing flow in EnclaveSignRequest"))?;
+            .ok_or_else(|| {
+                tracing::warn!("gRPC Sign called with no flow set");
+                Status::invalid_argument("missing flow in EnclaveSignRequest")
+            })?;
 
         let enclave_req = match flow {
             enclave_sign_request::Flow::Psbt(psbt_flow) => {
+                tracing::info!(
+                    psbt_len = psbt_flow.psbt.len(),
+                    has_tx_hash = !psbt_flow.validated_tx_hash.is_empty(),
+                    operation_idx = psbt_flow.operation_idx,
+                    evm_event_finalized = psbt_flow.evm_event_finalized,
+                    "gRPC Sign: PSBT flow"
+                );
                 // Translate PSBTSigningFlow → SignPsbtRequest.
                 // The Go Listener sends a subset of fields; we map what's available
                 // and set defaults for enriched fields the Go side doesn't send yet.
@@ -148,6 +158,15 @@ impl EnclaveService for ParentAdapterService {
                 }
             }
             enclave_sign_request::Flow::Evm(evm_flow) => {
+                tracing::info!(
+                    payload_len = evm_flow.sign_payload.len(),
+                    consignment_len = evm_flow.consignment.len(),
+                    has_consignment = !evm_flow.consignment.is_empty(),
+                    consignment_valid = evm_flow.consignment_valid,
+                    nonce = evm_flow.nonce,
+                    deadline = evm_flow.deadline,
+                    "gRPC Sign: EVM flow"
+                );
                 // Translate EVMSigningFlow → SignEvmRequest.
                 // Same story: map available fields, default the rest.
                 EnclaveRequest {
@@ -173,7 +192,9 @@ impl EnclaveService for ParentAdapterService {
             }
         };
 
+        let start = std::time::Instant::now();
         let resp = self.send_to_enclave(enclave_req).await?;
+        tracing::debug!(elapsed_ms = start.elapsed().as_millis() as u64, "enclave round-trip");
 
         match resp.response {
             Some(enclave_response::Response::SignedPsbt(r)) => {
@@ -202,6 +223,7 @@ impl EnclaveService for ParentAdapterService {
         &self,
         _request: Request<GetPublicKeysRequest>,
     ) -> Result<Response<GetPublicKeysResponse>, Status> {
+        tracing::info!("gRPC GetPublicKeys called");
         let enclave_req = EnclaveRequest {
             request: Some(enclave_request::Request::GetPublicKey(
                 enclave_proto::GetPublicKeyRequest {},

--- a/parent/tests/test_grpc_bridge.rs
+++ b/parent/tests/test_grpc_bridge.rs
@@ -1,0 +1,305 @@
+//! Integration tests for the gRPC bridge (Parent Adapter → Enclave).
+//!
+//! These tests start a mock enclave TCP server that speaks our wire protocol,
+//! then a real tonic gRPC server (Parent Adapter) pointing at it, and finally
+//! exercise the full path via a gRPC client.
+
+use std::net::TcpListener;
+
+use tonic::transport::Server;
+
+use utexo_bridge_parent::enclave_proto::{
+    self, enclave_request, enclave_response, EnclaveRequest, EnclaveResponse,
+};
+use utexo_bridge_parent::framing;
+use utexo_bridge_parent::grpc_proto::enclave_service_client::EnclaveServiceClient;
+use utexo_bridge_parent::grpc_proto::enclave_service_server::EnclaveServiceServer;
+use utexo_bridge_parent::grpc_proto::{
+    enclave_sign_request, enclave_sign_response, EnclaveSignRequest as GrpcSignRequest,
+    EvmSigningFlow, GetPublicKeysRequest as GrpcGetPublicKeysRequest, PsbtSigningFlow,
+};
+use utexo_bridge_parent::grpc_server::{EnclaveTarget, ParentAdapterService};
+
+/// Start a mock enclave TCP server that responds to specific request types.
+/// This mimics the real enclave wire protocol without depending on the enclave crate.
+fn start_mock_enclave() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let mut stream = match stream {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+
+            let req: EnclaveRequest = match framing::read_message(&mut stream) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+
+            let resp = match req.request {
+                Some(enclave_request::Request::GetPublicKey(_)) => EnclaveResponse {
+                    response: Some(enclave_response::Response::PublicKeys(
+                        enclave_proto::PublicKeysResponse {
+                            evm_address: vec![0xAA; 20],
+                            btc_compressed_pub: vec![0xBB; 33],
+                            btc_xpub: "xpub-test".into(),
+                        },
+                    )),
+                },
+                Some(enclave_request::Request::SignEvm(_)) => EnclaveResponse {
+                    response: Some(enclave_response::Response::EvmSignature(
+                        enclave_proto::EvmSignatureResponse {
+                            signature: vec![0xCC; 65],
+                        },
+                    )),
+                },
+                Some(enclave_request::Request::SignPsbt(_)) => EnclaveResponse {
+                    response: Some(enclave_response::Response::SignedPsbt(
+                        enclave_proto::SignedPsbtResponse {
+                            signed_psbt: vec![0xDD; 100],
+                            inputs_signed: 2,
+                        },
+                    )),
+                },
+                _ => EnclaveResponse {
+                    response: Some(enclave_response::Response::Error(
+                        enclave_proto::ErrorResponse {
+                            code: 1,
+                            message: "not implemented in mock".into(),
+                        },
+                    )),
+                },
+            };
+
+            let _ = framing::write_message(&mut stream, &resp);
+        }
+    });
+
+    port
+}
+
+async fn start_grpc_server(enclave_port: u16) -> u16 {
+    let grpc_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let grpc_addr = grpc_listener.local_addr().unwrap();
+    let grpc_port = grpc_addr.port();
+    drop(grpc_listener);
+
+    let service =
+        ParentAdapterService::new(EnclaveTarget::Tcp(format!("127.0.0.1:{enclave_port}")));
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(EnclaveServiceServer::new(service))
+            .serve(grpc_addr)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    grpc_port
+}
+
+// =========================================================================
+// Happy-path tests
+// =========================================================================
+
+#[tokio::test]
+async fn grpc_get_public_keys_roundtrip() {
+    let enclave_port = start_mock_enclave();
+    let grpc_port = start_grpc_server(enclave_port).await;
+
+    let mut client = EnclaveServiceClient::connect(format!("http://127.0.0.1:{grpc_port}"))
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_public_keys(GrpcGetPublicKeysRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(resp.public_keys.len(), 2);
+    assert_eq!(resp.public_keys[0].len(), 20, "EVM address");
+    assert_eq!(resp.public_keys[1].len(), 33, "BTC compressed pubkey");
+}
+
+#[tokio::test]
+async fn grpc_sign_evm_roundtrip() {
+    let enclave_port = start_mock_enclave();
+    let grpc_port = start_grpc_server(enclave_port).await;
+
+    let mut client = EnclaveServiceClient::connect(format!("http://127.0.0.1:{grpc_port}"))
+        .await
+        .unwrap();
+
+    let req = GrpcSignRequest {
+        flow: Some(enclave_sign_request::Flow::Evm(EvmSigningFlow {
+            sign_payload: vec![0xAB; 132],
+            consignment_hash: vec![],
+            consignment: vec![],
+            consignment_valid: true,
+            nonce: 1,
+            deadline: u64::MAX,
+        })),
+    };
+
+    let resp = client.sign(req).await.unwrap().into_inner();
+    match resp.result {
+        Some(enclave_sign_response::Result::EvmSignature(sig)) => {
+            assert_eq!(sig.len(), 65, "EVM signature must be 65 bytes");
+        }
+        other => panic!("expected EvmSignature, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn grpc_sign_psbt_roundtrip() {
+    let enclave_port = start_mock_enclave();
+    let grpc_port = start_grpc_server(enclave_port).await;
+
+    let mut client = EnclaveServiceClient::connect(format!("http://127.0.0.1:{grpc_port}"))
+        .await
+        .unwrap();
+
+    let req = GrpcSignRequest {
+        flow: Some(enclave_sign_request::Flow::Psbt(PsbtSigningFlow {
+            psbt: vec![0xFF; 32],
+            validated_tx_hash: "aa".repeat(32), // 32 bytes as hex
+            operation_idx: 5,
+            evm_event_finalized: true,
+        })),
+    };
+
+    let resp = client.sign(req).await.unwrap().into_inner();
+    match resp.result {
+        Some(enclave_sign_response::Result::SignedPsbt(psbt)) => {
+            assert!(!psbt.is_empty(), "signed PSBT should not be empty");
+        }
+        other => panic!("expected SignedPsbt, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn grpc_evm_passes_consignment_bytes_through() {
+    // Verify the Parent Adapter actually passes consignment + hash to the enclave.
+    // We use a custom mock that inspects the received request.
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let enclave_port = listener.local_addr().unwrap().port();
+
+    let (tx, rx) = std::sync::mpsc::channel::<enclave_proto::SignEvmRequest>();
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let mut stream = stream.unwrap();
+            let req: EnclaveRequest = framing::read_message(&mut stream).unwrap();
+
+            if let Some(enclave_request::Request::SignEvm(evm_req)) = req.request {
+                tx.send(evm_req).unwrap();
+                let resp = EnclaveResponse {
+                    response: Some(enclave_response::Response::EvmSignature(
+                        enclave_proto::EvmSignatureResponse {
+                            signature: vec![0xCC; 65],
+                        },
+                    )),
+                };
+                let _ = framing::write_message(&mut stream, &resp);
+            }
+        }
+    });
+
+    let grpc_port = start_grpc_server(enclave_port).await;
+    let mut client = EnclaveServiceClient::connect(format!("http://127.0.0.1:{grpc_port}"))
+        .await
+        .unwrap();
+
+    let consignment = b"test-consignment-payload".to_vec();
+    let hash = b"test-consignment-hash-32bytes!!!".to_vec();
+
+    let req = GrpcSignRequest {
+        flow: Some(enclave_sign_request::Flow::Evm(EvmSigningFlow {
+            sign_payload: vec![0xAB; 10],
+            consignment: consignment.clone(),
+            consignment_hash: hash.clone(),
+            consignment_valid: true,
+            nonce: 42,
+            deadline: 9999,
+        })),
+    };
+
+    client.sign(req).await.unwrap();
+
+    // Inspect what the mock enclave received
+    let received = rx.recv_timeout(std::time::Duration::from_secs(2)).unwrap();
+    assert_eq!(received.consignment, consignment, "consignment bytes must pass through");
+    assert_eq!(received.consignment_hash, hash, "consignment hash must pass through");
+    assert_eq!(received.call_data, vec![0xAB; 10], "call_data mapped from sign_payload");
+    assert_eq!(received.nonce, 42);
+    assert_eq!(received.deadline, 9999);
+    assert!(received.consignment_valid);
+}
+
+// =========================================================================
+// Error-path tests
+// =========================================================================
+
+#[tokio::test]
+async fn grpc_missing_flow_returns_invalid_argument() {
+    let enclave_port = start_mock_enclave();
+    let grpc_port = start_grpc_server(enclave_port).await;
+
+    let mut client = EnclaveServiceClient::connect(format!("http://127.0.0.1:{grpc_port}"))
+        .await
+        .unwrap();
+
+    let err = client.sign(GrpcSignRequest { flow: None }).await.unwrap_err();
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+}
+
+#[tokio::test]
+async fn grpc_invalid_tx_hash_hex_returns_invalid_argument() {
+    let enclave_port = start_mock_enclave();
+    let grpc_port = start_grpc_server(enclave_port).await;
+
+    let mut client = EnclaveServiceClient::connect(format!("http://127.0.0.1:{grpc_port}"))
+        .await
+        .unwrap();
+
+    let req = GrpcSignRequest {
+        flow: Some(enclave_sign_request::Flow::Psbt(PsbtSigningFlow {
+            psbt: vec![0xFF; 32],
+            validated_tx_hash: "not-hex!!!".to_string(),
+            operation_idx: 0,
+            evm_event_finalized: false,
+        })),
+    };
+
+    let err = client.sign(req).await.unwrap_err();
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    assert!(err.message().contains("not valid hex"));
+}
+
+#[tokio::test]
+async fn grpc_wrong_tx_hash_length_returns_invalid_argument() {
+    let enclave_port = start_mock_enclave();
+    let grpc_port = start_grpc_server(enclave_port).await;
+
+    let mut client = EnclaveServiceClient::connect(format!("http://127.0.0.1:{grpc_port}"))
+        .await
+        .unwrap();
+
+    // 16 bytes hex = valid hex but wrong length
+    let req = GrpcSignRequest {
+        flow: Some(enclave_sign_request::Flow::Psbt(PsbtSigningFlow {
+            psbt: vec![0xFF; 32],
+            validated_tx_hash: "aabbccdd00112233aabbccdd00112233".to_string(),
+            operation_idx: 0,
+            evm_event_finalized: false,
+        })),
+    };
+
+    let err = client.sign(req).await.unwrap_err();
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    assert!(err.message().contains("32 bytes"));
+}

--- a/parent/tests/test_grpc_bridge.rs
+++ b/parent/tests/test_grpc_bridge.rs
@@ -232,9 +232,19 @@ async fn grpc_evm_passes_consignment_bytes_through() {
 
     // Inspect what the mock enclave received
     let received = rx.recv_timeout(std::time::Duration::from_secs(2)).unwrap();
-    assert_eq!(received.consignment, consignment, "consignment bytes must pass through");
-    assert_eq!(received.consignment_hash, hash, "consignment hash must pass through");
-    assert_eq!(received.call_data, vec![0xAB; 10], "call_data mapped from sign_payload");
+    assert_eq!(
+        received.consignment, consignment,
+        "consignment bytes must pass through"
+    );
+    assert_eq!(
+        received.consignment_hash, hash,
+        "consignment hash must pass through"
+    );
+    assert_eq!(
+        received.call_data,
+        vec![0xAB; 10],
+        "call_data mapped from sign_payload"
+    );
     assert_eq!(received.nonce, 42);
     assert_eq!(received.deadline, 9999);
     assert!(received.consignment_valid);
@@ -253,7 +263,10 @@ async fn grpc_missing_flow_returns_invalid_argument() {
         .await
         .unwrap();
 
-    let err = client.sign(GrpcSignRequest { flow: None }).await.unwrap_err();
+    let err = client
+        .sign(GrpcSignRequest { flow: None })
+        .await
+        .unwrap_err();
     assert_eq!(err.code(), tonic::Code::InvalidArgument);
 }
 


### PR DESCRIPTION
## Summary

Adds full RGB consignment validation inside the Nitro enclave TEE, replacing trust of the Go Listener's `consignment_valid` boolean. The enclave now deserializes consignment bytes, connects to an Esplora indexer (via vsock-proxy in production), and runs rgbstd's validation pipeline before signing.

## Architecture

```
[Enclave]
  reqwest (blocking) → localhost:3443
      ↓ tcp-to-vsock forwarder
  vsock CID 3, port 8001
      ↓
[EC2 Host]
  vsock-proxy 8001 → Esplora API
```

In dev mode: reqwest talks directly to `ESPLORA_URL` (no vsock).

## New files

| File | What |
|------|------|
| `enclave/src/validation/rgb.rs` | `RgbValidator` — deserialize Transfer, create AnyResolver, call validate(), extract contract_id |
| `enclave/src/vsock_forwarder.rs` | TCP-to-vsock forwarder for Esplora access from inside Nitro enclave |

## Modified files

| File | What |
|------|------|
| `Cargo.toml` | `[patch.crates-io]` for rgb-consensus, rgb-ops, rgb-invoicing, rgb-strict-encoding (git master) |
| `enclave/Cargo.toml` | `rgb-ops` dep (optional), `rgb-validation` feature flag |
| `enclave/src/server.rs` | `ServerContext` replaces bare `EnclaveState`; RGB validation wired into `handle_sign_evm` |
| `enclave/src/validation/evm_crosscheck.rs` | Conditional Listener trust: when rgb-validation ran with consignment bytes, Listener's boolean is not authoritative |
| `enclave/src/main.rs` | Starts vsock forwarder, creates RgbValidator, builds ServerContext |
| `enclave/src/validation/mod.rs` | Registers `rgb` module behind feature flag |
| `enclave/src/lib.rs` | Registers `vsock_forwarder` module |
| `build/Dockerfile.enclave` | Enables `rgb-validation` feature in production build |
| `enclave/tests/common/mod.rs` | Updated for ServerContext |

## Feature flag: `rgb-validation`

- **Disabled** (default): zero behavior change, all existing code paths unchanged, no RGB deps compiled
- **Enabled**: full in-enclave validation, requires Esplora access

## Environment variables (when rgb-validation enabled)

| Variable | Default | Description |
|----------|---------|-------------|
| `ESPLORA_URL` | `http://127.0.0.1:3443` | Esplora API endpoint |
| `BITCOIN_NETWORK` | `bitcoin` | One of: bitcoin, testnet, signet, regtest |
| `ESPLORA_VSOCK_PORT` | `8001` | vsock port for the host's vsock-proxy |

## Host setup (production)

```bash
vsock-proxy 8001 <esplora-host> <esplora-port>
```

## Known limitations / follow-up work

- **rgb_amount not extracted from consignment** — extracting amounts from RGB state transitions is complex. Marked TODO. Existing calldata cross-checks still run as defense-in-depth.
- **Git master deps** — rgb-consensus, rgb-ops etc. point to git master. Should pin to specific commit hashes once stable.
- **E2E testing** — requires Esplora + real consignment. Unit tests cover deserialization errors and config validation. Full integration test deferred.

## Test plan

- [x] `cargo build -p utexo-bridge-enclave` — compiles without rgb-validation (no behavior change)
- [x] `cargo build -p utexo-bridge-enclave --features rgb-validation` — compiles with full RGB deps
- [x] `cargo test --workspace` — all 65 tests pass (without rgb-validation)
- [x] `cargo test -p utexo-bridge-enclave --features rgb-validation` — all 67 tests pass (2 new RGB validator tests)
- [ ] Manual E2E with Esplora + real consignment (future task)