### PR TITLE
feat(state): Phase state machine + cloning error variants (T5 PR 1/4)

### DIFF
--- a/enclave/src/error.rs
+++ b/enclave/src/error.rs
@@ -68,7 +68,7 @@ impl EnclaveError {
     /// Map error to a proto error code.
     pub fn error_code(&self) -> u32 {
         match self {
-            EnclaveError::CrossCheck(_) => 3, // ERROR_CODE_VALIDATION_FAILED
+            EnclaveError::CrossCheck(_) => 3,   // ERROR_CODE_VALIDATION_FAILED
             EnclaveError::NotReady { .. } => 2, // ERROR_CODE_NOT_READY
             _ => 1,
         }

--- a/enclave/src/error.rs
+++ b/enclave/src/error.rs
@@ -31,6 +31,37 @@ pub enum EnclaveError {
 
     #[error("internal error: {0}")]
     Internal(String),
+
+    #[error("not ready: enclave is in {state} state")]
+    NotReady { state: String },
+
+    #[error("attestation error: {0}")]
+    Attestation(String),
+
+    #[error("certificate error: {0}")]
+    Certificate(String),
+
+    #[error("clone failed: {0}")]
+    Clone(String),
+
+    #[error("PCR mismatch: PCR{pcr} expected={expected}, actual={actual}")]
+    PcrMismatch {
+        pcr: u32,
+        expected: String,
+        actual: String,
+    },
+
+    #[error("nonce replay detected")]
+    NonceReplay,
+
+    #[error("cloning digest mismatch")]
+    DigestMismatch,
+
+    #[error("pubkey mismatch: attestation pubkey does not match claimed pubkey")]
+    PubkeyMismatch,
+
+    #[error("identity mismatch: cloned seed does not derive to expected address")]
+    IdentityMismatch,
 }
 
 impl EnclaveError {
@@ -38,6 +69,7 @@ impl EnclaveError {
     pub fn error_code(&self) -> u32 {
         match self {
             EnclaveError::CrossCheck(_) => 3, // ERROR_CODE_VALIDATION_FAILED
+            EnclaveError::NotReady { .. } => 2, // ERROR_CODE_NOT_READY
             _ => 1,
         }
     }

--- a/enclave/src/keys.rs
+++ b/enclave/src/keys.rs
@@ -1,5 +1,4 @@
 use std::str::FromStr;
-use std::sync::Mutex;
 
 use bip39::Mnemonic;
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, Xpriv, Xpub};
@@ -331,123 +330,10 @@ impl KeyManager {
     }
 }
 
-/// Thread-safe enclave state holding an optional KeyManager behind a Mutex.
-pub struct EnclaveState {
-    inner: Mutex<Option<KeyManager>>,
-    network: Network,
-}
-
-impl Default for EnclaveState {
-    fn default() -> Self {
-        Self::new(Network::Bitcoin)
-    }
-}
-
-impl EnclaveState {
-    pub fn new(network: Network) -> Self {
-        Self {
-            inner: Mutex::new(None),
-            network,
-        }
-    }
-
-    pub fn network(&self) -> Network {
-        self.network
-    }
-
-    /// Initialize from OS entropy. Returns the mnemonic for one-time logging.
-    pub fn initialize_from_entropy(&self, entropy: &mut [u8; 32]) -> Result<Mnemonic> {
-        let mut guard = self
-            .inner
-            .lock()
-            .map_err(|e| EnclaveError::Internal(format!("lock poisoned: {}", e)))?;
-        if guard.is_some() {
-            return Err(EnclaveError::AlreadyInitialized);
-        }
-        let (manager, mnemonic) = KeyManager::generate(entropy, self.network)?;
-        *guard = Some(manager);
-        Ok(mnemonic)
-    }
-
-    /// Initialize from a BIP-39 mnemonic phrase (testing only, requires allow-seed-import feature).
-    pub fn initialize_from_mnemonic(&self, mnemonic_str: &str) -> Result<()> {
-        let mut guard = self
-            .inner
-            .lock()
-            .map_err(|e| EnclaveError::Internal(format!("lock poisoned: {}", e)))?;
-        if guard.is_some() {
-            return Err(EnclaveError::AlreadyInitialized);
-        }
-        let manager = KeyManager::from_mnemonic(mnemonic_str, self.network)?;
-        *guard = Some(manager);
-        Ok(())
-    }
-
-    /// Initialize from a raw 64-byte seed (testing only, requires allow-seed-import feature).
-    pub fn initialize_from_seed(&self, seed: [u8; 64]) -> Result<()> {
-        let mut guard = self
-            .inner
-            .lock()
-            .map_err(|e| EnclaveError::Internal(format!("lock poisoned: {}", e)))?;
-        if guard.is_some() {
-            return Err(EnclaveError::AlreadyInitialized);
-        }
-        let manager = KeyManager::from_seed(seed, self.network)?;
-        *guard = Some(manager);
-        Ok(())
-    }
-
-    /// Get public key info. Returns error if not initialized.
-    pub fn get_keys(&self) -> Result<KeyInfo> {
-        let guard = self
-            .inner
-            .lock()
-            .map_err(|e| EnclaveError::Internal(format!("lock poisoned: {}", e)))?;
-        match guard.as_ref() {
-            Some(km) => Ok(KeyInfo {
-                evm_address: *km.evm_address(),
-                btc_compressed_pubkey: *km.btc_compressed_pubkey(),
-                btc_xpub: km.btc_xpub().to_string(),
-                master_fingerprint: km.master_fingerprint().to_bytes(),
-                account_xpub_vanilla: km.account_xpub_vanilla().to_string(),
-                account_xpub_colored: km.account_xpub_colored().to_string(),
-            }),
-            None => Err(EnclaveError::KeyNotInitialized),
-        }
-    }
-
-    pub fn is_initialized(&self) -> bool {
-        self.inner.lock().map(|g| g.is_some()).unwrap_or(false)
-    }
-
-    /// Sign a 32-byte EVM message hash. Returns 65-byte signature.
-    pub fn sign_evm(&self, message_hash: &[u8; 32]) -> Result<[u8; 65]> {
-        let guard = self
-            .inner
-            .lock()
-            .map_err(|e| EnclaveError::Internal(format!("lock poisoned: {}", e)))?;
-        match guard.as_ref() {
-            Some(km) => km.sign_evm(message_hash),
-            None => Err(EnclaveError::KeyNotInitialized),
-        }
-    }
-
-    /// Sign PSBT inputs matching our BTC key. Returns (signed_psbt_bytes, inputs_signed).
-    pub fn sign_psbt(&self, psbt_bytes: &[u8]) -> Result<(Vec<u8>, usize)> {
-        let guard = self
-            .inner
-            .lock()
-            .map_err(|e| EnclaveError::Internal(format!("lock poisoned: {}", e)))?;
-        match guard.as_ref() {
-            Some(km) => km.sign_psbt(psbt_bytes),
-            None => Err(EnclaveError::KeyNotInitialized),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::state::EnclaveState;
 
     #[test]
     fn deterministic_derivation() {

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -5,6 +5,7 @@ pub mod framing;
 pub mod keys;
 pub mod server;
 pub mod signing;
+pub mod state;
 pub mod validation;
 #[cfg(all(feature = "vsock", target_os = "linux"))]
 pub mod vsock_forwarder;

--- a/enclave/src/main.rs
+++ b/enclave/src/main.rs
@@ -1,7 +1,7 @@
 use std::net::TcpListener;
 
-use utexo_bridge_enclave::keys::EnclaveState;
 use utexo_bridge_enclave::server::{self, ServerContext};
+use utexo_bridge_enclave::state::EnclaveState;
 
 fn main() {
     tracing_subscriber::fmt()

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -3,10 +3,10 @@ use std::io::{Read, Write};
 use crate::error::{EnclaveError, Result};
 use crate::framing;
 use crate::proto::enclave_request::Request;
-use crate::state::EnclaveState;
 use crate::proto::enclave_response::Response;
 use crate::proto::*;
 use crate::signing::evm::{sign_request_digest, Eip712Domain};
+use crate::state::EnclaveState;
 #[cfg(not(feature = "dev-mode"))]
 use crate::validation;
 

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -2,8 +2,8 @@ use std::io::{Read, Write};
 
 use crate::error::{EnclaveError, Result};
 use crate::framing;
-use crate::keys::EnclaveState;
 use crate::proto::enclave_request::Request;
+use crate::state::EnclaveState;
 use crate::proto::enclave_response::Response;
 use crate::proto::*;
 use crate::signing::evm::{sign_request_digest, Eip712Domain};

--- a/enclave/src/state.rs
+++ b/enclave/src/state.rs
@@ -1,0 +1,249 @@
+use std::sync::Mutex;
+
+use bip39::Mnemonic;
+use bitcoin::Network;
+
+use crate::error::{EnclaveError, Result};
+use crate::keys::{KeyInfo, KeyManager};
+
+/// Placeholder for cloning session state.
+///
+/// PR 3 (cloning crypto primitives) will replace this with the real type
+/// from `crate::cloning` carrying the X25519 ephemeral keypair, stored
+/// cloning secret, target cluster public key, and attestation nonce.
+#[derive(Debug, Default)]
+pub struct CloningSession {}
+
+/// Enclave lifecycle phase.
+///
+/// Valid transitions (see `EnclaveState`):
+///   Initial  -> Active   (InitializeKey / InitializeFromEntropy)
+///   Initial  -> Cloning  (InitiateCloning, wired in PR 4)
+///   Cloning  -> Active   (SetClone,      wired in PR 4)
+///   Active   -> Active   (GetClone handled by donor without state change)
+/// Any other transition is rejected.
+pub enum Phase {
+    /// No keys, waiting for an initialize request.
+    Initial,
+    /// Cloning handshake in progress, waiting for SetClone.
+    Cloning(CloningSession),
+    /// Keys loaded, ready to sign.
+    Active(KeyManager),
+}
+
+impl Phase {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Phase::Initial => "initial",
+            Phase::Cloning(_) => "cloning",
+            Phase::Active(_) => "active",
+        }
+    }
+}
+
+/// Thread-safe enclave state backed by a phase state machine.
+pub struct EnclaveState {
+    inner: Mutex<Phase>,
+    network: Network,
+}
+
+impl Default for EnclaveState {
+    fn default() -> Self {
+        Self::new(Network::Bitcoin)
+    }
+}
+
+impl EnclaveState {
+    pub fn new(network: Network) -> Self {
+        Self {
+            inner: Mutex::new(Phase::Initial),
+            network,
+        }
+    }
+
+    pub fn network(&self) -> Network {
+        self.network
+    }
+
+    /// Returns the name of the current phase ("initial", "cloning", "active").
+    pub fn phase_name(&self) -> &'static str {
+        self.inner
+            .lock()
+            .map(|g| g.name())
+            .unwrap_or("poisoned")
+    }
+
+    /// True only when the state holds an active `KeyManager`.
+    pub fn is_initialized(&self) -> bool {
+        matches!(
+            self.inner.lock().as_deref(),
+            Ok(Phase::Active(_))
+        )
+    }
+
+    /// Initialize from OS entropy. Returns the mnemonic for one-time logging.
+    /// Only valid from `Phase::Initial`; any other phase returns `AlreadyInitialized`.
+    pub fn initialize_from_entropy(&self, entropy: &mut [u8; 32]) -> Result<Mnemonic> {
+        let mut guard = self.lock_phase()?;
+        ensure_initial(&guard)?;
+        let (manager, mnemonic) = KeyManager::generate(entropy, self.network)?;
+        *guard = Phase::Active(manager);
+        Ok(mnemonic)
+    }
+
+    /// Initialize from a BIP-39 mnemonic phrase (testing only, requires `allow-seed-import` feature).
+    pub fn initialize_from_mnemonic(&self, mnemonic_str: &str) -> Result<()> {
+        let mut guard = self.lock_phase()?;
+        ensure_initial(&guard)?;
+        let manager = KeyManager::from_mnemonic(mnemonic_str, self.network)?;
+        *guard = Phase::Active(manager);
+        Ok(())
+    }
+
+    /// Initialize from a raw 64-byte seed (testing only, requires `allow-seed-import` feature).
+    pub fn initialize_from_seed(&self, seed: [u8; 64]) -> Result<()> {
+        let mut guard = self.lock_phase()?;
+        ensure_initial(&guard)?;
+        let manager = KeyManager::from_seed(seed, self.network)?;
+        *guard = Phase::Active(manager);
+        Ok(())
+    }
+
+    /// Get public key info. Returns `KeyNotInitialized` if not in the `Active` phase.
+    pub fn get_keys(&self) -> Result<KeyInfo> {
+        self.with_active(|km| {
+            Ok(KeyInfo {
+                evm_address: *km.evm_address(),
+                btc_compressed_pubkey: *km.btc_compressed_pubkey(),
+                btc_xpub: km.btc_xpub().to_string(),
+                master_fingerprint: km.master_fingerprint().to_bytes(),
+                account_xpub_vanilla: km.account_xpub_vanilla().to_string(),
+                account_xpub_colored: km.account_xpub_colored().to_string(),
+            })
+        })
+    }
+
+    /// Sign a 32-byte EVM message hash. Returns 65-byte signature.
+    pub fn sign_evm(&self, message_hash: &[u8; 32]) -> Result<[u8; 65]> {
+        self.with_active(|km| km.sign_evm(message_hash))
+    }
+
+    /// Sign PSBT inputs matching our BTC key. Returns (signed_psbt_bytes, inputs_signed).
+    pub fn sign_psbt(&self, psbt_bytes: &[u8]) -> Result<(Vec<u8>, usize)> {
+        self.with_active(|km| km.sign_psbt(psbt_bytes))
+    }
+
+    fn lock_phase(&self) -> Result<std::sync::MutexGuard<'_, Phase>> {
+        self.inner
+            .lock()
+            .map_err(|e| EnclaveError::Internal(format!("lock poisoned: {}", e)))
+    }
+
+    fn with_active<T>(&self, f: impl FnOnce(&KeyManager) -> Result<T>) -> Result<T> {
+        let guard = self.lock_phase()?;
+        match &*guard {
+            Phase::Active(km) => f(km),
+            Phase::Initial | Phase::Cloning(_) => Err(EnclaveError::KeyNotInitialized),
+        }
+    }
+}
+
+fn ensure_initial(phase: &Phase) -> Result<()> {
+    match phase {
+        Phase::Initial => Ok(()),
+        _ => Err(EnclaveError::AlreadyInitialized),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_state_is_initial() {
+        let state = EnclaveState::new(Network::Bitcoin);
+        assert_eq!(state.phase_name(), "initial");
+        assert!(!state.is_initialized());
+    }
+
+    #[test]
+    fn initial_to_active_via_entropy() {
+        let state = EnclaveState::new(Network::Bitcoin);
+        let mut entropy = [1u8; 32];
+        state.initialize_from_entropy(&mut entropy).unwrap();
+        assert_eq!(state.phase_name(), "active");
+        assert!(state.is_initialized());
+    }
+
+    #[test]
+    fn active_to_active_via_entropy_rejected() {
+        let state = EnclaveState::new(Network::Bitcoin);
+        let mut entropy = [1u8; 32];
+        state.initialize_from_entropy(&mut entropy).unwrap();
+
+        let mut entropy2 = [2u8; 32];
+        let err = state.initialize_from_entropy(&mut entropy2).unwrap_err();
+        assert!(matches!(err, EnclaveError::AlreadyInitialized));
+    }
+
+    #[test]
+    fn initial_to_active_via_seed() {
+        let state = EnclaveState::new(Network::Bitcoin);
+        state.initialize_from_seed([42u8; 64]).unwrap();
+        assert_eq!(state.phase_name(), "active");
+    }
+
+    #[test]
+    fn initial_to_active_via_mnemonic() {
+        let state = EnclaveState::new(Network::Bitcoin);
+        state
+            .initialize_from_mnemonic(
+                "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            )
+            .unwrap();
+        assert_eq!(state.phase_name(), "active");
+    }
+
+    #[test]
+    fn get_keys_on_initial_errors() {
+        let state = EnclaveState::new(Network::Bitcoin);
+        assert!(matches!(
+            state.get_keys(),
+            Err(EnclaveError::KeyNotInitialized)
+        ));
+    }
+
+    #[test]
+    fn sign_evm_on_initial_errors() {
+        let state = EnclaveState::new(Network::Bitcoin);
+        let err = state.sign_evm(&[0u8; 32]).unwrap_err();
+        assert!(matches!(err, EnclaveError::KeyNotInitialized));
+    }
+
+    #[test]
+    fn sign_psbt_on_initial_errors() {
+        let state = EnclaveState::new(Network::Bitcoin);
+        let err = state.sign_psbt(&[0u8; 8]).unwrap_err();
+        assert!(matches!(err, EnclaveError::KeyNotInitialized));
+    }
+
+    #[test]
+    fn cloning_phase_is_not_initialized() {
+        let state = EnclaveState::new(Network::Bitcoin);
+        *state.inner.lock().unwrap() = Phase::Cloning(CloningSession::default());
+        assert_eq!(state.phase_name(), "cloning");
+        assert!(!state.is_initialized());
+        assert!(matches!(
+            state.get_keys(),
+            Err(EnclaveError::KeyNotInitialized)
+        ));
+    }
+
+    #[test]
+    fn initialize_from_cloning_phase_rejected() {
+        let state = EnclaveState::new(Network::Bitcoin);
+        *state.inner.lock().unwrap() = Phase::Cloning(CloningSession::default());
+        let err = state.initialize_from_seed([42u8; 64]).unwrap_err();
+        assert!(matches!(err, EnclaveError::AlreadyInitialized));
+    }
+}

--- a/enclave/src/state.rs
+++ b/enclave/src/state.rs
@@ -22,13 +22,18 @@ pub struct CloningSession {}
 ///   Cloning  -> Active   (SetClone,      wired in PR 4)
 ///   Active   -> Active   (GetClone handled by donor without state change)
 /// Any other transition is rejected.
+///
+/// `KeyManager` is boxed so the enum stays small (~24 bytes) rather than
+/// bloating every `Phase` value to the size of the biggest variant
+/// (~584 bytes). The heap indirection is irrelevant in the hot path —
+/// the mutex lock dominates.
 pub enum Phase {
     /// No keys, waiting for an initialize request.
     Initial,
     /// Cloning handshake in progress, waiting for SetClone.
     Cloning(CloningSession),
     /// Keys loaded, ready to sign.
-    Active(KeyManager),
+    Active(Box<KeyManager>),
 }
 
 impl Phase {
@@ -81,7 +86,7 @@ impl EnclaveState {
         let mut guard = self.lock_phase()?;
         ensure_initial(&guard)?;
         let (manager, mnemonic) = KeyManager::generate(entropy, self.network)?;
-        *guard = Phase::Active(manager);
+        *guard = Phase::Active(Box::new(manager));
         Ok(mnemonic)
     }
 
@@ -90,7 +95,7 @@ impl EnclaveState {
         let mut guard = self.lock_phase()?;
         ensure_initial(&guard)?;
         let manager = KeyManager::from_mnemonic(mnemonic_str, self.network)?;
-        *guard = Phase::Active(manager);
+        *guard = Phase::Active(Box::new(manager));
         Ok(())
     }
 
@@ -99,7 +104,7 @@ impl EnclaveState {
         let mut guard = self.lock_phase()?;
         ensure_initial(&guard)?;
         let manager = KeyManager::from_seed(seed, self.network)?;
-        *guard = Phase::Active(manager);
+        *guard = Phase::Active(Box::new(manager));
         Ok(())
     }
 

--- a/enclave/src/state.rs
+++ b/enclave/src/state.rs
@@ -67,18 +67,12 @@ impl EnclaveState {
 
     /// Returns the name of the current phase ("initial", "cloning", "active").
     pub fn phase_name(&self) -> &'static str {
-        self.inner
-            .lock()
-            .map(|g| g.name())
-            .unwrap_or("poisoned")
+        self.inner.lock().map(|g| g.name()).unwrap_or("poisoned")
     }
 
     /// True only when the state holds an active `KeyManager`.
     pub fn is_initialized(&self) -> bool {
-        matches!(
-            self.inner.lock().as_deref(),
-            Ok(Phase::Active(_))
-        )
+        matches!(self.inner.lock().as_deref(), Ok(Phase::Active(_)))
     }
 
     /// Initialize from OS entropy. Returns the mnemonic for one-time logging.

--- a/enclave/tests/common/mod.rs
+++ b/enclave/tests/common/mod.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use std::thread;
 
 use utexo_bridge_enclave::framing;
-use utexo_bridge_enclave::keys::EnclaveState;
 use utexo_bridge_enclave::proto::*;
 use utexo_bridge_enclave::server::{self, ServerContext};
+use utexo_bridge_enclave::state::EnclaveState;
 
 /// Start a test server on a random TCP port. Returns the port number.
 /// The server runs in a background thread and handles connections until


### PR DESCRIPTION
First PR of the cloning + attestation series (T5). **Foundation only** — no new functionality, no proto changes, no new dependencies.

## Summary
- Adds the \`Phase\` state machine that PRs 2–4 will plug into.
- Adds the error variants needed by attestation verification and cloning.
- Pure refactor: all existing handlers still pass, no behavior change.

## Changes
- **\`enclave/src/error.rs\`** — new variants: \`NotReady { state }\`, \`Attestation\`, \`Certificate\`, \`Clone\`, \`PcrMismatch { pcr, expected, actual }\`, \`NonceReplay\`, \`DigestMismatch\`, \`PubkeyMismatch\`, \`IdentityMismatch\`. \`NotReady\` maps to error code \`2\`.
- **\`enclave/src/state.rs\`** (new) — \`Phase { Initial, Cloning(CloningSession), Active(KeyManager) }\` enum + \`EnclaveState\` backed by \`Mutex<Phase>\` instead of \`Mutex<Option<KeyManager>>\`. \`CloningSession\` is a placeholder struct that PR 3 will fill in.
- **\`enclave/src/keys.rs\`** — removed \`EnclaveState\` (now lives in \`state.rs\`). \`KeyManager\` and \`KeyInfo\` unchanged.
- **\`server.rs\`, \`main.rs\`, \`tests/common/mod.rs\`** — imports updated from \`keys::EnclaveState\` to \`state::EnclaveState\`.

## Transition logic
Valid transitions (unchanged semantically, just tracked explicitly):
- \`Initial → Active\` via \`initialize_from_entropy/mnemonic/seed\`
- Double-init returns \`AlreadyInitialized\` (applies to both \`Active\` and \`Cloning\`)
- Read ops (\`get_keys\`, \`sign_evm\`, \`sign_psbt\`) return \`KeyNotInitialized\` unless in \`Active\`

PR 4 wires \`Initial → Cloning\` and \`Cloning → Active\` via the cloning handlers.

## Test plan
- [x] \`cargo build\` — clean
- [x] \`cargo test\` — 72 unit + 27 integration tests pass
- [x] \`cargo test --features allow-seed-import\` — all tests pass
- [x] New unit tests in \`state.rs\`: new-state-is-initial, entropy/seed/mnemonic transitions, double-init rejected, read ops on initial/cloning error, init from cloning rejected
- [ ] Reviewer: sanity-check that no existing handler paths broke