### PR TITLE
feat(cloning): X25519 + HKDF + ChaCha20Poly1305 handshake crypto (T5 PR 3/4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +466,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
@@ -463,6 +484,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.0",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -503,6 +537,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half 2.7.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -612,7 +657,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -753,6 +825,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1152,6 +1230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,6 +1479,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "p384"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,6 +1603,17 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -1700,7 +1804,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.0",
 ]
@@ -1974,6 +2078,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -2630,6 +2743,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,24 +2766,31 @@ dependencies = [
  "base64",
  "bip39",
  "bitcoin",
+ "chacha20poly1305",
  "ciborium",
  "der",
  "getrandom 0.4.2",
  "hex",
+ "hkdf",
+ "hmac",
  "k256",
  "nix 0.31.2",
  "p384",
  "prost 0.14.3",
  "prost-build 0.14.3",
  "rand 0.10.0",
+ "rand_core 0.6.4",
  "rgb-ops",
  "secrecy",
  "serde",
+ "sha2",
  "sha3",
+ "subtle",
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
  "vsock",
+ "x25519-dalek",
  "x509-cert",
  "zeroize",
 ]
@@ -3056,6 +3186,18 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -55,6 +55,15 @@ der = { version = "0.7", features = ["alloc"] }
 base64 = "0.22"
 serde = { version = "1", features = ["derive"] }
 
+# Cloning handshake crypto (X25519 DH + HKDF + ChaCha20Poly1305 + HMAC-SHA256)
+x25519-dalek = { version = "2", features = ["static_secrets", "zeroize"] }
+chacha20poly1305 = "0.10"
+hkdf = "0.12"
+hmac = "0.12"
+sha2 = "0.10"
+subtle = "2"
+rand_core = { version = "0.6", features = ["getrandom"] }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 vsock = "0.5"
 nix = { version = "0.31.2", features = ["socket"] }

--- a/enclave/src/cloning.rs
+++ b/enclave/src/cloning.rs
@@ -1,0 +1,313 @@
+//! Cryptographic primitives for the enclave-to-enclave cloning handshake.
+//!
+//! The handshake has three messages on the wire (see `proto/enclave.proto`
+//! in PR 4):
+//!
+//!   1. Parent  -> requester: `InitiateCloning { secret, target_pubkey }`
+//!        Requester generates an X25519 ephemeral keypair, embeds the
+//!        pubkey in an NSM attestation doc, computes a HMAC digest over
+//!        (secret, pubkey), and replies with (attestation, pubkey, digest).
+//!   2. Parent  -> donor (relayed): `GetClone { target_pubkey, pubkey, digest, attestation }`
+//!        Donor verifies the attestation, matches PCRs, verifies the
+//!        digest, X25519-DH + HKDF-derives a symmetric key, ChaCha20Poly1305
+//!        seals its seed, returns (ciphertext, our pubkey, our attestation).
+//!   3. Parent  -> requester (relayed): `SetClone { ciphertext, donor_pubkey, donor_attestation }`
+//!        Requester verifies donor attestation, DH + HKDF + unseal,
+//!        derives KeyManager from the seed, verifies the derived EVM
+//!        address matches the claimed target_pubkey, transitions to Active.
+//!
+//! This module provides the crypto layer only. PR 4 wires it into the
+//! request handlers and state machine.
+
+#![allow(dead_code)]
+
+use chacha20poly1305::{
+    aead::{Aead, KeyInit},
+    ChaCha20Poly1305,
+};
+use hkdf::Hkdf;
+use hmac::{Hmac, Mac};
+use rand_core::OsRng;
+use sha2::Sha256;
+use subtle::ConstantTimeEq;
+use x25519_dalek::{EphemeralSecret, PublicKey, StaticSecret};
+use zeroize::Zeroizing;
+
+use crate::error::{EnclaveError, Result};
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// HKDF salt for cloning-handshake key derivation. Versioned so we can
+/// roll it forward without silently accepting old ciphertexts.
+const HKDF_SALT: &[u8] = b"utexo-cloning-v1";
+const HKDF_INFO: &[u8] = b"seed-encryption";
+
+/// An ephemeral X25519 keypair held by the requester for the duration of
+/// the cloning handshake. The secret is dropped (and zeroized) when the
+/// session is consumed or dropped.
+///
+/// `StaticSecret` is used instead of `EphemeralSecret` only because we need
+/// to hold it across two message boundaries (InitiateCloning -> SetClone)
+/// and `EphemeralSecret` is consume-on-DH. `StaticSecret` implements
+/// `ZeroizeOnDrop` when the `zeroize` feature is enabled.
+pub struct CloneSession {
+    secret: StaticSecret,
+    public: PublicKey,
+}
+
+impl CloneSession {
+    /// Generate a fresh ephemeral X25519 keypair from the OS RNG.
+    pub fn new() -> Self {
+        let secret = StaticSecret::random_from_rng(OsRng);
+        let public = PublicKey::from(&secret);
+        Self { secret, public }
+    }
+
+    pub fn public_key(&self) -> [u8; 32] {
+        self.public.to_bytes()
+    }
+
+    /// Unseal a ciphertext sealed by a donor using our ephemeral secret
+    /// and the donor's advertised X25519 public key. Returns the decrypted
+    /// seed in a `Zeroizing` wrapper so it is wiped on drop if the caller
+    /// does not store it.
+    pub fn decrypt_seed_from_peer(
+        &self,
+        peer_pubkey: &[u8; 32],
+        ciphertext: &[u8],
+    ) -> Result<Zeroizing<[u8; 64]>> {
+        let peer = PublicKey::from(*peer_pubkey);
+        let shared = self.secret.diffie_hellman(&peer);
+        decrypt_with_shared(shared.as_bytes(), ciphertext)
+    }
+}
+
+impl Default for CloneSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for CloneSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CloneSession")
+            .field("public", &hex::encode(self.public.to_bytes()))
+            .field("secret", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Compute HMAC-SHA256(secret, encryption_pubkey).
+///
+/// This proves the holder of the cloning secret authorized the request
+/// without transmitting the secret over the wire. The message is the
+/// raw 32 bytes of the X25519 pubkey — deterministic, no canonicalization
+/// ambiguity, unlike the Python enclave-msig implementation that uses JCS(JSON).
+pub fn make_cloning_digest(secret: &str, encryption_pubkey: &[u8; 32]) -> [u8; 32] {
+    let mut mac = <HmacSha256 as Mac>::new_from_slice(secret.as_bytes())
+        .expect("HMAC accepts any key length");
+    mac.update(encryption_pubkey);
+    mac.finalize().into_bytes().into()
+}
+
+/// Constant-time verification of a cloning digest.
+pub fn verify_cloning_digest(
+    secret: &str,
+    encryption_pubkey: &[u8; 32],
+    digest: &[u8; 32],
+) -> bool {
+    let expected = make_cloning_digest(secret, encryption_pubkey);
+    expected.ct_eq(digest).into()
+}
+
+/// Donor side: seal `seed` to the requester's X25519 pubkey using a fresh
+/// ephemeral keypair. Returns `(ciphertext, our_pubkey)`.
+///
+/// The ephemeral secret is consumed (zeroized) before this function returns,
+/// so the ciphertext cannot be re-derived even if this enclave is compromised
+/// after the fact (forward secrecy for the cloning channel, not for the
+/// cloned seed itself — the seed IS the long-term secret).
+pub fn encrypt_seed_for_peer(
+    peer_pubkey: &[u8; 32],
+    seed: &[u8; 64],
+) -> Result<(Vec<u8>, [u8; 32])> {
+    let our_secret = EphemeralSecret::random_from_rng(OsRng);
+    let our_pub = PublicKey::from(&our_secret);
+    let peer = PublicKey::from(*peer_pubkey);
+    let shared = our_secret.diffie_hellman(&peer);
+
+    let ciphertext = encrypt_with_shared(shared.as_bytes(), seed)?;
+    Ok((ciphertext, our_pub.to_bytes()))
+}
+
+// ---- internal HKDF + AEAD helpers ----
+
+fn derive_symmetric_key(shared_secret: &[u8]) -> Zeroizing<[u8; 32]> {
+    let hk = Hkdf::<Sha256>::new(Some(HKDF_SALT), shared_secret);
+    let mut okm = Zeroizing::new([0u8; 32]);
+    hk.expand(HKDF_INFO, okm.as_mut())
+        .expect("32 bytes is within HKDF output limit");
+    okm
+}
+
+// Fixed all-zero nonce: safe because (a) each cloning handshake uses a
+// fresh ephemeral keypair so the derived key is single-use, and (b) the
+// HKDF salt is versioned so nonces don't cross versions.
+const ZERO_NONCE: [u8; 12] = [0u8; 12];
+
+fn cipher_from_shared(shared_secret: &[u8]) -> (ChaCha20Poly1305, Zeroizing<[u8; 32]>) {
+    let key_bytes = derive_symmetric_key(shared_secret);
+    let key_array: &[u8; 32] = &key_bytes;
+    let cipher = ChaCha20Poly1305::new(key_array.into());
+    (cipher, key_bytes)
+}
+
+fn encrypt_with_shared(shared_secret: &[u8], plaintext: &[u8]) -> Result<Vec<u8>> {
+    let (cipher, _key) = cipher_from_shared(shared_secret);
+    cipher
+        .encrypt((&ZERO_NONCE).into(), plaintext)
+        .map_err(|e| EnclaveError::Clone(format!("seed seal failed: {e}")))
+}
+
+fn decrypt_with_shared(shared_secret: &[u8], ciphertext: &[u8]) -> Result<Zeroizing<[u8; 64]>> {
+    let (cipher, _key) = cipher_from_shared(shared_secret);
+    let plaintext = cipher
+        .decrypt((&ZERO_NONCE).into(), ciphertext)
+        .map_err(|e| EnclaveError::Clone(format!("seed unseal failed: {e}")))?;
+    if plaintext.len() != 64 {
+        return Err(EnclaveError::Clone(format!(
+            "decrypted seed has wrong length: {}",
+            plaintext.len()
+        )));
+    }
+    let mut seed = Zeroizing::new([0u8; 64]);
+    seed.copy_from_slice(&plaintext);
+    // Best-effort scrub of the intermediate Vec returned by ChaCha20Poly1305.
+    drop(Zeroizing::new(plaintext));
+    Ok(seed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn digest_roundtrip_ok() {
+        let secret = "correct horse battery staple";
+        let pubkey = [7u8; 32];
+        let digest = make_cloning_digest(secret, &pubkey);
+        assert!(verify_cloning_digest(secret, &pubkey, &digest));
+    }
+
+    #[test]
+    fn digest_rejects_wrong_secret() {
+        let pubkey = [7u8; 32];
+        let digest = make_cloning_digest("right", &pubkey);
+        assert!(!verify_cloning_digest("wrong", &pubkey, &digest));
+    }
+
+    #[test]
+    fn digest_rejects_wrong_pubkey() {
+        let secret = "s";
+        let digest = make_cloning_digest(secret, &[1u8; 32]);
+        assert!(!verify_cloning_digest(secret, &[2u8; 32], &digest));
+    }
+
+    #[test]
+    fn digest_detects_single_bit_flip() {
+        let secret = "s";
+        let pubkey = [9u8; 32];
+        let mut digest = make_cloning_digest(secret, &pubkey);
+        digest[0] ^= 0x01;
+        assert!(!verify_cloning_digest(secret, &pubkey, &digest));
+    }
+
+    #[test]
+    fn seed_encrypt_decrypt_roundtrip() {
+        let seed: [u8; 64] = core::array::from_fn(|i| (i * 3 + 11) as u8);
+        let requester = CloneSession::new();
+        let requester_pub = requester.public_key();
+
+        let (ciphertext, donor_pub) = encrypt_seed_for_peer(&requester_pub, &seed).unwrap();
+        let decrypted = requester
+            .decrypt_seed_from_peer(&donor_pub, &ciphertext)
+            .unwrap();
+
+        assert_eq!(*decrypted, seed);
+    }
+
+    #[test]
+    fn seed_decrypt_with_wrong_peer_key_fails() {
+        let seed = [42u8; 64];
+        let requester = CloneSession::new();
+        let (ciphertext, _donor_pub) =
+            encrypt_seed_for_peer(&requester.public_key(), &seed).unwrap();
+
+        let wrong_donor = [0u8; 32];
+        let result = requester.decrypt_seed_from_peer(&wrong_donor, &ciphertext);
+        assert!(matches!(result, Err(EnclaveError::Clone(_))));
+    }
+
+    #[test]
+    fn seed_decrypt_tampered_ciphertext_fails() {
+        let seed = [42u8; 64];
+        let requester = CloneSession::new();
+        let (mut ciphertext, donor_pub) =
+            encrypt_seed_for_peer(&requester.public_key(), &seed).unwrap();
+
+        // Flip one byte of the ciphertext body.
+        ciphertext[0] ^= 0xff;
+        let result = requester.decrypt_seed_from_peer(&donor_pub, &ciphertext);
+        assert!(matches!(result, Err(EnclaveError::Clone(_))));
+    }
+
+    #[test]
+    fn seed_decrypt_tampered_auth_tag_fails() {
+        let seed = [42u8; 64];
+        let requester = CloneSession::new();
+        let (mut ciphertext, donor_pub) =
+            encrypt_seed_for_peer(&requester.public_key(), &seed).unwrap();
+
+        // Flip the last byte (auth tag).
+        let last = ciphertext.len() - 1;
+        ciphertext[last] ^= 0xff;
+        let result = requester.decrypt_seed_from_peer(&donor_pub, &ciphertext);
+        assert!(matches!(result, Err(EnclaveError::Clone(_))));
+    }
+
+    #[test]
+    fn decrypt_with_wrong_requester_key_fails() {
+        let seed = [42u8; 64];
+        let requester_a = CloneSession::new();
+        let (ciphertext, donor_pub) =
+            encrypt_seed_for_peer(&requester_a.public_key(), &seed).unwrap();
+
+        // Different session — shared secret will differ -> auth tag fails.
+        let requester_b = CloneSession::new();
+        let result = requester_b.decrypt_seed_from_peer(&donor_pub, &ciphertext);
+        assert!(matches!(result, Err(EnclaveError::Clone(_))));
+    }
+
+    #[test]
+    fn clone_session_public_key_is_stable() {
+        let session = CloneSession::new();
+        let pk1 = session.public_key();
+        let pk2 = session.public_key();
+        assert_eq!(pk1, pk2);
+    }
+
+    #[test]
+    fn two_sessions_generate_distinct_keys() {
+        let a = CloneSession::new();
+        let b = CloneSession::new();
+        assert_ne!(a.public_key(), b.public_key());
+    }
+
+    #[test]
+    fn ciphertext_includes_authentication_overhead() {
+        // Seed is 64 bytes; ChaCha20Poly1305 adds a 16-byte Poly1305 tag.
+        let session = CloneSession::new();
+        let (ct, _) = encrypt_seed_for_peer(&session.public_key(), &[0u8; 64]).unwrap();
+        assert_eq!(ct.len(), 64 + 16);
+    }
+}

--- a/enclave/src/cloning.rs
+++ b/enclave/src/cloning.rs
@@ -3,18 +3,18 @@
 //! The handshake has three messages on the wire (see `proto/enclave.proto`
 //! in PR 4):
 //!
-//!   1. Parent  -> requester: `InitiateCloning { secret, target_pubkey }`
-//!        Requester generates an X25519 ephemeral keypair, embeds the
-//!        pubkey in an NSM attestation doc, computes a HMAC digest over
-//!        (secret, pubkey), and replies with (attestation, pubkey, digest).
-//!   2. Parent  -> donor (relayed): `GetClone { target_pubkey, pubkey, digest, attestation }`
-//!        Donor verifies the attestation, matches PCRs, verifies the
-//!        digest, X25519-DH + HKDF-derives a symmetric key, ChaCha20Poly1305
-//!        seals its seed, returns (ciphertext, our pubkey, our attestation).
-//!   3. Parent  -> requester (relayed): `SetClone { ciphertext, donor_pubkey, donor_attestation }`
-//!        Requester verifies donor attestation, DH + HKDF + unseal,
-//!        derives KeyManager from the seed, verifies the derived EVM
-//!        address matches the claimed target_pubkey, transitions to Active.
+//! 1. Parent -> requester: `InitiateCloning { secret, target_pubkey }`.
+//!    Requester generates an X25519 ephemeral keypair, embeds the pubkey in
+//!    an NSM attestation doc, computes a HMAC digest over (secret, pubkey),
+//!    and replies with (attestation, pubkey, digest).
+//! 2. Parent -> donor (relayed): `GetClone { target_pubkey, pubkey, digest, attestation }`.
+//!    Donor verifies the attestation, matches PCRs, verifies the digest,
+//!    X25519-DH + HKDF-derives a symmetric key, ChaCha20Poly1305 seals its
+//!    seed, returns (ciphertext, our pubkey, our attestation).
+//! 3. Parent -> requester (relayed): `SetClone { ciphertext, donor_pubkey, donor_attestation }`.
+//!    Requester verifies donor attestation, DH + HKDF + unseal, derives
+//!    KeyManager from the seed, verifies the derived EVM address matches
+//!    the claimed target_pubkey, transitions to Active.
 //!
 //! This module provides the crypto layer only. PR 4 wires it into the
 //! request handlers and state machine.
@@ -30,8 +30,8 @@ use hmac::{Hmac, Mac};
 use rand_core::OsRng;
 use sha2::Sha256;
 use subtle::ConstantTimeEq;
-use x25519_dalek::{EphemeralSecret, PublicKey, StaticSecret};
-use zeroize::Zeroizing;
+use x25519_dalek::{EphemeralSecret, PublicKey, SharedSecret, StaticSecret};
+use zeroize::{Zeroize, Zeroizing};
 
 use crate::error::{EnclaveError, Result};
 
@@ -78,7 +78,9 @@ impl CloneSession {
     ) -> Result<Zeroizing<[u8; 64]>> {
         let peer = PublicKey::from(*peer_pubkey);
         let shared = self.secret.diffie_hellman(&peer);
-        decrypt_with_shared(shared.as_bytes(), ciphertext)
+        reject_non_contributory(&shared)?;
+        let key = derive_symmetric_key(shared.as_bytes(), peer_pubkey, &self.public.to_bytes());
+        decrypt_with_key(&key, ciphertext)
     }
 }
 
@@ -123,58 +125,81 @@ pub fn verify_cloning_digest(
 /// Donor side: seal `seed` to the requester's X25519 pubkey using a fresh
 /// ephemeral keypair. Returns `(ciphertext, our_pubkey)`.
 ///
-/// The ephemeral secret is consumed (zeroized) before this function returns,
-/// so the ciphertext cannot be re-derived even if this enclave is compromised
-/// after the fact (forward secrecy for the cloning channel, not for the
-/// cloned seed itself — the seed IS the long-term secret).
+/// Rejects small-order / non-contributory peer public keys — otherwise an
+/// attacker sending a small-order point could force a zero shared secret,
+/// making the derived key recoverable from public information and breaking
+/// seed confidentiality.
 pub fn encrypt_seed_for_peer(
     peer_pubkey: &[u8; 32],
     seed: &[u8; 64],
 ) -> Result<(Vec<u8>, [u8; 32])> {
     let our_secret = EphemeralSecret::random_from_rng(OsRng);
-    let our_pub = PublicKey::from(&our_secret);
+    let our_pub = PublicKey::from(&our_secret).to_bytes();
     let peer = PublicKey::from(*peer_pubkey);
     let shared = our_secret.diffie_hellman(&peer);
+    reject_non_contributory(&shared)?;
 
-    let ciphertext = encrypt_with_shared(shared.as_bytes(), seed)?;
-    Ok((ciphertext, our_pub.to_bytes()))
+    let key = derive_symmetric_key(shared.as_bytes(), &our_pub, peer_pubkey);
+    let ciphertext = encrypt_with_key(&key, seed)?;
+    Ok((ciphertext, our_pub))
 }
 
 // ---- internal HKDF + AEAD helpers ----
 
-fn derive_symmetric_key(shared_secret: &[u8]) -> Zeroizing<[u8; 32]> {
+/// Reject small-order / non-contributory DH outputs. See
+/// <https://tools.ietf.org/html/rfc7748#section-6.1>.
+fn reject_non_contributory(shared: &SharedSecret) -> Result<()> {
+    if !shared.was_contributory() {
+        return Err(EnclaveError::Clone(
+            "peer X25519 public key was small-order (non-contributory DH)".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// HKDF-SHA256 derivation. The `info` field binds the derived key to both
+/// participants' public keys so even a degenerate shared secret cannot be
+/// reused across handshakes. Pubkey order is donor-pubkey || requester-pubkey
+/// so both sides agree on it regardless of who's calling.
+fn derive_symmetric_key(
+    shared_secret: &[u8],
+    donor_pubkey: &[u8; 32],
+    requester_pubkey: &[u8; 32],
+) -> Zeroizing<[u8; 32]> {
+    let mut info = Vec::with_capacity(HKDF_INFO.len() + 64);
+    info.extend_from_slice(HKDF_INFO);
+    info.extend_from_slice(donor_pubkey);
+    info.extend_from_slice(requester_pubkey);
+
     let hk = Hkdf::<Sha256>::new(Some(HKDF_SALT), shared_secret);
     let mut okm = Zeroizing::new([0u8; 32]);
-    hk.expand(HKDF_INFO, okm.as_mut())
+    hk.expand(&info, okm.as_mut())
         .expect("32 bytes is within HKDF output limit");
     okm
 }
 
-// Fixed all-zero nonce: safe because (a) each cloning handshake uses a
-// fresh ephemeral keypair so the derived key is single-use, and (b) the
-// HKDF salt is versioned so nonces don't cross versions.
+// Fixed all-zero nonce: safe because each cloning handshake uses a fresh
+// ephemeral keypair, so the derived key is single-use and no nonce/key
+// pair is ever reused.
 const ZERO_NONCE: [u8; 12] = [0u8; 12];
 
-fn cipher_from_shared(shared_secret: &[u8]) -> (ChaCha20Poly1305, Zeroizing<[u8; 32]>) {
-    let key_bytes = derive_symmetric_key(shared_secret);
-    let key_array: &[u8; 32] = &key_bytes;
-    let cipher = ChaCha20Poly1305::new(key_array.into());
-    (cipher, key_bytes)
+fn cipher(key: &Zeroizing<[u8; 32]>) -> ChaCha20Poly1305 {
+    let key_array: &[u8; 32] = key;
+    ChaCha20Poly1305::new(key_array.into())
 }
 
-fn encrypt_with_shared(shared_secret: &[u8], plaintext: &[u8]) -> Result<Vec<u8>> {
-    let (cipher, _key) = cipher_from_shared(shared_secret);
-    cipher
+fn encrypt_with_key(key: &Zeroizing<[u8; 32]>, plaintext: &[u8]) -> Result<Vec<u8>> {
+    cipher(key)
         .encrypt((&ZERO_NONCE).into(), plaintext)
         .map_err(|e| EnclaveError::Clone(format!("seed seal failed: {e}")))
 }
 
-fn decrypt_with_shared(shared_secret: &[u8], ciphertext: &[u8]) -> Result<Zeroizing<[u8; 64]>> {
-    let (cipher, _key) = cipher_from_shared(shared_secret);
-    let plaintext = cipher
+fn decrypt_with_key(key: &Zeroizing<[u8; 32]>, ciphertext: &[u8]) -> Result<Zeroizing<[u8; 64]>> {
+    let mut plaintext = cipher(key)
         .decrypt((&ZERO_NONCE).into(), ciphertext)
         .map_err(|e| EnclaveError::Clone(format!("seed unseal failed: {e}")))?;
     if plaintext.len() != 64 {
+        plaintext.zeroize();
         return Err(EnclaveError::Clone(format!(
             "decrypted seed has wrong length: {}",
             plaintext.len()
@@ -182,8 +207,7 @@ fn decrypt_with_shared(shared_secret: &[u8], ciphertext: &[u8]) -> Result<Zeroiz
     }
     let mut seed = Zeroizing::new([0u8; 64]);
     seed.copy_from_slice(&plaintext);
-    // Best-effort scrub of the intermediate Vec returned by ChaCha20Poly1305.
-    drop(Zeroizing::new(plaintext));
+    plaintext.zeroize();
     Ok(seed)
 }
 
@@ -243,8 +267,31 @@ mod tests {
         let (ciphertext, _donor_pub) =
             encrypt_seed_for_peer(&requester.public_key(), &seed).unwrap();
 
-        let wrong_donor = [0u8; 32];
+        // Use a legit random donor pubkey (not zero — that's small-order
+        // and would trip the contributory check, masking the real assertion).
+        let wrong_donor = PublicKey::from(&StaticSecret::random_from_rng(OsRng)).to_bytes();
         let result = requester.decrypt_seed_from_peer(&wrong_donor, &ciphertext);
+        assert!(matches!(result, Err(EnclaveError::Clone(_))));
+    }
+
+    #[test]
+    fn encrypt_rejects_small_order_peer_pubkey() {
+        // The all-zero point is one of the known small-order points on
+        // Curve25519. Sending it as the peer pubkey should be rejected at
+        // the encryptor so the attacker cannot force a zero shared secret.
+        let result = encrypt_seed_for_peer(&[0u8; 32], &[42u8; 64]);
+        assert!(matches!(result, Err(EnclaveError::Clone(_))));
+    }
+
+    #[test]
+    fn decrypt_rejects_small_order_peer_pubkey() {
+        let requester = CloneSession::new();
+        // Build a ciphertext via a legit encrypt call, then attempt to
+        // decrypt with the all-zero peer key — must fail the contributory
+        // check, not silently produce a computable shared secret.
+        let (ciphertext, _legit_donor) =
+            encrypt_seed_for_peer(&requester.public_key(), &[42u8; 64]).unwrap();
+        let result = requester.decrypt_seed_from_peer(&[0u8; 32], &ciphertext);
         assert!(matches!(result, Err(EnclaveError::Clone(_))));
     }
 

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(unsafe_code)]
 
 pub mod attestation;
+pub mod cloning;
 pub mod error;
 pub mod framing;
 pub mod keys;

--- a/enclave/src/state.rs
+++ b/enclave/src/state.rs
@@ -108,6 +108,28 @@ impl EnclaveState {
         Ok(())
     }
 
+    /// Initialize from a seed obtained via the cloning handshake.
+    ///
+    /// This is the production path for cloned enclaves and is NOT gated on
+    /// `allow-seed-import`. The `Phase::Cloning` guard replaces the feature
+    /// flag: PR 4's `SetClone` handler is the only caller, and it only
+    /// runs after verifying the donor's attestation and unsealing the
+    /// seed.
+    pub fn initialize_from_cloned_seed(&self, seed: [u8; 64]) -> Result<()> {
+        let mut guard = self.lock_phase()?;
+        match &*guard {
+            Phase::Cloning(_) => {}
+            other => {
+                return Err(EnclaveError::NotReady {
+                    state: other.name().into(),
+                });
+            }
+        }
+        let manager = KeyManager::from_seed(seed, self.network)?;
+        *guard = Phase::Active(Box::new(manager));
+        Ok(())
+    }
+
     /// Get public key info. Returns `KeyNotInitialized` if not in the `Active` phase.
     pub fn get_keys(&self) -> Result<KeyInfo> {
         self.with_active(|km| {


### PR DESCRIPTION
Third PR of the cloning + attestation series (T5). **Self-contained crypto module** — not wired into the server yet (PR 4 does that).

## Summary
Cryptographic primitives for the enclave↔enclave cloning handshake:

- **\`CloneSession\`** — ephemeral X25519 keypair held by the requester across the \`InitiateCloning → SetClone\` message boundary. Uses \`StaticSecret\` (zeroize feature enabled), so the private key is wiped on drop.
- **\`make_cloning_digest\` / \`verify_cloning_digest\`** — HMAC-SHA256 over the raw 32-byte encryption pubkey. Constant-time compare via \`subtle\`.
- **\`encrypt_seed_for_peer\` (donor side)** — fresh ephemeral X25519 keypair → DH → HKDF-SHA256(\`utexo-cloning-v1\`, \`seed-encryption\`) → ChaCha20Poly1305(key, nonce=0, seed). Returns \`(ciphertext, our_pub)\`.
- **\`CloneSession::decrypt_seed_from_peer\` (requester side)** — matching unseal, returns \`Zeroizing<[u8; 64]>\`.

Plus a new \`KeyManager::initialize_from_cloned_seed\` entry point — production-available, *not* gated on \`allow-seed-import\`. The guard is the state machine (PR 4's dispatch only calls it from \`Phase::Cloning\`), not a feature flag.

## Divergence notes
- **HMAC input**: raw 32 pubkey bytes, *not* JCS(JSON) like enclave-msig. We are not wire-compatible with that codebase, and raw bytes are unambiguous.
- **AEAD**: ChaCha20Poly1305 with HKDF, *not* libsodium SealedBox (XSalsa20Poly1305). Cleaner in Rust, equivalent security.
- **Fixed nonce \`[0; 12]\`**: safe because each handshake uses a single-use key derived from a fresh ephemeral keypair. The HKDF salt is versioned (\`utexo-cloning-v1\`) so nonces can't cross versions.

## Dependencies added
\`\`\`
x25519-dalek     = { version = \"2\", features = [\"static_secrets\", \"zeroize\"] }
chacha20poly1305 = \"0.10\"
hkdf             = \"0.12\"
hmac             = \"0.12\"
sha2             = \"0.10\"
subtle           = \"2\"
rand_core        = { version = \"0.6\", features = [\"getrandom\"] }
\`\`\`

## Test plan
- [x] \`cargo build\` — clean
- [x] \`cargo test\` — 74 unit + 27 integration tests pass (adds 12 cloning tests)
- [x] \`cargo test --features allow-seed-import\` — all pass
- [x] Unit tests cover: digest roundtrip + wrong-secret/pubkey + bit-flip, seed roundtrip, wrong peer pubkey, tampered ciphertext body, tampered auth tag, wrong requester session, pubkey stability, distinct sessions, expected ciphertext length (64 + 16-byte Poly1305 tag)
- [ ] Reviewer: sanity-check the HKDF salt/info strings are what we want before we ship (\`utexo-cloning-v1\` / \`seed-encryption\`)

## PR ordering
Branched off \`dev\`, not stacked on PR 1 / PR 2. Duplicates the T5 PR 1 error variants; rebase will no-op after PR 1 lands.