### PR TITLE
feat: add taproot Schnorr PSBT signing for multi_a script-path spend

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ Cryptographic signing service for the UTEXO RGB-EVM bridge, running inside an [A
 ### Signing
 
 - **EVM (EIP-712)** — Signs typed data for the MultisigProxy contract (fundsOut). Builds EIP-712 domain from chain_id + proxy_contract, computes struct hash from calldata/nonce/deadline, signs with recoverable ECDSA (65 bytes: r+s+v).
-- **PSBT (SegWit v0 P2WSH)** — Signs matching inputs in a partially signed Bitcoin transaction. Matches inputs by BIP-32 derivation path or witness script pubkey match.
+- **PSBT (SegWit v0 P2WSH + Taproot)** — Signs matching inputs in a partially signed Bitcoin transaction. Auto-detects input type:
+  - **Taproot script-path** (BIP-341/BIP-340): Matches via `tap_key_origins` fingerprint, derives child keys per-input, signs with Schnorr into `tap_script_sigs`. Supports `multi_a()` tapscripts.
+  - **SegWit v0 P2WSH** (legacy): Matches by BIP-32 derivation path or witness script pubkey, signs with ECDSA into `partial_sigs`.
 - **Raw message** — Signs arbitrary bytes (keccak256-hashed) for fundsIn authorization (1-of-n).
 
 ### Validation (before signing)
@@ -87,7 +89,7 @@ Cryptographic signing service for the UTEXO RGB-EVM bridge, running inside an [A
 | `InitializeKey` | Generate keys from OS entropy (or import raw seed / BIP-39 mnemonic in test mode) |
 | `GetPublicKey` | Retrieve EVM address, BTC pubkeys, master fingerprint, and BIP-86 account xpubs (vanilla + colored) |
 | `SignEvm` | EIP-712 typed data signing with cross-check validation |
-| `SignPsbt` | SegWit v0 P2WSH PSBT signing with cross-check validation |
+| `SignPsbt` | Taproot (Schnorr) + SegWit v0 P2WSH (ECDSA) PSBT signing with cross-check validation |
 | `SignRawMessage` | Keccak256-hash-then-sign for fundsIn authorization |
 | `ProxyFederation` | Federation signature proxy (stub, not yet wired) |
 
@@ -257,11 +259,11 @@ cargo test -p utexo-bridge-enclave --features allow-seed-import
 cargo test -p utexo-bridge-parent
 ```
 
-### Test coverage (92 tests)
+### Test coverage (96 tests)
 
 | Category | Count | What it covers |
 |----------|-------|----------------|
-| Enclave unit tests | 58 | Key derivation (BIP-84 + BIP-86), mnemonic import, master fingerprint, framing, EIP-712 digest, cross-checks, consignment hash integrity, RGB deserialization |
+| Enclave unit tests | 62 | Key derivation (BIP-84 + BIP-86), mnemonic import, master fingerprint, taproot Schnorr signing, framing, EIP-712 digest, cross-checks, consignment hash integrity, RGB deserialization |
 | Enclave integration tests | 20 | Full wire-protocol: keygen, signing roundtrips, cross-check rejections, consignment hash via real TCP |
 | gRPC bridge tests | 7 | Full gRPC → Parent Adapter → mock enclave roundtrips, error paths, consignment passthrough verification |
 | RGB validator unit tests | 2 | Bad bytes rejection, unknown network rejection |

--- a/enclave/src/keys.rs
+++ b/enclave/src/keys.rs
@@ -282,11 +282,8 @@ impl KeyManager {
         let mut signed_count = 0usize;
 
         // === Taproot signing (BIP-86 / BIP-340 Schnorr) ===
-        let taproot_jobs = crate::signing::taproot::find_taproot_sign_jobs(
-            &psbt,
-            &self.master_fingerprint,
-            self,
-        );
+        let taproot_jobs =
+            crate::signing::taproot::find_taproot_sign_jobs(&psbt, &self.master_fingerprint, self);
         if !taproot_jobs.is_empty() {
             signed_count +=
                 crate::signing::taproot::sign_taproot_inputs(&mut psbt, self, &taproot_jobs)?;
@@ -839,8 +836,7 @@ mod tests {
         use bitcoin::blockdata::script::Builder as ScriptBuilder;
         use bitcoin::taproot::{LeafVersion, TapLeafHash, TaprootBuilder};
         use bitcoin::{
-            Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid,
-            XOnlyPublicKey,
+            Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, XOnlyPublicKey,
         };
         use std::collections::BTreeMap;
 
@@ -850,7 +846,10 @@ mod tests {
         let our_secret = km
             .derive_btc_child(
                 AccountType::Vanilla,
-                &[ChildNumber::Normal { index: 0 }, ChildNumber::Normal { index: 0 }],
+                &[
+                    ChildNumber::Normal { index: 0 },
+                    ChildNumber::Normal { index: 0 },
+                ],
             )
             .unwrap();
         let our_keypair = bitcoin::secp256k1::Keypair::from_secret_key(&secp, &our_secret);
@@ -885,9 +884,9 @@ mod tests {
 
         // Use an unspendable internal key (NUMS point)
         let internal_key = XOnlyPublicKey::from_slice(&[
-            0x50, 0x92, 0x9b, 0x74, 0xc1, 0xa0, 0x49, 0x54, 0xb7, 0x8b, 0x4b, 0x60, 0x35,
-            0xe9, 0x7a, 0x5e, 0x07, 0x8a, 0x5a, 0x0f, 0x28, 0xec, 0x96, 0xd5, 0x47, 0xbf,
-            0xee, 0x9a, 0xce, 0x80, 0x3a, 0xc0,
+            0x50, 0x92, 0x9b, 0x74, 0xc1, 0xa0, 0x49, 0x54, 0xb7, 0x8b, 0x4b, 0x60, 0x35, 0xe9,
+            0x7a, 0x5e, 0x07, 0x8a, 0x5a, 0x0f, 0x28, 0xec, 0x96, 0xd5, 0x47, 0xbf, 0xee, 0x9a,
+            0xce, 0x80, 0x3a, 0xc0,
         ])
         .unwrap();
 
@@ -913,9 +912,7 @@ mod tests {
             }],
             output: vec![TxOut {
                 value: Amount::from_sat(50_000),
-                script_pubkey: ScriptBuf::new_p2tr_tweaked(
-                    taproot_spend_info.output_key(),
-                ),
+                script_pubkey: ScriptBuf::new_p2tr_tweaked(taproot_spend_info.output_key()),
             }],
         };
 
@@ -1024,8 +1021,7 @@ mod tests {
             )
             .unwrap();
 
-        let msg =
-            bitcoin::secp256k1::Message::from_digest(*sighash.as_byte_array());
+        let msg = bitcoin::secp256k1::Message::from_digest(*sighash.as_byte_array());
         assert!(secp.verify_schnorr(schnorr_sig, &msg, xonly_pk).is_ok());
     }
 }

--- a/enclave/src/keys.rs
+++ b/enclave/src/keys.rs
@@ -270,27 +270,41 @@ impl KeyManager {
         Ok(result)
     }
 
-    /// Sign PSBT inputs matching our BTC key (SegWit v0 P2WSH multisig).
+    /// Sign PSBT inputs matching our keys.
+    /// Auto-detects taproot (Schnorr, BIP-340) vs SegWit v0 P2WSH (ECDSA) per input.
     /// Returns the modified PSBT bytes and count of inputs signed.
     pub fn sign_psbt(&self, psbt_bytes: &[u8]) -> Result<(Vec<u8>, usize)> {
         let secp = Secp256k1::new();
-        let secret_key = SecretKey::from_slice(self.btc_secret.expose_secret())
-            .map_err(|e| EnclaveError::Signing(format!("btc key: {e}")))?;
-        let our_pubkey = secret_key.public_key(&secp);
 
         let mut psbt = Psbt::deserialize(psbt_bytes)
             .map_err(|e| EnclaveError::Signing(format!("psbt deserialize: {e}")))?;
 
+        let mut signed_count = 0usize;
+
+        // === Taproot signing (BIP-86 / BIP-340 Schnorr) ===
+        let taproot_jobs = crate::signing::taproot::find_taproot_sign_jobs(
+            &psbt,
+            &self.master_fingerprint,
+            self,
+        );
+        if !taproot_jobs.is_empty() {
+            signed_count +=
+                crate::signing::taproot::sign_taproot_inputs(&mut psbt, self, &taproot_jobs)?;
+        }
+
+        // === Legacy SegWit v0 P2WSH signing (ECDSA) ===
+        let secret_key = SecretKey::from_slice(self.btc_secret.expose_secret())
+            .map_err(|e| EnclaveError::Signing(format!("btc key: {e}")))?;
+        let our_pubkey = secret_key.public_key(&secp);
+
         let unsigned_tx = psbt.unsigned_tx.clone();
         let mut sighash_cache = SighashCache::new(&unsigned_tx);
-        let mut signed_count = 0usize;
 
         for i in 0..psbt.inputs.len() {
             if !crate::signing::psbt::should_sign_segwit_input(&psbt, i, &our_pubkey) {
                 continue;
             }
 
-            // SegWit v0 P2WSH: need witness_utxo (for value) and witness_script
             let witness_utxo = psbt.inputs[i].witness_utxo.as_ref().ok_or_else(|| {
                 EnclaveError::Signing(format!("missing witness_utxo for input {i}"))
             })?;
@@ -298,7 +312,6 @@ impl KeyManager {
                 EnclaveError::Signing(format!("missing witness_script for input {i}"))
             })?;
 
-            // BIP-143 sighash for SegWit v0
             let sighash = sighash_cache
                 .p2wsh_signature_hash(i, witness_script, witness_utxo.value, EcdsaSighashType::All)
                 .map_err(|e| EnclaveError::Signing(format!("sighash: {e}")))?;
@@ -306,7 +319,6 @@ impl KeyManager {
             let msg = Message::from_digest(sighash.to_byte_array());
             let sig = secp.sign_ecdsa(&msg, &secret_key);
 
-            // Insert partial signature into PSBT
             let bitcoin_sig = bitcoin::ecdsa::Signature {
                 signature: sig,
                 sighash_type: EcdsaSighashType::All,
@@ -817,5 +829,203 @@ mod tests {
 
         let (_, count) = km.sign_psbt(&psbt_bytes).unwrap();
         assert_eq!(count, 0);
+    }
+
+    /// Build a taproot multi_a(2, pk1, pk2, pk3) PSBT for testing.
+    /// The signer's key is derived at m/86'/1'/0'/0/0 (vanilla testnet).
+    fn build_test_taproot_psbt(km: &KeyManager) -> Vec<u8> {
+        use bitcoin::bip32::ChildNumber;
+        use bitcoin::blockdata::opcodes::all::*;
+        use bitcoin::blockdata::script::Builder as ScriptBuilder;
+        use bitcoin::taproot::{LeafVersion, TapLeafHash, TaprootBuilder};
+        use bitcoin::{
+            Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid,
+            XOnlyPublicKey,
+        };
+        use std::collections::BTreeMap;
+
+        let secp = Secp256k1::new();
+
+        // Our key: derive child at m/86'/1'/0'/0/0
+        let our_secret = km
+            .derive_btc_child(
+                AccountType::Vanilla,
+                &[ChildNumber::Normal { index: 0 }, ChildNumber::Normal { index: 0 }],
+            )
+            .unwrap();
+        let our_keypair = bitcoin::secp256k1::Keypair::from_secret_key(&secp, &our_secret);
+        let (our_xonly, _parity) = XOnlyPublicKey::from_keypair(&our_keypair);
+
+        // Two other cosigner keys
+        let sk2 = SecretKey::from_slice(&[0x02; 32]).unwrap();
+        let kp2 = bitcoin::secp256k1::Keypair::from_secret_key(&secp, &sk2);
+        let (xonly2, _) = XOnlyPublicKey::from_keypair(&kp2);
+
+        let sk3 = SecretKey::from_slice(&[0x03; 32]).unwrap();
+        let kp3 = bitcoin::secp256k1::Keypair::from_secret_key(&secp, &sk3);
+        let (xonly3, _) = XOnlyPublicKey::from_keypair(&kp3);
+
+        // Build multi_a(2, pk1, pk2, pk3) tapscript:
+        // pk1 OP_CHECKSIG pk2 OP_CHECKSIGADD pk3 OP_CHECKSIGADD 2 OP_NUMEQUAL
+        let mut keys = [our_xonly, xonly2, xonly3];
+        keys.sort();
+
+        let tap_script = ScriptBuilder::new()
+            .push_x_only_key(&keys[0])
+            .push_opcode(OP_CHECKSIG)
+            .push_x_only_key(&keys[1])
+            .push_opcode(OP_CHECKSIGADD)
+            .push_x_only_key(&keys[2])
+            .push_opcode(OP_CHECKSIGADD)
+            .push_int(2)
+            .push_opcode(OP_NUMEQUAL)
+            .into_script();
+
+        let leaf_hash = TapLeafHash::from_script(&tap_script, LeafVersion::TapScript);
+
+        // Use an unspendable internal key (NUMS point)
+        let internal_key = XOnlyPublicKey::from_slice(&[
+            0x50, 0x92, 0x9b, 0x74, 0xc1, 0xa0, 0x49, 0x54, 0xb7, 0x8b, 0x4b, 0x60, 0x35,
+            0xe9, 0x7a, 0x5e, 0x07, 0x8a, 0x5a, 0x0f, 0x28, 0xec, 0x96, 0xd5, 0x47, 0xbf,
+            0xee, 0x9a, 0xce, 0x80, 0x3a, 0xc0,
+        ])
+        .unwrap();
+
+        let taproot_builder = TaprootBuilder::new()
+            .add_leaf(0, tap_script.clone())
+            .unwrap();
+        let taproot_spend_info = taproot_builder.finalize(&secp, internal_key).unwrap();
+
+        let script_pubkey =
+            ScriptBuf::new_p2tr(&secp, internal_key, taproot_spend_info.merkle_root());
+
+        let unsigned_tx = Transaction {
+            version: bitcoin::transaction::Version(2),
+            lock_time: bitcoin::blockdata::locktime::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([0xAA; 32]),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: bitcoin::Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: ScriptBuf::new_p2tr_tweaked(
+                    taproot_spend_info.output_key(),
+                ),
+            }],
+        };
+
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+
+        // Set witness_utxo
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey,
+        });
+
+        // Set tap_internal_key
+        psbt.inputs[0].tap_internal_key = Some(internal_key);
+
+        // Set tap_scripts (control block → script)
+        let control_block = taproot_spend_info
+            .control_block(&(tap_script.clone(), LeafVersion::TapScript))
+            .unwrap();
+        psbt.inputs[0]
+            .tap_scripts
+            .insert(control_block, (tap_script, LeafVersion::TapScript));
+
+        // Set tap_key_origins for our key
+        let our_fingerprint = km.master_fingerprint().clone();
+        let our_derivation = DerivationPath::from(vec![
+            ChildNumber::from_hardened_idx(86).unwrap(),
+            ChildNumber::from_hardened_idx(1).unwrap(), // testnet
+            ChildNumber::from_hardened_idx(0).unwrap(),
+            ChildNumber::Normal { index: 0 },
+            ChildNumber::Normal { index: 0 },
+        ]);
+        psbt.inputs[0].tap_key_origins.insert(
+            our_xonly,
+            (vec![leaf_hash], (our_fingerprint, our_derivation)),
+        );
+
+        psbt.serialize()
+    }
+
+    #[test]
+    fn test_sign_taproot_psbt_one_input() {
+        let km = KeyManager::from_seed([0x42u8; 64], Network::Testnet).unwrap();
+        let psbt_bytes = build_test_taproot_psbt(&km);
+
+        let (signed_bytes, count) = km.sign_psbt(&psbt_bytes).unwrap();
+        assert_eq!(count, 1);
+
+        let signed_psbt = Psbt::deserialize(&signed_bytes).unwrap();
+        assert_eq!(signed_psbt.inputs[0].tap_script_sigs.len(), 1);
+    }
+
+    #[test]
+    fn test_sign_taproot_psbt_skip_already_signed() {
+        let km = KeyManager::from_seed([0x42u8; 64], Network::Testnet).unwrap();
+        let psbt_bytes = build_test_taproot_psbt(&km);
+
+        let (signed_bytes, count1) = km.sign_psbt(&psbt_bytes).unwrap();
+        assert_eq!(count1, 1);
+
+        // Sign the already-signed PSBT again — should skip
+        let (_, count2) = km.sign_psbt(&signed_bytes).unwrap();
+        assert_eq!(count2, 0);
+    }
+
+    #[test]
+    fn test_sign_taproot_psbt_no_matching_fingerprint() {
+        // Key with a different seed → different fingerprint → should not sign
+        let km_signer = KeyManager::from_seed([0x42u8; 64], Network::Testnet).unwrap();
+        let km_other = KeyManager::from_seed([0x99u8; 64], Network::Testnet).unwrap();
+
+        let psbt_bytes = build_test_taproot_psbt(&km_signer);
+
+        // km_other's fingerprint won't match the tap_key_origins
+        let (_, count) = km_other.sign_psbt(&psbt_bytes).unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_sign_taproot_psbt_schnorr_signature_valid() {
+        use bitcoin::secp256k1::schnorr;
+
+        let km = KeyManager::from_seed([0x42u8; 64], Network::Testnet).unwrap();
+        let psbt_bytes = build_test_taproot_psbt(&km);
+
+        let (signed_bytes, _) = km.sign_psbt(&psbt_bytes).unwrap();
+        let signed_psbt = Psbt::deserialize(&signed_bytes).unwrap();
+
+        // Extract the signature
+        let ((xonly_pk, _leaf_hash), tap_sig) =
+            signed_psbt.inputs[0].tap_script_sigs.iter().next().unwrap();
+
+        // Verify the Schnorr signature
+        let secp = Secp256k1::verification_only();
+        let schnorr_sig = &tap_sig.signature;
+
+        // Recompute the sighash
+        let prevouts = vec![signed_psbt.inputs[0].witness_utxo.clone().unwrap()];
+        let unsigned_tx = signed_psbt.unsigned_tx.clone();
+        let mut cache = bitcoin::sighash::SighashCache::new(&unsigned_tx);
+        let sighash = cache
+            .taproot_script_spend_signature_hash(
+                0,
+                &bitcoin::sighash::Prevouts::All(&prevouts),
+                *_leaf_hash,
+                bitcoin::sighash::TapSighashType::Default,
+            )
+            .unwrap();
+
+        let msg =
+            bitcoin::secp256k1::Message::from_digest(*sighash.as_byte_array());
+        assert!(secp.verify_schnorr(schnorr_sig, &msg, xonly_pk).is_ok());
     }
 }

--- a/enclave/src/signing/mod.rs
+++ b/enclave/src/signing/mod.rs
@@ -1,2 +1,3 @@
 pub mod evm;
 pub mod psbt;
+pub mod taproot;

--- a/enclave/src/signing/taproot.rs
+++ b/enclave/src/signing/taproot.rs
@@ -1,0 +1,134 @@
+use bitcoin::bip32::Fingerprint;
+use bitcoin::hashes::Hash;
+use bitcoin::psbt::Psbt;
+use bitcoin::secp256k1::{Keypair, Message, Secp256k1};
+use bitcoin::XOnlyPublicKey;
+use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
+use bitcoin::taproot::{self, TapLeafHash};
+use bitcoin::TxOut;
+
+use crate::error::{EnclaveError, Result};
+use crate::keys::{AccountType, KeyManager};
+
+/// Info about a single taproot signature we need to produce for one input.
+pub struct TaprootSignJob {
+    pub input_index: usize,
+    pub xonly_pubkey: XOnlyPublicKey,
+    pub leaf_hash: TapLeafHash,
+    pub account_type: AccountType,
+    pub child_path: Vec<bitcoin::bip32::ChildNumber>,
+}
+
+/// Scan all PSBT inputs for taproot inputs our key can sign.
+/// Returns a list of sign jobs.
+pub fn find_taproot_sign_jobs(
+    psbt: &Psbt,
+    master_fingerprint: &Fingerprint,
+    key_manager: &KeyManager,
+) -> Vec<TaprootSignJob> {
+    let mut jobs = Vec::new();
+
+    for (i, input) in psbt.inputs.iter().enumerate() {
+        // Iterate tap_key_origins looking for our fingerprint
+        for (xonly_pubkey, (leaf_hashes, (fingerprint, derivation_path))) in
+            &input.tap_key_origins
+        {
+            if fingerprint != master_fingerprint {
+                continue;
+            }
+
+            // Resolve account type and child path from the full derivation path
+            let resolved = key_manager.resolve_account_and_child_path(derivation_path);
+            let (account_type, child_path) = match resolved {
+                Some(r) => r,
+                None => continue, // Path doesn't match our BIP-86 accounts
+            };
+
+            // Sign for each leaf hash where our key participates
+            for leaf_hash in leaf_hashes {
+                // Skip if already signed for this (pubkey, leaf_hash) pair
+                if input
+                    .tap_script_sigs
+                    .contains_key(&(*xonly_pubkey, *leaf_hash))
+                {
+                    continue;
+                }
+
+                jobs.push(TaprootSignJob {
+                    input_index: i,
+                    xonly_pubkey: *xonly_pubkey,
+                    leaf_hash: *leaf_hash,
+                    account_type,
+                    child_path: child_path.clone(),
+                });
+            }
+        }
+    }
+
+    jobs
+}
+
+/// Sign taproot script-path inputs in the PSBT.
+/// Returns the number of signatures added.
+pub fn sign_taproot_inputs(
+    psbt: &mut Psbt,
+    key_manager: &KeyManager,
+    jobs: &[TaprootSignJob],
+) -> Result<usize> {
+    if jobs.is_empty() {
+        return Ok(0);
+    }
+
+    let secp = Secp256k1::new();
+
+    // BIP-341 requires ALL prevouts for taproot sighash computation
+    let prevouts: Vec<TxOut> = psbt
+        .inputs
+        .iter()
+        .map(|input| {
+            input
+                .witness_utxo
+                .clone()
+                .ok_or_else(|| EnclaveError::Signing("missing witness_utxo for taproot".into()))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let unsigned_tx = psbt.unsigned_tx.clone();
+    let mut sighash_cache = SighashCache::new(&unsigned_tx);
+
+    let mut signed_count = 0;
+
+    for job in jobs {
+        // Derive the child secret key for this input
+        let child_secret = key_manager.derive_btc_child(job.account_type, &job.child_path)?;
+
+        // Compute taproot script-path sighash
+        let sighash = sighash_cache
+            .taproot_script_spend_signature_hash(
+                job.input_index,
+                &Prevouts::All(&prevouts),
+                job.leaf_hash,
+                TapSighashType::Default,
+            )
+            .map_err(|e| EnclaveError::Signing(format!("taproot sighash: {e}")))?;
+
+        let msg = Message::from_digest(*sighash.as_byte_array());
+
+        // Create keypair for Schnorr signing (no tweak for script-path spend)
+        let keypair = Keypair::from_secret_key(&secp, &child_secret);
+        let schnorr_sig = secp.sign_schnorr_no_aux_rand(&msg, &keypair);
+
+        // Insert tap_script_sig with Default sighash (empty sighash byte)
+        let tap_sig = taproot::Signature {
+            signature: schnorr_sig,
+            sighash_type: TapSighashType::Default,
+        };
+        psbt.inputs[job.input_index]
+            .tap_script_sigs
+            .insert((job.xonly_pubkey, job.leaf_hash), tap_sig);
+
+        signed_count += 1;
+    }
+
+    Ok(signed_count)
+}

--- a/enclave/src/signing/taproot.rs
+++ b/enclave/src/signing/taproot.rs
@@ -2,10 +2,10 @@ use bitcoin::bip32::Fingerprint;
 use bitcoin::hashes::Hash;
 use bitcoin::psbt::Psbt;
 use bitcoin::secp256k1::{Keypair, Message, Secp256k1};
-use bitcoin::XOnlyPublicKey;
 use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
 use bitcoin::taproot::{self, TapLeafHash};
 use bitcoin::TxOut;
+use bitcoin::XOnlyPublicKey;
 
 use crate::error::{EnclaveError, Result};
 use crate::keys::{AccountType, KeyManager};
@@ -30,8 +30,7 @@ pub fn find_taproot_sign_jobs(
 
     for (i, input) in psbt.inputs.iter().enumerate() {
         // Iterate tap_key_origins looking for our fingerprint
-        for (xonly_pubkey, (leaf_hashes, (fingerprint, derivation_path))) in
-            &input.tap_key_origins
+        for (xonly_pubkey, (leaf_hashes, (fingerprint, derivation_path))) in &input.tap_key_origins
         {
             if fingerprint != master_fingerprint {
                 continue;


### PR DESCRIPTION
## Summary

Depends on #15

Add taproot script-path signing (BIP-341 / BIP-340) to the enclave, enabling it to sign PSBTs from the rgb-multisig-hub's `tr(..., multi_a(2,...))` descriptors.

`sign_psbt` now auto-detects input type:
- **Taproot inputs**: Matched via `tap_key_origins` fingerprint → derives child key from BIP-86 account xpriv → computes BIP-341 sighash (all prevouts) → signs with Schnorr → inserts into `tap_script_sigs`
- **SegWit v0 inputs**: Existing ECDSA path unchanged → inserts into `partial_sigs`

Both types can coexist in the same PSBT.

## New module: `enclave/src/signing/taproot.rs`

- `find_taproot_sign_jobs()` — scans PSBT inputs for matching fingerprint in `tap_key_origins`, resolves account type (vanilla/colored) and child path, skips already-signed entries
- `sign_taproot_inputs()` — derives child secret keys, computes BIP-341 taproot script-spend sighash, signs with Schnorr (no tweak for script-path), inserts `tap_script_sigs`

## Files changed

- `enclave/src/signing/taproot.rs` (new) — taproot signing logic
- `enclave/src/signing/mod.rs` — add `pub mod taproot`
- `enclave/src/keys.rs` — refactored `sign_psbt` to auto-detect + 4 new taproot tests
- `README.md` — updated signing docs, test counts

## Test plan

- [x] `cargo test --all --features allow-seed-import` — all 96 tests pass
- [x] `test_sign_taproot_psbt_one_input` — builds `multi_a(2, pk1, pk2, pk3)` tapscript PSBT, signs 1 input
- [x] `test_sign_taproot_psbt_skip_already_signed` — re-signing same PSBT produces 0 new signatures
- [x] `test_sign_taproot_psbt_no_matching_fingerprint` — different seed → 0 signatures
- [x] `test_sign_taproot_psbt_schnorr_signature_valid` — recomputes sighash, verifies Schnorr signature with `secp.verify_schnorr()`
- [x] Existing P2WSH tests still pass (backward compatible)