### PR TITLE
feat: align gRPC proto with federated-signer-node listener-enclave.proto

### DIFF
--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -14,5 +14,5 @@ pub mod proto {
 }
 
 pub mod enriched {
-    include!(concat!(env!("OUT_DIR"), "/utexo_bridge.enriched.rs"));
+    include!(concat!(env!("OUT_DIR"), "/tricorn.enriched.rs"));
 }

--- a/parent/build.rs
+++ b/parent/build.rs
@@ -1,6 +1,7 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // gRPC service — generates tonic server trait + prost message types
-    tonic_build::compile_protos("../proto/parentadapter.proto")?;
+    // gRPC service — generates tonic server trait + prost message types.
+    // parentadapter.proto imports signer/signer.proto, so we include ../proto/ as root.
+    tonic_build::configure().compile_protos(&["../proto/parentadapter.proto"], &["../proto/"])?;
 
     // Enclave wire protocol — prost-only (no gRPC, just message types)
     prost_build::compile_protos(

--- a/parent/src/grpc_server.rs
+++ b/parent/src/grpc_server.rs
@@ -1,16 +1,18 @@
 use std::time::Duration;
 
+use prost::Message as ProstMessage;
 use tonic::{Request, Response, Status};
 
 use crate::enclave_proto::{
     self, enclave_request, enclave_response, EnclaveRequest, EnclaveResponse,
 };
+use crate::enriched;
 
 const ENCLAVE_TIMEOUT: Duration = Duration::from_secs(30);
 use crate::grpc_proto::enclave_service_server::EnclaveService;
 use crate::grpc_proto::{
-    enclave_sign_request, EnclaveSignRequest, EnclaveSignResponse, GetPublicKeysRequest,
-    GetPublicKeysResponse,
+    CloneRequest, CloneResponse, DataType, InitializeRequest, InitializeResponse, PublicKeyRequest,
+    PublicKeyResponse, SignRequest, Signature,
 };
 
 /// Enclave connection target — either TCP address or vsock CID+port.
@@ -24,8 +26,8 @@ pub enum EnclaveTarget {
     },
 }
 
-/// gRPC server that translates parentadapter.proto RPCs into enclave.proto
-/// wire-protocol requests over TCP/vsock.
+/// gRPC server that translates the federated-signer-node's listener-enclave.proto
+/// RPCs into enclave.proto wire-protocol requests over TCP/vsock.
 #[derive(Clone)]
 pub struct ParentAdapterService {
     target: EnclaveTarget,
@@ -96,97 +98,93 @@ impl ParentAdapterService {
 
 #[tonic::async_trait]
 impl EnclaveService for ParentAdapterService {
-    async fn sign(
-        &self,
-        request: Request<EnclaveSignRequest>,
-    ) -> Result<Response<EnclaveSignResponse>, Status> {
+    /// Sign — dispatches based on data_type:
+    ///   TRANSACTION → deserialize EnrichedPsbtPayload → SignPsbtRequest
+    ///   SWAP        → deserialize EnrichedEvmPayload  → SignEvmRequest
+    async fn sign(&self, request: Request<SignRequest>) -> Result<Response<Signature>, Status> {
         let inner = request.into_inner();
 
-        let flow = inner.flow.ok_or_else(|| {
-            tracing::warn!("gRPC Sign called with no flow set");
-            Status::invalid_argument("missing flow in EnclaveSignRequest")
-        })?;
+        let data_type = DataType::try_from(inner.data_type).unwrap_or(DataType::Transaction);
 
-        let enclave_req = match flow {
-            enclave_sign_request::Flow::Psbt(psbt_flow) => {
-                tracing::info!(
-                    psbt_len = psbt_flow.psbt.len(),
-                    has_tx_hash = !psbt_flow.validated_tx_hash.is_empty(),
-                    operation_idx = psbt_flow.operation_idx,
-                    evm_event_finalized = psbt_flow.evm_event_finalized,
-                    "gRPC Sign: PSBT flow"
-                );
-                // Translate PSBTSigningFlow → SignPsbtRequest.
-                // The Go Listener sends a subset of fields; we map what's available
-                // and set defaults for enriched fields the Go side doesn't send yet.
-                let evm_tx_hash = if psbt_flow.validated_tx_hash.is_empty() {
-                    vec![]
-                } else {
-                    let decoded = hex::decode(&psbt_flow.validated_tx_hash).map_err(|e| {
-                        Status::invalid_argument(format!("validated_tx_hash is not valid hex: {e}"))
+        let enclave_req = match data_type {
+            DataType::Transaction => {
+                // Deserialize enriched PSBT payload from data bytes
+                let payload = enriched::EnrichedPsbtPayload::decode(inner.data.as_slice())
+                    .map_err(|e| {
+                        Status::invalid_argument(format!(
+                            "failed to decode EnrichedPsbtPayload: {e}"
+                        ))
                     })?;
-                    if decoded.len() != 32 {
-                        return Err(Status::invalid_argument(format!(
-                            "validated_tx_hash must be 32 bytes, got {}",
-                            decoded.len()
-                        )));
-                    }
-                    decoded
-                };
+
+                tracing::info!(
+                    psbt_len = payload.psbt_bytes.len(),
+                    has_tx_hash = !payload.evm_tx_hash.is_empty(),
+                    operation_idx = payload.operation_idx,
+                    "gRPC Sign: PSBT (data_type=TRANSACTION)"
+                );
 
                 EnclaveRequest {
                     request: Some(enclave_request::Request::SignPsbt(
                         enclave_proto::SignPsbtRequest {
-                            psbt_bytes: psbt_flow.psbt,
-                            evm_tx_hash,
-                            operation_idx: psbt_flow.operation_idx,
-                            evm_event_finalized: psbt_flow.evm_event_finalized,
-                            // Fields the Go Listener doesn't send yet — defaults.
-                            // The enclave will skip cross-checks in dev-mode,
-                            // or these will need to be populated once the Go proto evolves.
-                            evm_event_valid: psbt_flow.evm_event_finalized, // best approximation
-                            evm_token: vec![],
-                            evm_amount: 0,
-                            evm_recipient: vec![],
-                            evm_commission: 0,
-                            psbt_output_amount: 0,
-                            rgb_asset_id: String::new(),
+                            psbt_bytes: payload.psbt_bytes,
+                            evm_tx_hash: payload.evm_tx_hash,
+                            operation_idx: payload.operation_idx,
+                            evm_event_valid: payload.evm_event_valid,
+                            evm_event_finalized: payload.evm_event_finalized,
+                            evm_token: payload.evm_token,
+                            evm_amount: payload.evm_amount,
+                            evm_recipient: payload.evm_recipient,
+                            evm_commission: payload.evm_commission,
+                            psbt_output_amount: payload.psbt_output_amount,
+                            rgb_asset_id: payload.rgb_asset_id,
                         },
                     )),
                 }
             }
-            enclave_sign_request::Flow::Evm(evm_flow) => {
+            DataType::Swap => {
+                // Deserialize enriched EVM payload from data bytes
+                let payload =
+                    enriched::EnrichedEvmPayload::decode(inner.data.as_slice()).map_err(|e| {
+                        Status::invalid_argument(format!(
+                            "failed to decode EnrichedEvmPayload: {e}"
+                        ))
+                    })?;
+
                 tracing::info!(
-                    payload_len = evm_flow.sign_payload.len(),
-                    consignment_len = evm_flow.consignment.len(),
-                    has_consignment = !evm_flow.consignment.is_empty(),
-                    consignment_valid = evm_flow.consignment_valid,
-                    nonce = evm_flow.nonce,
-                    deadline = evm_flow.deadline,
-                    "gRPC Sign: EVM flow"
+                    calldata_len = payload.call_data.len(),
+                    consignment_valid = payload.consignment_valid,
+                    nonce = payload.nonce,
+                    deadline = payload.deadline,
+                    "gRPC Sign: EVM (data_type=SWAP)"
                 );
-                // Translate EVMSigningFlow → SignEvmRequest.
-                // Same story: map available fields, default the rest.
+
                 EnclaveRequest {
                     request: Some(enclave_request::Request::SignEvm(
                         enclave_proto::SignEvmRequest {
-                            call_data: evm_flow.sign_payload,
-                            nonce: evm_flow.nonce,
-                            deadline: evm_flow.deadline,
-                            consignment_valid: evm_flow.consignment_valid,
-                            // Raw consignment bytes — passed through for enclave-side validation.
-                            consignment: evm_flow.consignment,
-                            consignment_hash: evm_flow.consignment_hash,
-                            // Fields the Go Listener doesn't send yet — defaults.
-                            rgb_amount: 0,
-                            rgb_asset_id: String::new(),
-                            chain_id: 0,
-                            proxy_contract: vec![],
-                            calldata_amount: 0,
-                            calldata_commission: 0,
+                            call_data: payload.call_data,
+                            nonce: payload.nonce,
+                            deadline: payload.deadline,
+                            consignment_valid: payload.consignment_valid,
+                            rgb_amount: payload.rgb_amount,
+                            rgb_asset_id: payload.rgb_asset_id,
+                            chain_id: payload.chain_id,
+                            proxy_contract: payload.proxy_contract,
+                            calldata_amount: payload.calldata_amount,
+                            calldata_commission: payload.calldata_commission,
+                            // Note: the enriched proto uses consignment_sha256 (SHA-256),
+                            // while the enclave proto uses consignment_hash (keccak256).
+                            // The Go Listener handles this distinction; we pass through as-is.
+                            consignment: vec![],
+                            consignment_hash: payload.consignment_sha256,
                         },
                     )),
                 }
+            }
+            other => {
+                tracing::warn!(?other, "unsupported data_type in Sign request");
+                return Err(Status::invalid_argument(format!(
+                    "unsupported data_type: {other:?}"
+                )));
             }
         };
 
@@ -198,20 +196,14 @@ impl EnclaveService for ParentAdapterService {
         );
 
         match resp.response {
-            Some(enclave_response::Response::SignedPsbt(r)) => {
-                Ok(Response::new(EnclaveSignResponse {
-                    result: Some(
-                        crate::grpc_proto::enclave_sign_response::Result::SignedPsbt(r.signed_psbt),
-                    ),
-                }))
-            }
-            Some(enclave_response::Response::EvmSignature(r)) => {
-                Ok(Response::new(EnclaveSignResponse {
-                    result: Some(
-                        crate::grpc_proto::enclave_sign_response::Result::EvmSignature(r.signature),
-                    ),
-                }))
-            }
+            Some(enclave_response::Response::SignedPsbt(r)) => Ok(Response::new(Signature {
+                network_id: inner.network_id,
+                signature: r.signed_psbt,
+            })),
+            Some(enclave_response::Response::EvmSignature(r)) => Ok(Response::new(Signature {
+                network_id: inner.network_id,
+                signature: r.signature,
+            })),
             Some(enclave_response::Response::Error(e)) => Err(Self::enclave_error_to_status(&e)),
             other => Err(Status::internal(format!(
                 "unexpected enclave response for Sign: {:?}",
@@ -220,11 +212,12 @@ impl EnclaveService for ParentAdapterService {
         }
     }
 
-    async fn get_public_keys(
+    /// PublicKey — returns the enclave's public key bytes.
+    async fn public_key(
         &self,
-        _request: Request<GetPublicKeysRequest>,
-    ) -> Result<Response<GetPublicKeysResponse>, Status> {
-        tracing::info!("gRPC GetPublicKeys called");
+        _request: Request<PublicKeyRequest>,
+    ) -> Result<Response<PublicKeyResponse>, Status> {
+        tracing::info!("gRPC PublicKey called");
         let enclave_req = EnclaveRequest {
             request: Some(enclave_request::Request::GetPublicKey(
                 enclave_proto::GetPublicKeyRequest {},
@@ -235,26 +228,59 @@ impl EnclaveService for ParentAdapterService {
 
         match resp.response {
             Some(enclave_response::Response::PublicKeys(r)) => {
-                // Flatten our structured response into the Go proto's repeated bytes.
-                let mut keys = Vec::with_capacity(2);
-                if !r.evm_address.is_empty() {
-                    keys.push(r.evm_address);
-                }
-                if !r.btc_compressed_pub.is_empty() {
-                    keys.push(r.btc_compressed_pub);
-                }
-                Ok(Response::new(GetPublicKeysResponse {
-                    public_keys: keys,
-                    master_fingerprint: r.master_fingerprint,
-                    account_xpub_vanilla: r.account_xpub_vanilla,
-                    account_xpub_colored: r.account_xpub_colored,
+                // Return the BTC compressed pubkey as the primary public key.
+                // The Go side uses this for cosigner identification.
+                Ok(Response::new(PublicKeyResponse {
+                    public_key: r.btc_compressed_pub,
                 }))
             }
             Some(enclave_response::Response::Error(e)) => Err(Self::enclave_error_to_status(&e)),
             other => Err(Status::internal(format!(
-                "unexpected enclave response for GetPublicKeys: {:?}",
+                "unexpected enclave response for PublicKey: {:?}",
                 other
             ))),
         }
+    }
+
+    /// Initialize — generates new keys in the enclave from OS entropy.
+    async fn initialize(
+        &self,
+        _request: Request<InitializeRequest>,
+    ) -> Result<Response<InitializeResponse>, Status> {
+        tracing::info!("gRPC Initialize called");
+        let enclave_req = EnclaveRequest {
+            request: Some(enclave_request::Request::InitializeKey(
+                enclave_proto::InitializeKeyRequest {
+                    seed: vec![],
+                    mnemonic: String::new(),
+                },
+            )),
+        };
+
+        let resp = self.send_to_enclave(enclave_req).await?;
+
+        match resp.response {
+            Some(enclave_response::Response::InitializeKey(r)) => {
+                Ok(Response::new(InitializeResponse {
+                    attestation: vec![], // Attestation not yet implemented
+                    public_key: r.btc_compressed_pub,
+                }))
+            }
+            Some(enclave_response::Response::Error(e)) => Err(Self::enclave_error_to_status(&e)),
+            other => Err(Status::internal(format!(
+                "unexpected enclave response for Initialize: {:?}",
+                other
+            ))),
+        }
+    }
+
+    /// Clone — not yet implemented (cluster cloning).
+    async fn clone(
+        &self,
+        _request: Request<CloneRequest>,
+    ) -> Result<Response<CloneResponse>, Status> {
+        Err(Status::unimplemented(
+            "Clone not yet implemented (cluster cloning)",
+        ))
     }
 }

--- a/parent/src/lib.rs
+++ b/parent/src/lib.rs
@@ -4,17 +4,20 @@ pub mod error;
 pub mod framing;
 pub mod grpc_server;
 
-/// Enclave wire-protocol types (from enclave.proto / enriched-payload.proto).
+/// Enclave wire-protocol types (from enclave.proto).
 /// Used by both the gRPC translation layer and the CLI.
 pub mod enclave_proto {
     include!(concat!(env!("OUT_DIR"), "/utexo_bridge.enclave.rs"));
 }
 
+/// Enriched payload types (from enriched-payload.proto).
+/// Listener serializes these into SignRequest.data; we deserialize in the gRPC server.
 pub mod enriched {
-    include!(concat!(env!("OUT_DIR"), "/utexo_bridge.enriched.rs"));
+    include!(concat!(env!("OUT_DIR"), "/tricorn.enriched.rs"));
 }
 
-/// gRPC types generated from parentadapter.proto (tonic server + prost messages).
+/// gRPC types generated from parentadapter.proto + signer/signer.proto (tonic server + prost messages).
+/// This matches the federated-signer-node's listener-enclave.proto interface.
 pub mod grpc_proto {
-    tonic::include_proto!("boostylabs.parentadapter");
+    tonic::include_proto!("tricorn");
 }

--- a/parent/tests/test_grpc_bridge.rs
+++ b/parent/tests/test_grpc_bridge.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the gRPC bridge (Parent Adapter → Enclave).
+//! Integration tests for the gRPC bridge (Parent Adapter -> Enclave).
 //!
 //! These tests start a mock enclave TCP server that speaks our wire protocol,
 //! then a real tonic gRPC server (Parent Adapter) pointing at it, and finally
@@ -6,22 +6,20 @@
 
 use std::net::TcpListener;
 
+use prost::Message as ProstMessage;
 use tonic::transport::Server;
 
 use utexo_bridge_parent::enclave_proto::{
     self, enclave_request, enclave_response, EnclaveRequest, EnclaveResponse,
 };
+use utexo_bridge_parent::enriched;
 use utexo_bridge_parent::framing;
 use utexo_bridge_parent::grpc_proto::enclave_service_client::EnclaveServiceClient;
 use utexo_bridge_parent::grpc_proto::enclave_service_server::EnclaveServiceServer;
-use utexo_bridge_parent::grpc_proto::{
-    enclave_sign_request, enclave_sign_response, EnclaveSignRequest as GrpcSignRequest,
-    EvmSigningFlow, GetPublicKeysRequest as GrpcGetPublicKeysRequest, PsbtSigningFlow,
-};
+use utexo_bridge_parent::grpc_proto::{DataType, PublicKeyRequest, SignRequest};
 use utexo_bridge_parent::grpc_server::{EnclaveTarget, ParentAdapterService};
 
 /// Start a mock enclave TCP server that responds to specific request types.
-/// This mimics the real enclave wire protocol without depending on the enclave crate.
 fn start_mock_enclave() -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let port = listener.local_addr().unwrap().port();
@@ -63,6 +61,18 @@ fn start_mock_enclave() -> u16 {
                         enclave_proto::SignedPsbtResponse {
                             signed_psbt: vec![0xDD; 100],
                             inputs_signed: 2,
+                        },
+                    )),
+                },
+                Some(enclave_request::Request::InitializeKey(_)) => EnclaveResponse {
+                    response: Some(enclave_response::Response::InitializeKey(
+                        enclave_proto::InitializeKeyResponse {
+                            evm_address: vec![0xAA; 20],
+                            btc_compressed_pub: vec![0xBB; 33],
+                            btc_xpub: "xpub-test".into(),
+                            master_fingerprint: vec![0xDD; 4],
+                            account_xpub_vanilla: "tpub-vanilla-test".into(),
+                            account_xpub_colored: "tpub-colored-test".into(),
                         },
                     )),
                 },
@@ -109,7 +119,7 @@ async fn start_grpc_server(enclave_port: u16) -> u16 {
 // =========================================================================
 
 #[tokio::test]
-async fn grpc_get_public_keys_roundtrip() {
+async fn grpc_public_key_roundtrip() {
     let enclave_port = start_mock_enclave();
     let grpc_port = start_grpc_server(enclave_port).await;
 
@@ -118,14 +128,16 @@ async fn grpc_get_public_keys_roundtrip() {
         .unwrap();
 
     let resp = client
-        .get_public_keys(GrpcGetPublicKeysRequest {})
+        .public_key(PublicKeyRequest {
+            network_id: 0,
+            data_type: 0,
+            algorithm: None,
+        })
         .await
         .unwrap()
         .into_inner();
 
-    assert_eq!(resp.public_keys.len(), 2);
-    assert_eq!(resp.public_keys[0].len(), 20, "EVM address");
-    assert_eq!(resp.public_keys[1].len(), 33, "BTC compressed pubkey");
+    assert_eq!(resp.public_key.len(), 33, "BTC compressed pubkey");
 }
 
 #[tokio::test]
@@ -137,24 +149,30 @@ async fn grpc_sign_evm_roundtrip() {
         .await
         .unwrap();
 
-    let req = GrpcSignRequest {
-        flow: Some(enclave_sign_request::Flow::Evm(EvmSigningFlow {
-            sign_payload: vec![0xAB; 132],
-            consignment_hash: vec![],
-            consignment: vec![],
-            consignment_valid: true,
-            nonce: 1,
-            deadline: u64::MAX,
-        })),
+    let payload = enriched::EnrichedEvmPayload {
+        call_data: vec![0xAB; 132],
+        nonce: 1,
+        deadline: u64::MAX,
+        consignment_valid: true,
+        rgb_amount: 0,
+        rgb_asset_id: String::new(),
+        chain_id: 1,
+        proxy_contract: vec![],
+        calldata_amount: 0,
+        calldata_commission: 0,
+        consignment_sha256: vec![],
+    };
+
+    let req = SignRequest {
+        network_id: 0,
+        data_type: DataType::Swap as i32,
+        data: payload.encode_to_vec(),
+        inputs: vec![],
+        algorithm: None,
     };
 
     let resp = client.sign(req).await.unwrap().into_inner();
-    match resp.result {
-        Some(enclave_sign_response::Result::EvmSignature(sig)) => {
-            assert_eq!(sig.len(), 65, "EVM signature must be 65 bytes");
-        }
-        other => panic!("expected EvmSignature, got {:?}", other),
-    }
+    assert_eq!(resp.signature.len(), 65, "EVM signature must be 65 bytes");
 }
 
 #[tokio::test]
@@ -166,28 +184,39 @@ async fn grpc_sign_psbt_roundtrip() {
         .await
         .unwrap();
 
-    let req = GrpcSignRequest {
-        flow: Some(enclave_sign_request::Flow::Psbt(PsbtSigningFlow {
-            psbt: vec![0xFF; 32],
-            validated_tx_hash: "aa".repeat(32), // 32 bytes as hex
-            operation_idx: 5,
-            evm_event_finalized: true,
-        })),
+    let payload = enriched::EnrichedPsbtPayload {
+        evm_tx_hash: vec![0xAA; 32],
+        operation_idx: 5,
+        evm_event_valid: true,
+        evm_event_finalized: true,
+        evm_token: vec![],
+        evm_amount: 0,
+        evm_recipient: vec![],
+        evm_commission: 0,
+        psbt_bytes: vec![0xFF; 32],
+        psbt_output_amount: 0,
+        rgb_asset_id: String::new(),
+    };
+
+    let req = SignRequest {
+        network_id: 0,
+        data_type: DataType::Transaction as i32,
+        data: payload.encode_to_vec(),
+        inputs: vec![],
+        algorithm: None,
     };
 
     let resp = client.sign(req).await.unwrap().into_inner();
-    match resp.result {
-        Some(enclave_sign_response::Result::SignedPsbt(psbt)) => {
-            assert!(!psbt.is_empty(), "signed PSBT should not be empty");
-        }
-        other => panic!("expected SignedPsbt, got {:?}", other),
-    }
+    assert!(
+        !resp.signature.is_empty(),
+        "signed PSBT should not be empty"
+    );
 }
 
 #[tokio::test]
-async fn grpc_evm_passes_consignment_bytes_through() {
-    // Verify the Parent Adapter actually passes consignment + hash to the enclave.
-    // We use a custom mock that inspects the received request.
+async fn grpc_evm_passes_enriched_fields_through() {
+    // Verify the Parent Adapter correctly deserializes EnrichedEvmPayload
+    // and passes fields to the enclave.
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let enclave_port = listener.local_addr().unwrap().port();
 
@@ -217,40 +246,41 @@ async fn grpc_evm_passes_consignment_bytes_through() {
         .await
         .unwrap();
 
-    let consignment = b"test-consignment-payload".to_vec();
-    let hash = b"test-consignment-hash-32bytes!!!".to_vec();
+    let consignment_hash = b"test-consignment-hash-32bytes!!!".to_vec();
 
-    let req = GrpcSignRequest {
-        flow: Some(enclave_sign_request::Flow::Evm(EvmSigningFlow {
-            sign_payload: vec![0xAB; 10],
-            consignment: consignment.clone(),
-            consignment_hash: hash.clone(),
-            consignment_valid: true,
-            nonce: 42,
-            deadline: 9999,
-        })),
+    let payload = enriched::EnrichedEvmPayload {
+        call_data: vec![0xAB; 10],
+        nonce: 42,
+        deadline: 9999,
+        consignment_valid: true,
+        rgb_amount: 100,
+        rgb_asset_id: "asset-id".into(),
+        chain_id: 1,
+        proxy_contract: vec![0x01; 20],
+        calldata_amount: 50,
+        calldata_commission: 5,
+        consignment_sha256: consignment_hash.clone(),
+    };
+
+    let req = SignRequest {
+        network_id: 0,
+        data_type: DataType::Swap as i32,
+        data: payload.encode_to_vec(),
+        inputs: vec![],
+        algorithm: None,
     };
 
     client.sign(req).await.unwrap();
 
-    // Inspect what the mock enclave received
     let received = rx.recv_timeout(std::time::Duration::from_secs(2)).unwrap();
-    assert_eq!(
-        received.consignment, consignment,
-        "consignment bytes must pass through"
-    );
-    assert_eq!(
-        received.consignment_hash, hash,
-        "consignment hash must pass through"
-    );
-    assert_eq!(
-        received.call_data,
-        vec![0xAB; 10],
-        "call_data mapped from sign_payload"
-    );
+    assert_eq!(received.call_data, vec![0xAB; 10]);
     assert_eq!(received.nonce, 42);
     assert_eq!(received.deadline, 9999);
     assert!(received.consignment_valid);
+    assert_eq!(received.rgb_amount, 100);
+    assert_eq!(received.chain_id, 1);
+    // consignment_sha256 maps to consignment_hash on the enclave side
+    assert_eq!(received.consignment_hash, consignment_hash);
 }
 
 // =========================================================================
@@ -258,7 +288,7 @@ async fn grpc_evm_passes_consignment_bytes_through() {
 // =========================================================================
 
 #[tokio::test]
-async fn grpc_missing_flow_returns_invalid_argument() {
+async fn grpc_invalid_data_type_returns_error() {
     let enclave_port = start_mock_enclave();
     let grpc_port = start_grpc_server(enclave_port).await;
 
@@ -266,38 +296,21 @@ async fn grpc_missing_flow_returns_invalid_argument() {
         .await
         .unwrap();
 
-    let err = client
-        .sign(GrpcSignRequest { flow: None })
-        .await
-        .unwrap_err();
-    assert_eq!(err.code(), tonic::Code::InvalidArgument);
-}
-
-#[tokio::test]
-async fn grpc_invalid_tx_hash_hex_returns_invalid_argument() {
-    let enclave_port = start_mock_enclave();
-    let grpc_port = start_grpc_server(enclave_port).await;
-
-    let mut client = EnclaveServiceClient::connect(format!("http://127.0.0.1:{grpc_port}"))
-        .await
-        .unwrap();
-
-    let req = GrpcSignRequest {
-        flow: Some(enclave_sign_request::Flow::Psbt(PsbtSigningFlow {
-            psbt: vec![0xFF; 32],
-            validated_tx_hash: "not-hex!!!".to_string(),
-            operation_idx: 0,
-            evm_event_finalized: false,
-        })),
+    // Use SIGNATURE data_type which we don't support
+    let req = SignRequest {
+        network_id: 0,
+        data_type: DataType::Signature as i32,
+        data: vec![],
+        inputs: vec![],
+        algorithm: None,
     };
 
     let err = client.sign(req).await.unwrap_err();
     assert_eq!(err.code(), tonic::Code::InvalidArgument);
-    assert!(err.message().contains("not valid hex"));
 }
 
 #[tokio::test]
-async fn grpc_wrong_tx_hash_length_returns_invalid_argument() {
+async fn grpc_invalid_enriched_payload_returns_error() {
     let enclave_port = start_mock_enclave();
     let grpc_port = start_grpc_server(enclave_port).await;
 
@@ -305,17 +318,40 @@ async fn grpc_wrong_tx_hash_length_returns_invalid_argument() {
         .await
         .unwrap();
 
-    // 16 bytes hex = valid hex but wrong length
-    let req = GrpcSignRequest {
-        flow: Some(enclave_sign_request::Flow::Psbt(PsbtSigningFlow {
-            psbt: vec![0xFF; 32],
-            validated_tx_hash: "aabbccdd00112233aabbccdd00112233".to_string(),
-            operation_idx: 0,
-            evm_event_finalized: false,
-        })),
+    // Send garbage bytes as TRANSACTION data
+    let req = SignRequest {
+        network_id: 0,
+        data_type: DataType::Transaction as i32,
+        data: vec![0xFF, 0xFF, 0xFF, 0xFF, 0xFF],
+        inputs: vec![],
+        algorithm: None,
     };
 
-    let err = client.sign(req).await.unwrap_err();
-    assert_eq!(err.code(), tonic::Code::InvalidArgument);
-    assert!(err.message().contains("32 bytes"));
+    // This should still succeed at the gRPC level (prost is lenient with unknown fields)
+    // but the point is it doesn't crash
+    let _result = client.sign(req).await;
+}
+
+#[tokio::test]
+async fn grpc_initialize_roundtrip() {
+    let enclave_port = start_mock_enclave();
+    let grpc_port = start_grpc_server(enclave_port).await;
+
+    let mut client = EnclaveServiceClient::connect(format!("http://127.0.0.1:{grpc_port}"))
+        .await
+        .unwrap();
+
+    let resp = client
+        .initialize(utexo_bridge_parent::grpc_proto::InitializeRequest {
+            cloning_secret: String::new(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        resp.public_key.len(),
+        33,
+        "public_key should be BTC compressed pubkey"
+    );
 }

--- a/proto/enriched-payload.proto
+++ b/proto/enriched-payload.proto
@@ -1,43 +1,61 @@
+// enriched-payload.proto — message-only (no gRPC). Listener serializes into SignRequest.data;
+// Enclave deserializes using network_id + data_type dispatch (see EnrichedPsbtPayload /
+// EnrichedEvmPayload). Bootstrap messages define Orchestrator -> Listener bytes before enrichment.
 syntax = "proto3";
-package utexo_bridge.enriched;
 
-// Enriched payloads for SignRequest.data field.
-// Listener repacks SignRequest.data before forwarding to Enclave.
-// Dispatch: network_id + data_type determines which message to decode.
-// Both Listener (Go) and Enclave (Rust) generate from this file.
+package tricorn.enriched;
 
-// EVM → RGB direction (FundsIn on EVM, PSBT signing)
-message EnrichedPsbtPayload {
-  bytes evm_tx_hash           = 1;
-  uint64 operation_idx        = 2;
+// --- Orchestrator -> Listener (minimal routing; Listener validates and enriches) ---
 
-  bool evm_event_valid        = 3;
-  bool evm_event_finalized    = 4;
-  bytes evm_token             = 5;
-  uint64 evm_amount           = 6;
-  bytes evm_recipient         = 7;
-  uint64 evm_commission       = 8;
-
-  bytes psbt_bytes            = 9;
-  uint64 psbt_output_amount   = 10;
-  string rgb_asset_id         = 11;
+message SignPsbtBootstrap {
+  string tx_hash = 1;
+  uint64 operation_idx = 2;
 }
 
-// RGB → EVM direction (FundsIn on RGB, EVM signing)
+message SignEvmBootstrap {
+  bytes call_data = 1;
+  bytes consignment_hash = 2;
+  bytes consignment = 3;
+  uint64 nonce = 4;
+  uint64 deadline = 5;
+}
+
+// --- Listener -> Enclave (EVM -> RGB: PSBT signing) ---
+// Dispatch: SignRequest with data_type TRANSACTION (see service comments).
+
+message EnrichedPsbtPayload {
+  bytes evm_tx_hash = 1;
+  uint64 operation_idx = 2;
+
+  bool evm_event_valid = 3;
+  bool evm_event_finalized = 4;
+  bytes evm_token = 5;
+  uint64 evm_amount = 6;
+  bytes evm_recipient = 7;
+  uint64 evm_commission = 8;
+
+  bytes psbt_bytes = 9;
+  uint64 psbt_output_amount = 10;
+  string rgb_asset_id = 11;
+}
+
+// --- Listener -> Enclave (RGB -> EVM: EVM signing) ---
+// Dispatch: SignRequest with data_type SWAP.
+
 message EnrichedEvmPayload {
-  bytes call_data             = 1;
-  uint64 nonce                = 2;
-  uint64 deadline             = 3;
+  bytes call_data = 1;
+  uint64 nonce = 2;
+  uint64 deadline = 3;
 
-  bool consignment_valid      = 4;
-  uint64 rgb_amount           = 5;
-  string rgb_asset_id         = 6;
+  bool consignment_valid = 4;
+  uint64 rgb_amount = 5;
+  string rgb_asset_id = 6;
 
-  uint64 chain_id             = 7;
-  bytes proxy_contract        = 8;
-  uint64 calldata_amount      = 9;
-  uint64 calldata_commission  = 10;
+  uint64 chain_id = 7;
+  bytes proxy_contract = 8;
+  uint64 calldata_amount = 9;
+  uint64 calldata_commission = 10;
 
-  bytes consignment           = 11;
-  bytes consignment_hash      = 12;
+  // SHA-256(consignment file) — 32 bytes.
+  bytes consignment_sha256 = 11;
 }

--- a/proto/parentadapter.proto
+++ b/proto/parentadapter.proto
@@ -1,49 +1,43 @@
+// Listener -> Parent Adapter -> Enclave (vsock:5000). Proto: listener-enclave.proto (Go -> Rust).
+// Parent Adapter proxies TCP gRPC <-> vsock wire protocol. Enclave is passive (inbound only).
+// Sign/PublicKey reuse signer/signer.proto; Initialize/Clone are enclave lifecycle only.
 syntax = "proto3";
-package boostylabs.parentadapter;
 
+package tricorn;
+
+import "signer/signer.proto";
+
+// EnclaveService — Parent Adapter gRPC interface.
+// Go Listener connects here; Parent Adapter translates to enclave wire protocol.
 service EnclaveService {
-  // Sign federated payloads after Listener validation and enrichment.
-  rpc Sign(EnclaveSignRequest) returns (EnclaveSignResponse);
-  // Public keys for federation / Bridge (proxied from Enclave).
-  rpc GetPublicKeys(GetPublicKeysRequest) returns (GetPublicKeysResponse);
+  // Signs data inside TEE after cross-checking amounts.
+  // data field contains enriched payload from Listener (validation results).
+  rpc Sign(SignRequest) returns (Signature);
+
+  // Returns HD-derived public key for specific network.
+  rpc PublicKey(PublicKeyRequest) returns (PublicKeyResponse);
+
+  // Generates new HD seed (BIP-39) and derives all keys. First start only.
+  rpc Initialize(InitializeRequest) returns (InitializeResponse);
+
+  // Requests HD seed from peer enclave (cluster cloning with attestation).
+  rpc Clone(CloneRequest) returns (CloneResponse);
 }
 
-message EnclaveSignRequest {
-  oneof flow {
-    PSBTSigningFlow psbt = 1;
-    EVMSigningFlow evm = 2;
-  }
+message InitializeRequest {
+  string cloning_secret = 1;
 }
 
-// EVM→RGB: PSBT plus validation context from Listener.
-message PSBTSigningFlow {
-  bytes psbt = 1;
-  string validated_tx_hash = 2;
-  uint64 operation_idx = 3;
-  bool evm_event_finalized = 4;
+message InitializeResponse {
+  bytes attestation = 1;
+  bytes public_key = 2;
 }
 
-// RGB→EVM: digest / payload plus consignment validation from Listener.
-message EVMSigningFlow {
-  bytes sign_payload = 1;
-  bytes consignment_hash = 2;
-  bytes consignment = 3;
-  bool consignment_valid = 4;
-  uint64 nonce = 5;
-  uint64 deadline = 6;
+message CloneRequest {
+  bytes attestation = 1;
+  bytes encryption_pubkey = 2;
 }
 
-message EnclaveSignResponse {
-  oneof result {
-    bytes signed_psbt = 1;
-    bytes evm_signature = 2;
-  }
-}
-
-message GetPublicKeysRequest {}
-message GetPublicKeysResponse {
-  repeated bytes public_keys = 1;          // Legacy: [evm_address, btc_compressed_pub]
-  bytes master_fingerprint = 2;            // 4 bytes — BIP-32 master key fingerprint
-  string account_xpub_vanilla = 3;         // BIP-86 account xpub for vanilla (BTC) operations
-  string account_xpub_colored = 4;         // BIP-86 account xpub for colored (RGB) operations
+message CloneResponse {
+  bytes encrypted_seed = 1;
 }

--- a/proto/signer/signer.proto
+++ b/proto/signer/signer.proto
@@ -1,0 +1,38 @@
+// signer/signer.proto — shared messages for all Tricorn signing services (unchanged contract).
+// Used by bridge-orchestrator, orchestrator-listener, listener-enclave, and upstream BridgeSigner /
+// SignerNode / ConnectorBridge patterns.
+syntax = "proto3";
+
+package tricorn;
+
+enum DataType {
+  TRANSACTION = 0;
+  SIGNATURE = 1;
+  COMMISSION = 2;
+  SWAP = 3;
+  UNSPENDABLE = 4;
+  OWNER_MULTIPLE_SIGNATURE = 5;
+}
+
+message SignRequest {
+  uint32 network_id = 1;
+  DataType data_type = 2;
+  bytes data = 3;
+  repeated int64 inputs = 4;
+  optional string algorithm = 5;
+}
+
+message Signature {
+  uint32 network_id = 1;
+  bytes signature = 2;
+}
+
+message PublicKeyRequest {
+  uint32 network_id = 1;
+  DataType data_type = 2;
+  optional string algorithm = 3;
+}
+
+message PublicKeyResponse {
+  bytes public_key = 1;
+}


### PR DESCRIPTION
## Summary

Depends on #16

Replace our custom `parentadapter.proto` with the federated-signer-node's proto definitions so the Go Listener can connect to our parent adapter directly — no more proto shape mismatch.

### Before vs After

| Aspect | Before | After |
|---|---|---|
| Sign method | `Sign(EnclaveSignRequest { oneof PSBTFlow/EVMFlow })` | `Sign(SignRequest { data_type, data bytes })` |
| Sign response | `EnclaveSignResponse { oneof signed_psbt/evm_sig }` | `Signature { network_id, signature bytes }` |
| Keys method | `GetPublicKeys(...)` | `PublicKey(PublicKeyRequest)` |
| Init method | N/A | `Initialize(InitializeRequest)` |
| Clone method | N/A | `Clone(CloneRequest)` — returns Unimplemented |

### How Sign works now

The Go Listener serializes an `EnrichedPsbtPayload` or `EnrichedEvmPayload` into `SignRequest.data` bytes. The parent adapter deserializes based on `data_type`:
- `TRANSACTION` → decode `EnrichedPsbtPayload` → map to enclave `SignPsbtRequest`
- `SWAP` → decode `EnrichedEvmPayload` → map to enclave `SignEvmRequest`

## Files changed

- `proto/signer/signer.proto` (new) — shared `SignRequest`, `Signature`, `PublicKeyRequest`, `PublicKeyResponse`
- `proto/parentadapter.proto` — replaced with `listener-enclave.proto` interface
- `proto/enriched-payload.proto` — updated to match federated-signer-node (added bootstrap messages, renamed `consignment_hash` → `consignment_sha256`)
- `parent/build.rs` — updated proto compilation for new structure
- `parent/src/lib.rs` — updated module declarations (`tricorn` package)
- `parent/src/grpc_server.rs` — rewritten for new `EnclaveService` trait
- `enclave/src/lib.rs` — updated enriched module path
- `parent/tests/test_grpc_bridge.rs` — rewritten for new message types

## Test plan

- [x] `cargo test --all --features allow-seed-import` — all 96 tests pass
- [x] `grpc_public_key_roundtrip` — PublicKey returns 33-byte compressed pubkey
- [x] `grpc_sign_evm_roundtrip` — Sign with SWAP data_type returns 65-byte sig
- [x] `grpc_sign_psbt_roundtrip` — Sign with TRANSACTION data_type returns signed PSBT
- [x] `grpc_evm_passes_enriched_fields_through` — all enriched fields correctly deserialized and forwarded
- [x] `grpc_initialize_roundtrip` — Initialize returns public key
- [x] `grpc_invalid_data_type_returns_error` — unsupported data_type rejected