### PR TITLE
feat(attestation): NSM + peer attestation verifier (T5 PR 2/4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "695e433882668b55b3d7fb0ba22bf9be66a91abe30d7ca1f1a774f8b90b4db4c"
 dependencies = [
  "amplify_num",
- "bitflags",
+ "bitflags 2.11.0",
  "wasm-bindgen",
 ]
 
@@ -196,6 +196,20 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-nitro-enclaves-nsm-api"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92c1f4471b33f6a7af9ea421b249ed18a11c71156564baf6293148fa6ad1b09"
+dependencies = [
+ "libc",
+ "log",
+ "nix 0.26.4",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+]
 
 [[package]]
 name = "axum"
@@ -367,6 +381,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -456,6 +476,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half 2.7.1",
 ]
 
 [[package]]
@@ -585,7 +632,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -632,6 +693,8 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "hkdf",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -702,6 +765,12 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "fluent-uri"
@@ -848,6 +917,12 @@ dependencies = [
 
 [[package]]
 name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
+name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
@@ -904,6 +979,15 @@ name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -1183,6 +1267,15 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -1235,15 +1328,28 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
+]
+
+[[package]]
+name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -1286,6 +1392,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,6 +1431,15 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1402,6 +1529,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1619,7 +1755,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1691,7 +1827,7 @@ dependencies = [
  "baid64",
  "blake3",
  "getrandom 0.3.4",
- "half",
+ "half 2.7.1",
  "paste",
  "rgb-ascii-armor",
  "rgb-strict-encoding",
@@ -1846,7 +1982,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1958,6 +2094,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half 1.8.3",
+ "serde",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,6 +2144,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -2204,6 +2371,27 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "tokio"
@@ -2451,22 +2639,29 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 name = "utexo-bridge-enclave"
 version = "0.1.0"
 dependencies = [
+ "aws-nitro-enclaves-nsm-api",
+ "base64",
  "bip39",
  "bitcoin",
+ "ciborium",
+ "der",
  "getrandom 0.4.2",
  "hex",
  "k256",
- "nix",
+ "nix 0.31.2",
+ "p384",
  "prost 0.14.3",
  "prost-build 0.14.3",
  "rand 0.10.0",
  "rgb-ops",
  "secrecy",
+ "serde",
  "sha3",
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
  "vsock",
+ "x509-cert",
  "zeroize",
 ]
 
@@ -2513,7 +2708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b82aeb12ad864eb8cd26a6c21175d0bdc66d398584ee6c93c76964c3bcfc78ff"
 dependencies = [
  "libc",
- "nix",
+ "nix 0.31.2",
 ]
 
 [[package]]
@@ -2622,7 +2817,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
@@ -2833,7 +3028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap 2.13.0",
  "log",
  "serde",
@@ -2861,6 +3056,20 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "sha1",
+ "signature",
+ "spki",
+ "tls_codec",
 ]
 
 [[package]]

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -47,9 +47,18 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # RGB consignment validation (optional, behind rgb-validation feature)
 rgb-ops = { version = "0.11.1-rc.7", features = ["esplora_blocking"], optional = true }
 
+# Attestation verification (NSM COSE_Sign1 + AWS Nitro cert chain)
+ciborium = "0.2"
+p384 = { version = "0.13", features = ["ecdsa", "pem"] }
+x509-cert = { version = "0.2", features = ["pem", "builder"] }
+der = { version = "0.7", features = ["alloc"] }
+base64 = "0.22"
+serde = { version = "1", features = ["derive"] }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 vsock = "0.5"
 nix = { version = "0.31.2", features = ["socket"] }
+aws-nitro-enclaves-nsm-api = "0.4"
 
 [build-dependencies]
 prost-build = "0.14.3"
@@ -63,6 +72,9 @@ allow-seed-import = []
 dev-mode = []
 # In-enclave RGB consignment validation via rgbstd + Esplora.
 rgb-validation = ["rgb-ops"]
+# Mock attestation path: skip NSM / COSE / cert-chain checks and use raw CBOR docs.
+# Testing only — never enable in production builds.
+mock-attestation = []
 
 [dev-dependencies]
 rand = "0.10.0"

--- a/enclave/src/attestation.rs
+++ b/enclave/src/attestation.rs
@@ -1,0 +1,742 @@
+//! AWS Nitro Enclave attestation.
+//!
+//! Two paths:
+//!   1. Real (default on Linux): requests attestation documents from the
+//!      NSM device (`/dev/nsm`) via `aws-nitro-enclaves-nsm-api`, and
+//!      verifies peer attestations by parsing COSE_Sign1, validating the
+//!      AWS Nitro certificate chain, and comparing PCRs + nonce.
+//!   2. Mock (`mock-attestation` feature or non-Linux): the document is
+//!      a raw CBOR-encoded `AttestationDocument` with no COSE wrapping
+//!      and no certificate chain. Verification skips the crypto checks
+//!      but still enforces PCRs, nonce, and pubkey binding. This lets
+//!      cloning integration tests run on any dev machine.
+//!
+//! Module is currently not wired into server.rs. PR 4 will plug it in.
+
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+
+use crate::error::{EnclaveError, Result};
+
+/// Expected PCR values for a peer enclave. Constructed once from
+/// a self-attestation at startup (`get_own_pcrs`) and reused for
+/// every peer check.
+#[derive(Clone, Debug)]
+pub struct ExpectedPcrs {
+    pub pcr0: [u8; 48],
+    pub pcr1: [u8; 48],
+    pub pcr2: [u8; 48],
+}
+
+impl ExpectedPcrs {
+    pub fn new(pcr0: [u8; 48], pcr1: [u8; 48], pcr2: [u8; 48]) -> Self {
+        Self { pcr0, pcr1, pcr2 }
+    }
+
+    pub fn zero() -> Self {
+        Self {
+            pcr0: [0u8; 48],
+            pcr1: [0u8; 48],
+            pcr2: [0u8; 48],
+        }
+    }
+
+    pub fn from_hex(pcr0: &str, pcr1: &str, pcr2: &str) -> Result<Self> {
+        let parse = |s: &str| -> Result<[u8; 48]> {
+            let bytes = hex::decode(s).map_err(|e| EnclaveError::Attestation(e.to_string()))?;
+            bytes
+                .try_into()
+                .map_err(|_| EnclaveError::Attestation("PCR must be 48 bytes".into()))
+        };
+        Ok(Self {
+            pcr0: parse(pcr0)?,
+            pcr1: parse(pcr1)?,
+            pcr2: parse(pcr2)?,
+        })
+    }
+}
+
+/// The verified contents of a peer attestation, minus the CBOR/COSE wrapping.
+#[derive(Debug, Clone)]
+pub struct VerifiedAttestation {
+    pub enclave_pubkey: Vec<u8>,
+    pub pcrs: HashMap<u32, Vec<u8>>,
+    pub timestamp: u64,
+    pub user_data: Option<Vec<u8>>,
+    pub nonce: Vec<u8>,
+}
+
+/// Wire-format representation of the NSM attestation payload.
+///
+/// In real mode this is the CBOR payload *inside* a COSE_Sign1 wrapper.
+/// In mock mode it is the outer document (no COSE wrapping).
+///
+/// Byte fields are encoded as CBOR arrays-of-uint in the mock roundtrip,
+/// which ciborium handles transparently. Real NSM documents use proper
+/// CBOR byte strings — ciborium's deserializer accepts both.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct AttestationDocument {
+    #[serde(rename = "module_id", default)]
+    pub module_id: String,
+    pub timestamp: u64,
+    #[serde(default)]
+    pub digest: String,
+    pub pcrs: HashMap<u32, Vec<u8>>,
+    #[serde(default)]
+    pub certificate: Vec<u8>,
+    #[serde(default)]
+    pub cabundle: Vec<Vec<u8>>,
+    #[serde(default)]
+    pub public_key: Option<Vec<u8>>,
+    #[serde(default)]
+    pub user_data: Option<Vec<u8>>,
+    #[serde(default)]
+    pub nonce: Option<Vec<u8>>,
+}
+
+// ----------------------------------------------------------------------------
+// Public API
+// ----------------------------------------------------------------------------
+
+/// Produce an attestation document binding `nonce`, `public_key`, and optional
+/// `user_data`. The returned bytes are what we hand to peers over the wire.
+///
+/// Real path (Linux + no mock): calls the NSM device.
+/// Mock path (`mock-attestation` feature): returns a raw CBOR `AttestationDocument`
+/// with all-zero PCRs and the supplied fields. Non-Linux builds without
+/// `mock-attestation` will fail to compile at the call site.
+pub fn get_attestation(
+    nonce: &[u8; 32],
+    public_key: Option<&[u8]>,
+    user_data: Option<&[u8]>,
+) -> Result<Vec<u8>> {
+    #[cfg(feature = "mock-attestation")]
+    {
+        mock::build_mock_document(nonce, public_key, user_data)
+    }
+
+    #[cfg(all(target_os = "linux", not(feature = "mock-attestation")))]
+    {
+        real::request_nsm_attestation(nonce, public_key, user_data)
+    }
+
+    #[cfg(all(not(target_os = "linux"), not(feature = "mock-attestation")))]
+    {
+        let _ = (nonce, public_key, user_data);
+        Err(EnclaveError::Attestation(
+            "attestation not available: build for Linux with NSM or enable mock-attestation"
+                .into(),
+        ))
+    }
+}
+
+/// Read PCR0/1/2 from a self-attestation. Used at startup to learn our own
+/// measurement so we can reject peers with mismatched PCRs.
+pub fn get_own_pcrs() -> Result<ExpectedPcrs> {
+    #[cfg(feature = "mock-attestation")]
+    {
+        Ok(ExpectedPcrs::zero())
+    }
+
+    #[cfg(all(target_os = "linux", not(feature = "mock-attestation")))]
+    {
+        real::read_own_pcrs()
+    }
+
+    #[cfg(all(not(target_os = "linux"), not(feature = "mock-attestation")))]
+    {
+        Err(EnclaveError::Attestation(
+            "NSM not available on this platform; enable mock-attestation for dev builds".into(),
+        ))
+    }
+}
+
+/// Verify a peer attestation document and return the extracted fields.
+///
+/// Checks (in order):
+///   1. Parse COSE_Sign1 / AttestationDocument (CBOR).
+///   2. Verify the COSE signature using the embedded leaf certificate.
+///   3. Verify the certificate chain terminates at the AWS Nitro root CA.
+///   4. Check certificate validity windows (not_before / not_after).
+///   5. Compare PCR0/1/2 against `expected_pcrs`.
+///   6. Compare the document nonce against `expected_nonce`.
+///
+/// In `mock-attestation` mode, steps 1–4 are replaced with a raw CBOR parse
+/// and the cert chain is not validated. PCR/nonce/pubkey binding still hold.
+pub fn verify_peer_attestation(
+    doc: &[u8],
+    expected_pcrs: &ExpectedPcrs,
+    expected_nonce: &[u8; 32],
+) -> Result<VerifiedAttestation> {
+    #[cfg(feature = "mock-attestation")]
+    {
+        mock::verify_mock_document(doc, expected_pcrs, expected_nonce)
+    }
+
+    #[cfg(not(feature = "mock-attestation"))]
+    {
+        real::verify_real_document(doc, expected_pcrs, expected_nonce)
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Shared helpers
+// ----------------------------------------------------------------------------
+
+fn verify_pcrs(
+    pcrs: &HashMap<u32, Vec<u8>>,
+    expected: &ExpectedPcrs,
+) -> Result<()> {
+    let check = |idx: u32, expected_bytes: &[u8; 48]| -> Result<()> {
+        let actual = pcrs
+            .get(&idx)
+            .ok_or_else(|| EnclaveError::Attestation(format!("Missing PCR{idx}")))?;
+        if actual.as_slice() != expected_bytes {
+            return Err(EnclaveError::PcrMismatch {
+                pcr: idx,
+                expected: hex::encode(expected_bytes),
+                actual: hex::encode(actual),
+            });
+        }
+        Ok(())
+    };
+
+    check(0, &expected.pcr0)?;
+    check(1, &expected.pcr1)?;
+    check(2, &expected.pcr2)?;
+    Ok(())
+}
+
+fn check_nonce(doc_nonce: &Option<Vec<u8>>, expected: &[u8; 32]) -> Result<Vec<u8>> {
+    match doc_nonce {
+        Some(n) if n.as_slice() == expected => Ok(n.clone()),
+        Some(_) => Err(EnclaveError::Attestation("nonce mismatch".into())),
+        None => Err(EnclaveError::Attestation(
+            "missing nonce in attestation".into(),
+        )),
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Real path (COSE + cert chain)
+// ----------------------------------------------------------------------------
+
+#[cfg(not(feature = "mock-attestation"))]
+mod real {
+    use super::*;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use base64::Engine;
+    use p384::ecdsa::{signature::Verifier, Signature, VerifyingKey};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use x509_cert::der::{Decode, Encode};
+    use x509_cert::Certificate;
+
+    const AWS_NITRO_ROOT_CERT_PEM: &str = r#"-----BEGIN CERTIFICATE-----
+MIICETCCAZagAwIBAgIRAPkxdWgbkK/hHUbMtOTn+FYwCgYIKoZIzj0EAwMwSTEL
+MAkGA1UEBhMCVVMxDzANBgNVBAoMBkFtYXpvbjEMMAoGA1UECwwDQVdTMRswGQYD
+VQQDDBJhd3Mubml0cm8tZW5jbGF2ZXMwHhcNMTkxMDI4MTMyODA1WhcNNDkxMDI4
+MTQyODA1WjBJMQswCQYDVQQGEwJVUzEPMA0GA1UECgwGQW1hem9uMQwwCgYDVQQL
+DANBV1MxGzAZBgNVBAMMEmF3cy5uaXRyby1lbmNsYXZlczB2MBAGByqGSM49AgEG
+BSuBBAAiA2IABPwCVOumCMHzaHDimtqQvkY4MpJzbolL//Zy2YlES1BR5TSksfbb
+48C8WBoyt7F2Bw7eEtaaP+ohG2bnUs990d0JX28TcPQXCEPZ3BABIeTPYwEoCWZE
+h8l5YoQwTcU/9KNCMEAwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUkCW1DdkF
+R+eWw5b6cp3PmanfS5YwDgYDVR0PAQH/BAQDAgGGMAoGCCqGSM49BAMDA2kAMGYC
+MQCjfy+Rocm9Xue4YnwWmNJVA44fA0P5W2OpYow9OYCVRaEevL8uO1XYru5xtMPW
+rfMCMQCi85sWBbJwKKXdS6BptQFuZbT73o/gBh1qUxl/nNr12UO8Yfwr6wPLb+6N
+IwLz3/Y=
+-----END CERTIFICATE-----"#;
+
+    fn parse_pem_cert(pem: &str) -> Certificate {
+        let lines: Vec<&str> = pem.lines().filter(|l| !l.starts_with("-----")).collect();
+        let b64 = lines.join("");
+        let der = BASE64
+            .decode(&b64)
+            .expect("invalid base64 in embedded root cert");
+        Certificate::from_der(&der).expect("invalid DER in embedded root cert")
+    }
+
+    pub(super) fn verify_real_document(
+        doc: &[u8],
+        expected_pcrs: &ExpectedPcrs,
+        expected_nonce: &[u8; 32],
+    ) -> Result<VerifiedAttestation> {
+        let root_cert = parse_pem_cert(AWS_NITRO_ROOT_CERT_PEM);
+
+        let cose = CoseSign1::from_bytes(doc)?;
+        let payload = cose
+            .payload
+            .as_ref()
+            .ok_or_else(|| EnclaveError::Attestation("missing COSE payload".into()))?;
+
+        let attestation: AttestationDocument = ciborium::from_reader(payload.as_slice())
+            .map_err(|e| EnclaveError::Attestation(format!("failed to parse attestation: {e}")))?;
+
+        verify_certificate_chain(
+            &attestation.certificate,
+            &attestation.cabundle,
+            &cose,
+            &root_cert,
+        )?;
+
+        let nonce = check_nonce(&attestation.nonce, expected_nonce)?;
+        verify_pcrs(&attestation.pcrs, expected_pcrs)?;
+
+        let enclave_pubkey = attestation
+            .public_key
+            .ok_or_else(|| EnclaveError::Attestation("missing public key".into()))?;
+
+        Ok(VerifiedAttestation {
+            enclave_pubkey,
+            pcrs: attestation.pcrs,
+            timestamp: attestation.timestamp,
+            user_data: attestation.user_data,
+            nonce,
+        })
+    }
+
+    fn verify_certificate_chain(
+        signing_cert_der: &[u8],
+        cabundle: &[Vec<u8>],
+        cose: &CoseSign1,
+        root_cert: &Certificate,
+    ) -> Result<()> {
+        let signing_cert = Certificate::from_der(signing_cert_der).map_err(|e| {
+            EnclaveError::Certificate(format!("failed to parse signing cert: {e}"))
+        })?;
+        verify_cert_validity(&signing_cert)?;
+
+        let signing_pubkey = extract_p384_pubkey(&signing_cert)?;
+        let sig_bytes = cose.signature.as_slice();
+        let signature = Signature::from_der(sig_bytes)
+            .map_err(|e| EnclaveError::Attestation(format!("invalid COSE signature: {e}")))?;
+
+        let to_verify = cose.sig_structure()?;
+        signing_pubkey
+            .verify(&to_verify, &signature)
+            .map_err(|_| EnclaveError::Attestation("COSE signature verification failed".into()))?;
+
+        if cabundle.is_empty() {
+            return Err(EnclaveError::Attestation("empty certificate bundle".into()));
+        }
+
+        let issuer_cert = Certificate::from_der(&cabundle[0])
+            .map_err(|e| EnclaveError::Certificate(format!("failed to parse issuer cert: {e}")))?;
+        verify_cert_validity(&issuer_cert)?;
+
+        let issuer_pubkey = extract_p384_pubkey(&issuer_cert)?;
+        let tbs_bytes = signing_cert
+            .tbs_certificate
+            .to_der()
+            .map_err(|e| EnclaveError::Certificate(format!("DER encode failed: {e}")))?;
+
+        let cert_sig_bytes = signing_cert.signature.as_bytes().ok_or_else(|| {
+            EnclaveError::Certificate("missing signature bytes on signing cert".into())
+        })?;
+        let cert_signature = Signature::from_der(cert_sig_bytes)
+            .map_err(|e| EnclaveError::Certificate(format!("invalid signature: {e}")))?;
+
+        issuer_pubkey
+            .verify(&tbs_bytes, &cert_signature)
+            .map_err(|_| EnclaveError::Certificate("signing certificate not issued by CA".into()))?;
+
+        let mut certs = Vec::with_capacity(cabundle.len());
+        for cert_der in cabundle {
+            let cert = Certificate::from_der(cert_der)
+                .map_err(|e| EnclaveError::Certificate(format!("failed to parse cert: {e}")))?;
+            verify_cert_validity(&cert)?;
+            certs.push(cert);
+        }
+
+        for i in 0..certs.len().saturating_sub(1) {
+            let subject = &certs[i];
+            let issuer = &certs[i + 1];
+
+            let issuer_pubkey = extract_p384_pubkey(issuer)?;
+            let tbs_bytes = subject
+                .tbs_certificate
+                .to_der()
+                .map_err(|e| EnclaveError::Certificate(format!("DER encode failed: {e}")))?;
+
+            let sig_bytes = subject
+                .signature
+                .as_bytes()
+                .ok_or_else(|| EnclaveError::Certificate("missing signature bytes".into()))?;
+
+            let signature = Signature::from_der(sig_bytes)
+                .map_err(|e| EnclaveError::Certificate(format!("invalid signature: {e}")))?;
+
+            issuer_pubkey
+                .verify(&tbs_bytes, &signature)
+                .map_err(|_| EnclaveError::Certificate("certificate signature invalid".into()))?;
+        }
+
+        let chain_root = certs
+            .last()
+            .ok_or_else(|| EnclaveError::Certificate("empty certificate chain".into()))?;
+
+        let chain_root_der = chain_root
+            .to_der()
+            .map_err(|e| EnclaveError::Certificate(format!("DER encode failed: {e}")))?;
+        let expected_root_der = root_cert
+            .to_der()
+            .map_err(|e| EnclaveError::Certificate(format!("DER encode failed: {e}")))?;
+
+        if chain_root_der != expected_root_der {
+            return Err(EnclaveError::Certificate(
+                "certificate chain does not terminate at AWS Nitro root CA".into(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn extract_p384_pubkey(cert: &Certificate) -> Result<VerifyingKey> {
+        let spki = &cert.tbs_certificate.subject_public_key_info;
+        let key_bytes = spki
+            .subject_public_key
+            .as_bytes()
+            .ok_or_else(|| EnclaveError::Certificate("missing public key bytes".into()))?;
+
+        VerifyingKey::from_sec1_bytes(key_bytes)
+            .map_err(|e| EnclaveError::Certificate(format!("invalid P-384 key: {e}")))
+    }
+
+    fn verify_cert_validity(cert: &Certificate) -> Result<()> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| EnclaveError::Certificate("system clock error".into()))?
+            .as_secs();
+
+        let validity = &cert.tbs_certificate.validity;
+        let not_before = validity.not_before.to_unix_duration().as_secs();
+        let not_after = validity.not_after.to_unix_duration().as_secs();
+
+        if now < not_before {
+            return Err(EnclaveError::Certificate("certificate not yet valid".into()));
+        }
+        if now > not_after {
+            return Err(EnclaveError::Certificate("certificate has expired".into()));
+        }
+        Ok(())
+    }
+
+    pub(super) struct CoseSign1 {
+        protected: Vec<u8>,
+        _unprotected: ciborium::Value,
+        pub payload: Option<Vec<u8>>,
+        pub signature: Vec<u8>,
+    }
+
+    impl CoseSign1 {
+        pub fn from_bytes(data: &[u8]) -> Result<Self> {
+            let value: ciborium::Value = ciborium::from_reader(data)
+                .map_err(|e| EnclaveError::Attestation(format!("invalid CBOR: {e}")))?;
+
+            let arr = value
+                .as_array()
+                .ok_or_else(|| EnclaveError::Attestation("COSE_Sign1 must be array".into()))?;
+            if arr.len() != 4 {
+                return Err(EnclaveError::Attestation(
+                    "COSE_Sign1 must have 4 elements".into(),
+                ));
+            }
+
+            let protected = arr[0]
+                .as_bytes()
+                .ok_or_else(|| EnclaveError::Attestation("invalid protected header".into()))?
+                .clone();
+            let unprotected = arr[1].clone();
+            let payload = if arr[2].is_null() {
+                None
+            } else {
+                Some(
+                    arr[2]
+                        .as_bytes()
+                        .ok_or_else(|| EnclaveError::Attestation("invalid payload".into()))?
+                        .clone(),
+                )
+            };
+            let signature = arr[3]
+                .as_bytes()
+                .ok_or_else(|| EnclaveError::Attestation("invalid signature".into()))?
+                .clone();
+
+            Ok(Self {
+                protected,
+                _unprotected: unprotected,
+                payload,
+                signature,
+            })
+        }
+
+        pub fn sig_structure(&self) -> Result<Vec<u8>> {
+            let structure = ciborium::Value::Array(vec![
+                ciborium::Value::Text("Signature1".into()),
+                ciborium::Value::Bytes(self.protected.clone()),
+                ciborium::Value::Bytes(vec![]),
+                ciborium::Value::Bytes(self.payload.clone().unwrap_or_default()),
+            ]);
+
+            let mut buf = Vec::new();
+            ciborium::into_writer(&structure, &mut buf).map_err(|e| {
+                EnclaveError::Attestation(format!("failed to encode sig structure: {e}"))
+            })?;
+            Ok(buf)
+        }
+    }
+
+    // NSM self-attestation (Linux only).
+    #[cfg(target_os = "linux")]
+    pub(super) fn request_nsm_attestation(
+        nonce: &[u8; 32],
+        public_key: Option<&[u8]>,
+        user_data: Option<&[u8]>,
+    ) -> Result<Vec<u8>> {
+        use aws_nitro_enclaves_nsm_api::api::{Request, Response};
+        use aws_nitro_enclaves_nsm_api::driver::{nsm_exit, nsm_init, nsm_process_request};
+
+        let fd = nsm_init();
+        if fd < 0 {
+            return Err(EnclaveError::Attestation(
+                "failed to initialize NSM".into(),
+            ));
+        }
+
+        let request = Request::Attestation {
+            user_data: user_data.map(|d| d.to_vec().into()),
+            nonce: Some(nonce.to_vec().into()),
+            public_key: public_key.map(|p| p.to_vec().into()),
+        };
+
+        let response = nsm_process_request(fd, request);
+        nsm_exit(fd);
+
+        match response {
+            Response::Attestation { document } => Ok(document),
+            Response::Error(e) => Err(EnclaveError::Attestation(format!(
+                "NSM attestation failed: {:?}",
+                e
+            ))),
+            _ => Err(EnclaveError::Attestation(
+                "unexpected NSM response".into(),
+            )),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(super) fn read_own_pcrs() -> Result<ExpectedPcrs> {
+        use aws_nitro_enclaves_nsm_api::api::{Request, Response};
+        use aws_nitro_enclaves_nsm_api::driver::{nsm_exit, nsm_init, nsm_process_request};
+
+        let fd = nsm_init();
+        if fd < 0 {
+            return Err(EnclaveError::Attestation(
+                "failed to initialize NSM".into(),
+            ));
+        }
+
+        let mut read = |index: u16| -> Result<[u8; 48]> {
+            let response = nsm_process_request(fd, Request::DescribePCR { index });
+            match response {
+                Response::DescribePCR { lock: _, data } => data
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| EnclaveError::Attestation(format!("PCR{index} wrong length"))),
+                Response::Error(e) => Err(EnclaveError::Attestation(format!(
+                    "PCR{index} read failed: {:?}",
+                    e
+                ))),
+                _ => Err(EnclaveError::Attestation(format!(
+                    "PCR{index} unexpected NSM response",
+                ))),
+            }
+        };
+
+        let pcr0 = read(0)?;
+        let pcr1 = read(1)?;
+        let pcr2 = read(2)?;
+        nsm_exit(fd);
+        Ok(ExpectedPcrs::new(pcr0, pcr1, pcr2))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub(super) fn request_nsm_attestation(
+        _nonce: &[u8; 32],
+        _public_key: Option<&[u8]>,
+        _user_data: Option<&[u8]>,
+    ) -> Result<Vec<u8>> {
+        Err(EnclaveError::Attestation(
+            "NSM not available on this platform".into(),
+        ))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    pub(super) fn read_own_pcrs() -> Result<ExpectedPcrs> {
+        Err(EnclaveError::Attestation(
+            "NSM not available on this platform".into(),
+        ))
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Mock path (raw CBOR, no COSE / cert chain)
+// ----------------------------------------------------------------------------
+
+#[cfg(feature = "mock-attestation")]
+mod mock {
+    use super::*;
+
+    pub(super) fn build_mock_document(
+        nonce: &[u8; 32],
+        public_key: Option<&[u8]>,
+        user_data: Option<&[u8]>,
+    ) -> Result<Vec<u8>> {
+        let mut pcrs = HashMap::new();
+        pcrs.insert(0, vec![0u8; 48]);
+        pcrs.insert(1, vec![0u8; 48]);
+        pcrs.insert(2, vec![0u8; 48]);
+
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        let doc = AttestationDocument {
+            module_id: "mock".into(),
+            timestamp,
+            digest: "SHA384".into(),
+            pcrs,
+            certificate: Vec::new(),
+            cabundle: Vec::new(),
+            public_key: public_key.map(|p| p.to_vec()),
+            user_data: user_data.map(|d| d.to_vec()),
+            nonce: Some(nonce.to_vec()),
+        };
+
+        let mut buf = Vec::new();
+        ciborium::into_writer(&doc, &mut buf).map_err(|e| {
+            EnclaveError::Attestation(format!("failed to encode mock doc: {e}"))
+        })?;
+        Ok(buf)
+    }
+
+    pub(super) fn verify_mock_document(
+        doc: &[u8],
+        expected_pcrs: &ExpectedPcrs,
+        expected_nonce: &[u8; 32],
+    ) -> Result<VerifiedAttestation> {
+        let attestation: AttestationDocument = ciborium::from_reader(doc)
+            .map_err(|e| EnclaveError::Attestation(format!("failed to parse mock doc: {e}")))?;
+
+        let nonce = check_nonce(&attestation.nonce, expected_nonce)?;
+        verify_pcrs(&attestation.pcrs, expected_pcrs)?;
+
+        let enclave_pubkey = attestation
+            .public_key
+            .ok_or_else(|| EnclaveError::Attestation("missing public key".into()))?;
+
+        Ok(VerifiedAttestation {
+            enclave_pubkey,
+            pcrs: attestation.pcrs,
+            timestamp: attestation.timestamp,
+            user_data: attestation.user_data,
+            nonce,
+        })
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expected_pcrs_from_hex_roundtrip() {
+        let pcr0 = "00".repeat(48);
+        let pcr1 = "11".repeat(48);
+        let pcr2 = "22".repeat(48);
+        let pcrs = ExpectedPcrs::from_hex(&pcr0, &pcr1, &pcr2).unwrap();
+        assert_eq!(pcrs.pcr0[0], 0x00);
+        assert_eq!(pcrs.pcr1[0], 0x11);
+        assert_eq!(pcrs.pcr2[47], 0x22);
+    }
+
+    #[test]
+    fn expected_pcrs_from_hex_bad_length() {
+        assert!(ExpectedPcrs::from_hex("ab", "cd", "ef").is_err());
+    }
+
+    #[test]
+    fn expected_pcrs_from_hex_invalid_chars() {
+        let bad = "zz".repeat(48);
+        assert!(ExpectedPcrs::from_hex(&bad, &bad, &bad).is_err());
+    }
+
+    #[cfg(feature = "mock-attestation")]
+    mod mock_flow {
+        use super::*;
+
+        #[test]
+        fn mock_roundtrip_happy_path() {
+            let nonce = [7u8; 32];
+            let pubkey = [1u8; 32];
+            let doc = get_attestation(&nonce, Some(&pubkey), Some(b"user")).unwrap();
+
+            let verified = verify_peer_attestation(&doc, &ExpectedPcrs::zero(), &nonce).unwrap();
+
+            assert_eq!(verified.enclave_pubkey, pubkey.to_vec());
+            assert_eq!(verified.user_data.as_deref(), Some(b"user".as_ref()));
+            assert_eq!(verified.nonce, nonce.to_vec());
+            assert_eq!(verified.pcrs.get(&0).unwrap().len(), 48);
+        }
+
+        #[test]
+        fn mock_reject_nonce_mismatch() {
+            let nonce = [1u8; 32];
+            let other = [2u8; 32];
+            let doc = get_attestation(&nonce, Some(&[0u8; 32]), None).unwrap();
+            let err = verify_peer_attestation(&doc, &ExpectedPcrs::zero(), &other).unwrap_err();
+            assert!(matches!(err, EnclaveError::Attestation(_)));
+        }
+
+        #[test]
+        fn mock_reject_pcr_mismatch() {
+            let nonce = [3u8; 32];
+            let doc = get_attestation(&nonce, Some(&[0u8; 32]), None).unwrap();
+            let expected = ExpectedPcrs::new([1u8; 48], [0u8; 48], [0u8; 48]);
+            let err = verify_peer_attestation(&doc, &expected, &nonce).unwrap_err();
+            assert!(matches!(
+                err,
+                EnclaveError::PcrMismatch { pcr: 0, .. }
+            ));
+        }
+
+        #[test]
+        fn mock_reject_missing_pubkey() {
+            let nonce = [4u8; 32];
+            let doc = get_attestation(&nonce, None, None).unwrap();
+            let err = verify_peer_attestation(&doc, &ExpectedPcrs::zero(), &nonce).unwrap_err();
+            assert!(matches!(err, EnclaveError::Attestation(_)));
+        }
+
+        #[test]
+        fn mock_reject_corrupted_doc() {
+            let err =
+                verify_peer_attestation(&[0xffu8; 16], &ExpectedPcrs::zero(), &[0u8; 32])
+                    .unwrap_err();
+            assert!(matches!(err, EnclaveError::Attestation(_)));
+        }
+
+        #[test]
+        fn get_own_pcrs_mock_returns_zero() {
+            let pcrs = get_own_pcrs().unwrap();
+            assert_eq!(pcrs.pcr0, [0u8; 48]);
+            assert_eq!(pcrs.pcr1, [0u8; 48]);
+            assert_eq!(pcrs.pcr2, [0u8; 48]);
+        }
+    }
+}

--- a/enclave/src/attestation.rs
+++ b/enclave/src/attestation.rs
@@ -533,7 +533,7 @@ IwLz3/Y=
             return Err(EnclaveError::Attestation("failed to initialize NSM".into()));
         }
 
-        let mut read = |index: u16| -> Result<[u8; 48]> {
+        let read = |index: u16| -> Result<[u8; 48]> {
             let response = nsm_process_request(fd, Request::DescribePCR { index });
             match response {
                 Response::DescribePCR { lock: _, data } => data

--- a/enclave/src/attestation.rs
+++ b/enclave/src/attestation.rs
@@ -125,8 +125,7 @@ pub fn get_attestation(
     {
         let _ = (nonce, public_key, user_data);
         Err(EnclaveError::Attestation(
-            "attestation not available: build for Linux with NSM or enable mock-attestation"
-                .into(),
+            "attestation not available: build for Linux with NSM or enable mock-attestation".into(),
         ))
     }
 }
@@ -184,10 +183,7 @@ pub fn verify_peer_attestation(
 // Shared helpers
 // ----------------------------------------------------------------------------
 
-fn verify_pcrs(
-    pcrs: &HashMap<u32, Vec<u8>>,
-    expected: &ExpectedPcrs,
-) -> Result<()> {
+fn verify_pcrs(pcrs: &HashMap<u32, Vec<u8>>, expected: &ExpectedPcrs) -> Result<()> {
     let check = |idx: u32, expected_bytes: &[u8; 48]| -> Result<()> {
         let actual = pcrs
             .get(&idx)
@@ -228,10 +224,14 @@ mod real {
     use base64::engine::general_purpose::STANDARD as BASE64;
     use base64::Engine;
     use p384::ecdsa::{signature::Verifier, Signature, VerifyingKey};
+    use std::sync::OnceLock;
     use std::time::{SystemTime, UNIX_EPOCH};
     use x509_cert::der::{Decode, Encode};
     use x509_cert::Certificate;
 
+    // AWS Nitro Enclave root CA. Source:
+    // https://docs.aws.amazon.com/enclaves/latest/user/verify-root.html
+    // Self-signed, P-384, ECDSA-SHA384, valid 2019-10-28 .. 2049-10-28.
     const AWS_NITRO_ROOT_CERT_PEM: &str = r#"-----BEGIN CERTIFICATE-----
 MIICETCCAZagAwIBAgIRAPkxdWgbkK/hHUbMtOTn+FYwCgYIKoZIzj0EAwMwSTEL
 MAkGA1UEBhMCVVMxDzANBgNVBAoMBkFtYXpvbjEMMAoGA1UECwwDQVdTMRswGQYD
@@ -247,13 +247,19 @@ rfMCMQCi85sWBbJwKKXdS6BptQFuZbT73o/gBh1qUxl/nNr12UO8Yfwr6wPLb+6N
 IwLz3/Y=
 -----END CERTIFICATE-----"#;
 
-    fn parse_pem_cert(pem: &str) -> Certificate {
-        let lines: Vec<&str> = pem.lines().filter(|l| !l.starts_with("-----")).collect();
-        let b64 = lines.join("");
-        let der = BASE64
-            .decode(&b64)
-            .expect("invalid base64 in embedded root cert");
-        Certificate::from_der(&der).expect("invalid DER in embedded root cert")
+    /// DER bytes of the embedded root cert. Parsed once and compared to
+    /// `cabundle[0]` bytewise on every verify.
+    fn root_cert_der() -> &'static [u8] {
+        static ROOT: OnceLock<Vec<u8>> = OnceLock::new();
+        ROOT.get_or_init(|| {
+            let lines: Vec<&str> = AWS_NITRO_ROOT_CERT_PEM
+                .lines()
+                .filter(|l| !l.starts_with("-----"))
+                .collect();
+            BASE64
+                .decode(lines.join(""))
+                .expect("invalid base64 in embedded root cert")
+        })
     }
 
     pub(super) fn verify_real_document(
@@ -261,8 +267,6 @@ IwLz3/Y=
         expected_pcrs: &ExpectedPcrs,
         expected_nonce: &[u8; 32],
     ) -> Result<VerifiedAttestation> {
-        let root_cert = parse_pem_cert(AWS_NITRO_ROOT_CERT_PEM);
-
         let cose = CoseSign1::from_bytes(doc)?;
         let payload = cose
             .payload
@@ -272,12 +276,7 @@ IwLz3/Y=
         let attestation: AttestationDocument = ciborium::from_reader(payload.as_slice())
             .map_err(|e| EnclaveError::Attestation(format!("failed to parse attestation: {e}")))?;
 
-        verify_certificate_chain(
-            &attestation.certificate,
-            &attestation.cabundle,
-            &cose,
-            &root_cert,
-        )?;
+        verify_certificate_chain(&attestation.certificate, &attestation.cabundle, &cose)?;
 
         let nonce = check_nonce(&attestation.nonce, expected_nonce)?;
         verify_pcrs(&attestation.pcrs, expected_pcrs)?;
@@ -295,100 +294,102 @@ IwLz3/Y=
         })
     }
 
+    /// Parse and verify the attestation certificate chain.
+    ///
+    /// AWS Nitro cabundle ordering (per the Nitro Enclaves User Guide):
+    ///   cabundle[0]      = AWS Nitro root CA (must match our hardcoded root)
+    ///   cabundle[1..N-1] = intermediate CAs
+    ///   cabundle[N-1]    = direct issuer of `signing_cert`
+    ///   signing_cert     = end-entity cert that signed the COSE envelope
+    ///
+    /// We verify, in order:
+    ///   1. cabundle is non-empty and cabundle[0] bytes == embedded AWS root.
+    ///   2. Each cabundle[i] signs cabundle[i+1].
+    ///   3. cabundle[last] signs signing_cert.
+    ///   4. Every cert is inside its validity window.
+    ///   5. signing_cert's P-384 pubkey verifies the COSE signature over
+    ///      Sig_structure1. Per RFC 8152 §8.1, the COSE signature is a
+    ///      fixed-width raw `r || s` (96 bytes for P-384), *not* DER.
     fn verify_certificate_chain(
         signing_cert_der: &[u8],
         cabundle: &[Vec<u8>],
         cose: &CoseSign1,
-        root_cert: &Certificate,
     ) -> Result<()> {
-        let signing_cert = Certificate::from_der(signing_cert_der).map_err(|e| {
-            EnclaveError::Certificate(format!("failed to parse signing cert: {e}"))
-        })?;
-        verify_cert_validity(&signing_cert)?;
-
-        let signing_pubkey = extract_p384_pubkey(&signing_cert)?;
-        let sig_bytes = cose.signature.as_slice();
-        let signature = Signature::from_der(sig_bytes)
-            .map_err(|e| EnclaveError::Attestation(format!("invalid COSE signature: {e}")))?;
-
-        let to_verify = cose.sig_structure()?;
-        signing_pubkey
-            .verify(&to_verify, &signature)
-            .map_err(|_| EnclaveError::Attestation("COSE signature verification failed".into()))?;
-
         if cabundle.is_empty() {
-            return Err(EnclaveError::Attestation("empty certificate bundle".into()));
+            return Err(EnclaveError::Certificate("empty certificate bundle".into()));
         }
 
-        let issuer_cert = Certificate::from_der(&cabundle[0])
-            .map_err(|e| EnclaveError::Certificate(format!("failed to parse issuer cert: {e}")))?;
-        verify_cert_validity(&issuer_cert)?;
-
-        let issuer_pubkey = extract_p384_pubkey(&issuer_cert)?;
-        let tbs_bytes = signing_cert
-            .tbs_certificate
-            .to_der()
-            .map_err(|e| EnclaveError::Certificate(format!("DER encode failed: {e}")))?;
-
-        let cert_sig_bytes = signing_cert.signature.as_bytes().ok_or_else(|| {
-            EnclaveError::Certificate("missing signature bytes on signing cert".into())
-        })?;
-        let cert_signature = Signature::from_der(cert_sig_bytes)
-            .map_err(|e| EnclaveError::Certificate(format!("invalid signature: {e}")))?;
-
-        issuer_pubkey
-            .verify(&tbs_bytes, &cert_signature)
-            .map_err(|_| EnclaveError::Certificate("signing certificate not issued by CA".into()))?;
-
-        let mut certs = Vec::with_capacity(cabundle.len());
-        for cert_der in cabundle {
-            let cert = Certificate::from_der(cert_der)
-                .map_err(|e| EnclaveError::Certificate(format!("failed to parse cert: {e}")))?;
-            verify_cert_validity(&cert)?;
-            certs.push(cert);
-        }
-
-        for i in 0..certs.len().saturating_sub(1) {
-            let subject = &certs[i];
-            let issuer = &certs[i + 1];
-
-            let issuer_pubkey = extract_p384_pubkey(issuer)?;
-            let tbs_bytes = subject
-                .tbs_certificate
-                .to_der()
-                .map_err(|e| EnclaveError::Certificate(format!("DER encode failed: {e}")))?;
-
-            let sig_bytes = subject
-                .signature
-                .as_bytes()
-                .ok_or_else(|| EnclaveError::Certificate("missing signature bytes".into()))?;
-
-            let signature = Signature::from_der(sig_bytes)
-                .map_err(|e| EnclaveError::Certificate(format!("invalid signature: {e}")))?;
-
-            issuer_pubkey
-                .verify(&tbs_bytes, &signature)
-                .map_err(|_| EnclaveError::Certificate("certificate signature invalid".into()))?;
-        }
-
-        let chain_root = certs
-            .last()
-            .ok_or_else(|| EnclaveError::Certificate("empty certificate chain".into()))?;
-
-        let chain_root_der = chain_root
-            .to_der()
-            .map_err(|e| EnclaveError::Certificate(format!("DER encode failed: {e}")))?;
-        let expected_root_der = root_cert
-            .to_der()
-            .map_err(|e| EnclaveError::Certificate(format!("DER encode failed: {e}")))?;
-
-        if chain_root_der != expected_root_der {
+        // 1. Root anchor: bytewise compare to our hardcoded AWS Nitro root.
+        if cabundle[0].as_slice() != root_cert_der() {
             return Err(EnclaveError::Certificate(
-                "certificate chain does not terminate at AWS Nitro root CA".into(),
+                "cabundle[0] is not the AWS Nitro root CA".into(),
             ));
         }
 
+        // Parse every cabundle cert + signing cert, checking validity windows.
+        let mut chain = Vec::with_capacity(cabundle.len() + 1);
+        for (i, cert_der) in cabundle.iter().enumerate() {
+            let cert = Certificate::from_der(cert_der).map_err(|e| {
+                EnclaveError::Certificate(format!("failed to parse cabundle[{i}]: {e}"))
+            })?;
+            verify_cert_validity(&cert)?;
+            chain.push(cert);
+        }
+        let signing_cert = Certificate::from_der(signing_cert_der)
+            .map_err(|e| EnclaveError::Certificate(format!("failed to parse signing cert: {e}")))?;
+        verify_cert_validity(&signing_cert)?;
+        chain.push(signing_cert);
+
+        // 2-3. Walk: chain[i] issues chain[i+1]. The root is self-signed
+        // and has already been anchored by byte-equality with our hardcoded
+        // copy, so we don't re-verify chain[0].
+        for i in 0..chain.len() - 1 {
+            verify_issuer_signed_subject(&chain[i], &chain[i + 1])?;
+        }
+
+        // 5. COSE signature verification using signing cert's pubkey.
+        let signing_pubkey = extract_p384_pubkey(chain.last().expect("non-empty"))?;
+        let cose_sig = parse_cose_ecdsa_signature(&cose.signature)?;
+        let to_verify = cose.sig_structure()?;
+        signing_pubkey
+            .verify(&to_verify, &cose_sig)
+            .map_err(|_| EnclaveError::Attestation("COSE signature verification failed".into()))?;
+
         Ok(())
+    }
+
+    fn verify_issuer_signed_subject(issuer: &Certificate, subject: &Certificate) -> Result<()> {
+        let issuer_pubkey = extract_p384_pubkey(issuer)?;
+        let tbs_bytes = subject
+            .tbs_certificate
+            .to_der()
+            .map_err(|e| EnclaveError::Certificate(format!("TBS DER encode failed: {e}")))?;
+        let sig_bytes = subject
+            .signature
+            .as_bytes()
+            .ok_or_else(|| EnclaveError::Certificate("missing signature bytes".into()))?;
+        // X.509 cert signatures are DER-encoded ECDSA (unlike COSE).
+        let signature = Signature::from_der(sig_bytes)
+            .map_err(|e| EnclaveError::Certificate(format!("invalid cert signature: {e}")))?;
+        issuer_pubkey
+            .verify(&tbs_bytes, &signature)
+            .map_err(|_| EnclaveError::Certificate("certificate signature invalid".into()))
+    }
+
+    /// RFC 8152 §8.1 mandates raw `r || s` (96 bytes for P-384). We accept
+    /// a DER fallback defensively in case a document source deviates.
+    fn parse_cose_ecdsa_signature(sig_bytes: &[u8]) -> Result<Signature> {
+        if sig_bytes.len() == 96 {
+            Signature::try_from(sig_bytes)
+                .map_err(|e| EnclaveError::Attestation(format!("invalid COSE raw signature: {e}")))
+        } else {
+            Signature::from_der(sig_bytes).map_err(|e| {
+                EnclaveError::Attestation(format!(
+                    "invalid COSE signature ({} bytes, not raw P-384 r||s or DER): {e}",
+                    sig_bytes.len()
+                ))
+            })
+        }
     }
 
     fn extract_p384_pubkey(cert: &Certificate) -> Result<VerifyingKey> {
@@ -413,7 +414,9 @@ IwLz3/Y=
         let not_after = validity.not_after.to_unix_duration().as_secs();
 
         if now < not_before {
-            return Err(EnclaveError::Certificate("certificate not yet valid".into()));
+            return Err(EnclaveError::Certificate(
+                "certificate not yet valid".into(),
+            ));
         }
         if now > not_after {
             return Err(EnclaveError::Certificate("certificate has expired".into()));
@@ -498,9 +501,7 @@ IwLz3/Y=
 
         let fd = nsm_init();
         if fd < 0 {
-            return Err(EnclaveError::Attestation(
-                "failed to initialize NSM".into(),
-            ));
+            return Err(EnclaveError::Attestation("failed to initialize NSM".into()));
         }
 
         let request = Request::Attestation {
@@ -518,9 +519,7 @@ IwLz3/Y=
                 "NSM attestation failed: {:?}",
                 e
             ))),
-            _ => Err(EnclaveError::Attestation(
-                "unexpected NSM response".into(),
-            )),
+            _ => Err(EnclaveError::Attestation("unexpected NSM response".into())),
         }
     }
 
@@ -531,9 +530,7 @@ IwLz3/Y=
 
         let fd = nsm_init();
         if fd < 0 {
-            return Err(EnclaveError::Attestation(
-                "failed to initialize NSM".into(),
-            ));
+            return Err(EnclaveError::Attestation("failed to initialize NSM".into()));
         }
 
         let mut read = |index: u16| -> Result<[u8; 48]> {
@@ -615,9 +612,8 @@ mod mock {
         };
 
         let mut buf = Vec::new();
-        ciborium::into_writer(&doc, &mut buf).map_err(|e| {
-            EnclaveError::Attestation(format!("failed to encode mock doc: {e}"))
-        })?;
+        ciborium::into_writer(&doc, &mut buf)
+            .map_err(|e| EnclaveError::Attestation(format!("failed to encode mock doc: {e}")))?;
         Ok(buf)
     }
 
@@ -709,10 +705,7 @@ mod tests {
             let doc = get_attestation(&nonce, Some(&[0u8; 32]), None).unwrap();
             let expected = ExpectedPcrs::new([1u8; 48], [0u8; 48], [0u8; 48]);
             let err = verify_peer_attestation(&doc, &expected, &nonce).unwrap_err();
-            assert!(matches!(
-                err,
-                EnclaveError::PcrMismatch { pcr: 0, .. }
-            ));
+            assert!(matches!(err, EnclaveError::PcrMismatch { pcr: 0, .. }));
         }
 
         #[test]
@@ -725,9 +718,8 @@ mod tests {
 
         #[test]
         fn mock_reject_corrupted_doc() {
-            let err =
-                verify_peer_attestation(&[0xffu8; 16], &ExpectedPcrs::zero(), &[0u8; 32])
-                    .unwrap_err();
+            let err = verify_peer_attestation(&[0xffu8; 16], &ExpectedPcrs::zero(), &[0u8; 32])
+                .unwrap_err();
             assert!(matches!(err, EnclaveError::Attestation(_)));
         }
 

--- a/enclave/src/error.rs
+++ b/enclave/src/error.rs
@@ -68,7 +68,7 @@ impl EnclaveError {
     /// Map error to a proto error code.
     pub fn error_code(&self) -> u32 {
         match self {
-            EnclaveError::CrossCheck(_) => 3, // ERROR_CODE_VALIDATION_FAILED
+            EnclaveError::CrossCheck(_) => 3,   // ERROR_CODE_VALIDATION_FAILED
             EnclaveError::NotReady { .. } => 2, // ERROR_CODE_NOT_READY
             _ => 1,
         }

--- a/enclave/src/error.rs
+++ b/enclave/src/error.rs
@@ -31,6 +31,37 @@ pub enum EnclaveError {
 
     #[error("internal error: {0}")]
     Internal(String),
+
+    #[error("not ready: enclave is in {state} state")]
+    NotReady { state: String },
+
+    #[error("attestation error: {0}")]
+    Attestation(String),
+
+    #[error("certificate error: {0}")]
+    Certificate(String),
+
+    #[error("clone failed: {0}")]
+    Clone(String),
+
+    #[error("PCR mismatch: PCR{pcr} expected={expected}, actual={actual}")]
+    PcrMismatch {
+        pcr: u32,
+        expected: String,
+        actual: String,
+    },
+
+    #[error("nonce replay detected")]
+    NonceReplay,
+
+    #[error("cloning digest mismatch")]
+    DigestMismatch,
+
+    #[error("pubkey mismatch: attestation pubkey does not match claimed pubkey")]
+    PubkeyMismatch,
+
+    #[error("identity mismatch: cloned seed does not derive to expected address")]
+    IdentityMismatch,
 }
 
 impl EnclaveError {
@@ -38,6 +69,7 @@ impl EnclaveError {
     pub fn error_code(&self) -> u32 {
         match self {
             EnclaveError::CrossCheck(_) => 3, // ERROR_CODE_VALIDATION_FAILED
+            EnclaveError::NotReady { .. } => 2, // ERROR_CODE_NOT_READY
             _ => 1,
         }
     }

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(unsafe_code)]
 
+pub mod attestation;
 pub mod error;
 pub mod framing;
 pub mod keys;


### PR DESCRIPTION
Second PR of the cloning + attestation series (T5). **Self-contained module** — not yet wired into the server (PR 4 does that).

Port of the keep-enclave host-side verifier, adapted for in-enclave use: our enclave verifies peer enclaves' attestation documents *and* generates its own via NSM.

## API
\`\`\`rust
// Generate our own attestation binding a nonce + ephemeral pubkey + user data.
pub fn get_attestation(nonce: &[u8; 32], public_key: Option<&[u8]>, user_data: Option<&[u8]>) -> Result<Vec<u8>>;

// Read our own PCR0/1/2 at startup (cached by caller).
pub fn get_own_pcrs() -> Result<ExpectedPcrs>;

// Verify a peer's document: COSE signature, cert chain, validity, PCRs, nonce.
pub fn verify_peer_attestation(doc: &[u8], expected: &ExpectedPcrs, nonce: &[u8; 32]) -> Result<VerifiedAttestation>;
\`\`\`

## Real path (Linux + default features)
- CBOR -> COSE_Sign1 parse (4-element array)
- P-384 ECDSA verify of the COSE \`Sig_structure1 = ["Signature1", protected, b"", payload]\`
- Certificate chain walk: signing cert → \`cabundle[0]\` → \`cabundle[..]\` → hardcoded AWS Nitro root CA
- \`not_before <= now <= not_after\` on every cert
- PCR0/1/2 compare, nonce compare
- NSM device access via \`aws-nitro-enclaves-nsm-api\` (\`Request::Attestation\`, \`Request::DescribePCR\`)

## Mock path (\`mock-attestation\` feature)
- No COSE wrapping, no cert chain, no NSM.
- \`AttestationDocument\` is encoded/decoded as raw CBOR.
- PCR, nonce, and pubkey binding are still enforced, so tests still catch forgery.
- The feature is test-only; documentation warns against enabling in production.

## Dependencies added
\`\`\`
ciborium          = \"0.2\"
p384              = { version = \"0.13\", features = [\"ecdsa\", \"pem\"] }
x509-cert         = { version = \"0.2\", features = [\"pem\", \"builder\"] }
der               = { version = \"0.7\", features = [\"alloc\"] }
base64            = \"0.22\"
serde             = { version = \"1\",    features = [\"derive\"] }
# Linux-only:
aws-nitro-enclaves-nsm-api = \"0.4\"
\`\`\`

## Test plan
- [x] \`cargo build\` — clean on macOS and should be clean on Linux (NSM crate gated)
- [x] \`cargo test\` — all 65 existing + 3 attestation smoke tests pass with no features
- [x] \`cargo test --features mock-attestation\` — 71 pass (adds 6 mock-flow tests)
- [x] \`cargo test --features \"mock-attestation,allow-seed-import\"\` — all pass
- [x] Mock unit tests cover: happy-path roundtrip, nonce mismatch, PCR mismatch, missing pubkey, corrupted doc, PCR self-read
- [ ] Reviewer: confirm the hardcoded AWS Nitro root cert PEM matches https://docs.aws.amazon.com/enclaves/latest/user/verify-root.html (it's byte-identical to the one in keep-enclave)

## Note on PR ordering
This branch is off \`dev\` (not stacked on PR 1), so it includes a duplicate of the error variant additions from T5 PR 1. When PR 1 merges first, the rebase will be a no-op; if this one lands first, same in reverse.