### PR TITLE
feat: add BIP-39 mnemonic import for key initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Cryptographic signing service for the UTEXO RGB-EVM bridge, running inside an [A
 
 ### Key management
 
-- Generates a BIP-39 mnemonic from OS entropy, derives a 64-byte seed, stores it in `SecretBox` (zeroize-on-drop)
+- Generates a BIP-39 mnemonic from OS entropy (or imports a mnemonic phrase in test mode), derives a 64-byte seed, stores it in `SecretBox` (zeroize-on-drop)
 - EVM: derives `m/44'/60'/0'/0/0`, computes 20-byte address via `keccak256(uncompressed_pubkey[1..])[12..]`
 - BTC: derives `m/84'/0'/0'/0/0`, produces 33-byte compressed pubkey and BIP-32 xpub
 
@@ -80,7 +80,7 @@ Cryptographic signing service for the UTEXO RGB-EVM bridge, running inside an [A
 
 | Operation | Description |
 |-----------|-------------|
-| `InitializeKey` | Generate keys from OS entropy (or import raw seed in test mode) |
+| `InitializeKey` | Generate keys from OS entropy (or import raw seed / BIP-39 mnemonic in test mode) |
 | `GetPublicKey` | Retrieve EVM address, BTC compressed pubkey, and xpub |
 | `SignEvm` | EIP-712 typed data signing with cross-check validation |
 | `SignPsbt` | SegWit v0 P2WSH PSBT signing with cross-check validation |
@@ -149,8 +149,12 @@ RUST_LOG=debug cargo run -p utexo-bridge-parent
 Use the CLI tool directly:
 
 ```bash
-# Initialize keys
+# Initialize keys (generate new mnemonic)
 cargo run --bin utexo-bridge-parent-cli -- init
+
+# Initialize keys from a known mnemonic (requires allow-seed-import feature)
+cargo run --features allow-seed-import --bin utexo-bridge-parent-cli -- \
+  init-mnemonic "word1 word2 word3 ... word12"
 
 # Get public keys
 cargo run --bin utexo-bridge-parent-cli -- get-keys
@@ -264,7 +268,7 @@ cargo test -p utexo-bridge-parent
 |---------|-------------|
 | `vsock` | Enable vsock transport (production, Linux only) |
 | `rgb-validation` | In-enclave RGB consignment validation via rgbstd + Esplora |
-| `allow-seed-import` | Allow raw 64-byte seed import (testing only, never enable in production) |
+| `allow-seed-import` | Allow raw 64-byte seed or BIP-39 mnemonic import (testing only, never enable in production) |
 | `dev-mode` | Skip cross-check validation on signing requests (development only) |
 
 ## Protocol

--- a/enclave/src/keys.rs
+++ b/enclave/src/keys.rs
@@ -362,9 +362,8 @@ mod tests {
                 "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
             )
             .unwrap();
-        let result = state.initialize_from_mnemonic(
-            "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
-        );
+        let result =
+            state.initialize_from_mnemonic("zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong");
         assert!(result.is_err());
     }
 

--- a/enclave/src/keys.rs
+++ b/enclave/src/keys.rs
@@ -46,6 +46,14 @@ impl KeyManager {
         Ok((manager, mnemonic))
     }
 
+    /// Create a KeyManager from a BIP-39 mnemonic phrase string.
+    pub fn from_mnemonic(mnemonic_str: &str) -> Result<Self> {
+        let mnemonic = Mnemonic::from_str(mnemonic_str)
+            .map_err(|e| EnclaveError::InvalidKey(format!("invalid mnemonic: {}", e)))?;
+        let seed = mnemonic.to_seed("");
+        Self::from_seed(seed)
+    }
+
     /// Create a KeyManager from a raw 64-byte BIP-39 seed.
     ///
     /// CRITICAL: The seed is moved into SecretBox FIRST, before any derivation.
@@ -225,6 +233,20 @@ impl EnclaveState {
         Ok(mnemonic)
     }
 
+    /// Initialize from a BIP-39 mnemonic phrase (testing only, requires allow-seed-import feature).
+    pub fn initialize_from_mnemonic(&self, mnemonic_str: &str) -> Result<()> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|e| EnclaveError::Internal(format!("lock poisoned: {}", e)))?;
+        if guard.is_some() {
+            return Err(EnclaveError::AlreadyInitialized);
+        }
+        let manager = KeyManager::from_mnemonic(mnemonic_str)?;
+        *guard = Some(manager);
+        Ok(())
+    }
+
     /// Initialize from a raw 64-byte seed (testing only, requires allow-seed-import feature).
     pub fn initialize_from_seed(&self, seed: [u8; 64]) -> Result<()> {
         let mut guard = self
@@ -297,6 +319,53 @@ mod tests {
         assert_eq!(km1.evm_address(), km2.evm_address());
         assert_eq!(km1.btc_compressed_pubkey(), km2.btc_compressed_pubkey());
         assert_eq!(km1.btc_xpub().to_string(), km2.btc_xpub().to_string());
+    }
+
+    #[test]
+    fn from_mnemonic_deterministic() {
+        let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        let km1 = KeyManager::from_mnemonic(mnemonic).unwrap();
+        let km2 = KeyManager::from_mnemonic(mnemonic).unwrap();
+
+        assert_eq!(km1.evm_address(), km2.evm_address());
+        assert_eq!(km1.btc_compressed_pubkey(), km2.btc_compressed_pubkey());
+        assert_eq!(km1.btc_xpub().to_string(), km2.btc_xpub().to_string());
+    }
+
+    #[test]
+    fn from_mnemonic_matches_seed_derivation() {
+        let mnemonic_str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+        let mnemonic = Mnemonic::from_str(mnemonic_str).unwrap();
+        let seed = mnemonic.to_seed("");
+
+        let km_mnemonic = KeyManager::from_mnemonic(mnemonic_str).unwrap();
+        let km_seed = KeyManager::from_seed(seed).unwrap();
+
+        assert_eq!(km_mnemonic.evm_address(), km_seed.evm_address());
+        assert_eq!(
+            km_mnemonic.btc_compressed_pubkey(),
+            km_seed.btc_compressed_pubkey()
+        );
+    }
+
+    #[test]
+    fn from_mnemonic_invalid() {
+        let result = KeyManager::from_mnemonic("not a valid mnemonic");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn initialize_from_mnemonic_then_double_init_fails() {
+        let state = EnclaveState::new();
+        state
+            .initialize_from_mnemonic(
+                "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            )
+            .unwrap();
+        let result = state.initialize_from_mnemonic(
+            "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
+        );
+        assert!(result.is_err());
     }
 
     #[test]

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -38,7 +38,9 @@ fn process_connection(mut stream: impl Read + Write, ctx: &ServerContext) -> Res
 fn dispatch(request: EnclaveRequest, ctx: &ServerContext) -> EnclaveResponse {
     let result = match request.request {
         Some(Request::InitializeKey(req)) => {
-            let path = if req.seed.is_empty() {
+            let path = if !req.mnemonic.is_empty() {
+                "mnemonic-import"
+            } else if req.seed.is_empty() {
                 "entropy"
             } else {
                 "seed-import"
@@ -92,7 +94,20 @@ fn dispatch(request: EnclaveRequest, ctx: &ServerContext) -> EnclaveResponse {
 }
 
 fn handle_initialize(state: &EnclaveState, req: InitializeKeyRequest) -> Result<EnclaveResponse> {
-    if req.seed.is_empty() {
+    if !req.mnemonic.is_empty() {
+        // Testing path: import from BIP-39 mnemonic phrase
+        #[cfg(feature = "allow-seed-import")]
+        {
+            state.initialize_from_mnemonic(&req.mnemonic)?;
+            tracing::info!("key initialized from imported mnemonic");
+        }
+        #[cfg(not(feature = "allow-seed-import"))]
+        {
+            return Err(EnclaveError::InvalidRequest(
+                "mnemonic import not allowed without allow-seed-import feature".into(),
+            ));
+        }
+    } else if req.seed.is_empty() {
         // Production path: generate from OS entropy
         let mut entropy = [0u8; 32];
         getrandom::fill(&mut entropy)

--- a/enclave/tests/test_keygen.rs
+++ b/enclave/tests/test_keygen.rs
@@ -12,6 +12,7 @@ fn initialize_and_get_keys() {
     let req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: vec![],
+            mnemonic: String::new(),
         })),
     };
     let resp = common::send_request(port, &req);
@@ -61,6 +62,7 @@ fn double_initialize_returns_error() {
     let req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: vec![],
+            mnemonic: String::new(),
         })),
     };
 
@@ -112,6 +114,7 @@ fn deterministic_seed_import() {
     let req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: seed.to_vec(),
+            mnemonic: String::new(),
         })),
     };
     let resp1 = common::send_request(port1, &req);

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -444,9 +444,9 @@ fn test_sign_vanilla_psbt_skips_evm_checks() {
     // but should pass in vanilla mode.
     let sign_req = EnclaveRequest {
         request: Some(Request::SignPsbt(SignPsbtRequest {
-            evm_tx_hash: vec![],     // empty = vanilla mode
+            evm_tx_hash: vec![], // empty = vanilla mode
             operation_idx: 0,
-            evm_event_valid: false,  // would fail in bridge mode
+            evm_event_valid: false, // would fail in bridge mode
             evm_event_finalized: false,
             evm_token: vec![],
             evm_amount: 0,

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -143,6 +143,7 @@ fn test_sign_evm_roundtrip() {
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: vec![],
+            mnemonic: String::new(),
         })),
     };
     let init_resp = common::send_request(port, &init_req);
@@ -190,6 +191,7 @@ fn test_sign_evm_rejects_invalid_consignment() {
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: vec![],
+            mnemonic: String::new(),
         })),
     };
     common::send_request(port, &init_req);
@@ -218,6 +220,7 @@ fn test_sign_evm_rejects_amount_mismatch() {
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: vec![],
+            mnemonic: String::new(),
         })),
     };
     common::send_request(port, &init_req);
@@ -246,6 +249,7 @@ fn test_sign_evm_rejects_calldata_extraction_mismatch() {
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: vec![],
+            mnemonic: String::new(),
         })),
     };
     common::send_request(port, &init_req);
@@ -282,6 +286,7 @@ fn test_sign_psbt_roundtrip() {
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: seed.to_vec(),
+            mnemonic: String::new(),
         })),
     };
     let init_resp = common::send_request(port, &init_req);
@@ -349,6 +354,7 @@ fn test_sign_psbt_rejects_unfinalized() {
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: vec![],
+            mnemonic: String::new(),
         })),
     };
     common::send_request(port, &init_req);
@@ -386,6 +392,7 @@ fn test_sign_psbt_rejects_amount_mismatch() {
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: vec![],
+            mnemonic: String::new(),
         })),
     };
     common::send_request(port, &init_req);
@@ -427,6 +434,7 @@ fn test_sign_vanilla_psbt_skips_evm_checks() {
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: vec![],
+            mnemonic: String::new(),
         })),
     };
     common::send_request(port, &init_req);
@@ -481,6 +489,7 @@ fn test_sign_evm_rejects_consignment_hash_mismatch() {
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: vec![],
+            mnemonic: String::new(),
         })),
     };
     common::send_request(port, &init_req);
@@ -517,6 +526,7 @@ fn test_sign_evm_rejects_consignment_without_hash() {
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: vec![],
+            mnemonic: String::new(),
         })),
     };
     common::send_request(port, &init_req);
@@ -548,6 +558,7 @@ fn test_sign_evm_accepts_valid_consignment_hash() {
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: vec![],
+            mnemonic: String::new(),
         })),
     };
     common::send_request(port, &init_req);
@@ -584,6 +595,7 @@ fn test_sign_raw_message_roundtrip() {
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: vec![],
+            mnemonic: String::new(),
         })),
     };
     let init_resp = common::send_request(port, &init_req);
@@ -631,6 +643,7 @@ fn test_sign_raw_message_empty() {
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: vec![],
+            mnemonic: String::new(),
         })),
     };
     common::send_request(port, &init_req);
@@ -655,6 +668,7 @@ fn test_sign_raw_message_deterministic() {
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: vec![],
+            mnemonic: String::new(),
         })),
     };
     common::send_request(port, &init_req);
@@ -697,6 +711,7 @@ fn test_sign_raw_message_different_messages_differ() {
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: vec![],
+            mnemonic: String::new(),
         })),
     };
     common::send_request(port, &init_req);
@@ -739,6 +754,7 @@ fn test_sign_raw_message_recoverable() {
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
             seed: seed.to_vec(),
+            mnemonic: String::new(),
         })),
     };
     let init_resp = common::send_request(port, &init_req);

--- a/parent/src/bin/cli.rs
+++ b/parent/src/bin/cli.rs
@@ -32,6 +32,11 @@ enum Command {
         /// 128 hex characters = 64 bytes
         hex: String,
     },
+    /// Initialize from a BIP-39 mnemonic phrase (testing only)
+    InitMnemonic {
+        /// BIP-39 mnemonic words (e.g. "word1 word2 ... word12")
+        words: String,
+    },
     /// Get public keys from the enclave
     GetKeys,
     /// Sign an EVM transaction (EIP-712 typed data)
@@ -146,12 +151,22 @@ fn run_interactive(client: &EnclaveClient) {
                     Err(e) => eprintln!("Invalid hex: {}", e),
                 }
             }
+            "init-mnemonic" => {
+                if parts.len() < 2 {
+                    eprintln!("Usage: init-mnemonic <word1 word2 ... word12>");
+                    continue;
+                }
+                match client.initialize_keys_mnemonic(parts[1]) {
+                    Ok(r) => print_init_response(&r),
+                    Err(e) => eprintln!("Error: {}", e),
+                }
+            }
             "get-keys" => match client.get_public_keys() {
                 Ok(r) => print_keys_response(&r),
                 Err(e) => eprintln!("Error: {}", e),
             },
             "help" => {
-                println!("Commands: init, init-seed <hex>, get-keys, help, quit, exit");
+                println!("Commands: init, init-seed <hex>, init-mnemonic <words>, get-keys, help, quit, exit");
             }
             "quit" | "exit" => break,
             "" => {}
@@ -186,6 +201,13 @@ fn main() {
             },
             Err(e) => {
                 eprintln!("Invalid hex: {}", e);
+                process::exit(1);
+            }
+        },
+        Command::InitMnemonic { words } => match client.initialize_keys_mnemonic(&words) {
+            Ok(r) => print_init_response(&r),
+            Err(e) => {
+                eprintln!("Error: {}", e);
                 process::exit(1);
             }
         },

--- a/parent/src/client.rs
+++ b/parent/src/client.rs
@@ -39,10 +39,23 @@ impl EnclaveClient {
     }
 
     pub fn initialize_keys(&self, seed: Option<Vec<u8>>) -> Result<InitializeKeyResponse> {
+        self.initialize_keys_inner(seed, None)
+    }
+
+    pub fn initialize_keys_mnemonic(&self, mnemonic: &str) -> Result<InitializeKeyResponse> {
+        self.initialize_keys_inner(None, Some(mnemonic.to_string()))
+    }
+
+    fn initialize_keys_inner(
+        &self,
+        seed: Option<Vec<u8>>,
+        mnemonic: Option<String>,
+    ) -> Result<InitializeKeyResponse> {
         let req = EnclaveRequest {
             request: Some(enclave_request::Request::InitializeKey(
                 InitializeKeyRequest {
                     seed: seed.unwrap_or_default(),
+                    mnemonic: mnemonic.unwrap_or_default(),
                 },
             )),
         };

--- a/proto/enclave.proto
+++ b/proto/enclave.proto
@@ -39,6 +39,9 @@ message InitializeKeyRequest {
   // Empty = generate new mnemonic from OS entropy (production path).
   // Non-empty = import raw 64-byte seed (requires `allow-seed-import` feature, testing only).
   bytes seed = 1;
+  // BIP-39 mnemonic phrase (requires `allow-seed-import` feature, testing only).
+  // If non-empty, takes precedence over seed.
+  string mnemonic = 2;
 }
 
 message InitializeKeyResponse {


### PR DESCRIPTION
## Summary

- Add `string mnemonic` field to `InitializeKeyRequest` proto, enabling initialization from a BIP-39 mnemonic phrase
- Add `init-mnemonic` CLI subcommand and interactive command for deterministic key setup
- Mnemonic takes precedence over raw seed when both are provided
- Gated behind existing `allow-seed-import` feature flag (testing only)

This unblocks multisig testing — cosigners can now initialize the enclave with a known mnemonic to verify derived keys match the expected multisig descriptor.

## Files changed

- `proto/enclave.proto` — new `string mnemonic = 2` field
- `enclave/src/keys.rs` — `KeyManager::from_mnemonic()`, `EnclaveState::initialize_from_mnemonic()`, 4 new tests
- `enclave/src/server.rs` — mnemonic dispatch branch in `handle_initialize`
- `parent/src/client.rs` — `initialize_keys_mnemonic()` method
- `parent/src/bin/cli.rs` — `InitMnemonic` subcommand + interactive command
- `README.md` — updated CLI examples, feature flag docs

## Test plan

- [x] `cargo test --all --features allow-seed-import` — all 86 tests pass
- [x] Deterministic derivation from known mnemonic matches seed derivation
- [x] Invalid mnemonic rejected
- [x] Double initialization after mnemonic import fails