### PR TITLE
feat(cloning): wire enclave-to-enclave cloning handshake (T5 PR 4/4)

### DIFF
--- a/enclave/src/attestation.rs
+++ b/enclave/src/attestation.rs
@@ -159,14 +159,16 @@ pub fn get_own_pcrs() -> Result<ExpectedPcrs> {
 ///   3. Verify the certificate chain terminates at the AWS Nitro root CA.
 ///   4. Check certificate validity windows (not_before / not_after).
 ///   5. Compare PCR0/1/2 against `expected_pcrs`.
-///   6. Compare the document nonce against `expected_nonce`.
+///   6. Require a nonce field to be present. If `expected_nonce` is `Some`,
+///      require byte-equality with it. If `None`, caller is expected to
+///      enforce freshness via its own replay guard (see `state::ReplayGuard`).
 ///
 /// In `mock-attestation` mode, steps 1–4 are replaced with a raw CBOR parse
 /// and the cert chain is not validated. PCR/nonce/pubkey binding still hold.
 pub fn verify_peer_attestation(
     doc: &[u8],
     expected_pcrs: &ExpectedPcrs,
-    expected_nonce: &[u8; 32],
+    expected_nonce: Option<&[u8; 32]>,
 ) -> Result<VerifiedAttestation> {
     #[cfg(feature = "mock-attestation")]
     {
@@ -204,14 +206,16 @@ fn verify_pcrs(pcrs: &HashMap<u32, Vec<u8>>, expected: &ExpectedPcrs) -> Result<
     Ok(())
 }
 
-fn check_nonce(doc_nonce: &Option<Vec<u8>>, expected: &[u8; 32]) -> Result<Vec<u8>> {
-    match doc_nonce {
-        Some(n) if n.as_slice() == expected => Ok(n.clone()),
-        Some(_) => Err(EnclaveError::Attestation("nonce mismatch".into())),
-        None => Err(EnclaveError::Attestation(
-            "missing nonce in attestation".into(),
-        )),
+fn check_nonce(doc_nonce: &Option<Vec<u8>>, expected: Option<&[u8; 32]>) -> Result<Vec<u8>> {
+    let nonce = doc_nonce
+        .as_ref()
+        .ok_or_else(|| EnclaveError::Attestation("missing nonce in attestation".into()))?;
+    if let Some(exp) = expected {
+        if nonce.as_slice() != exp {
+            return Err(EnclaveError::Attestation("nonce mismatch".into()));
+        }
     }
+    Ok(nonce.clone())
 }
 
 // ----------------------------------------------------------------------------
@@ -265,7 +269,7 @@ IwLz3/Y=
     pub(super) fn verify_real_document(
         doc: &[u8],
         expected_pcrs: &ExpectedPcrs,
-        expected_nonce: &[u8; 32],
+        expected_nonce: Option<&[u8; 32]>,
     ) -> Result<VerifiedAttestation> {
         let cose = CoseSign1::from_bytes(doc)?;
         let payload = cose
@@ -620,7 +624,7 @@ mod mock {
     pub(super) fn verify_mock_document(
         doc: &[u8],
         expected_pcrs: &ExpectedPcrs,
-        expected_nonce: &[u8; 32],
+        expected_nonce: Option<&[u8; 32]>,
     ) -> Result<VerifiedAttestation> {
         let attestation: AttestationDocument = ciborium::from_reader(doc)
             .map_err(|e| EnclaveError::Attestation(format!("failed to parse mock doc: {e}")))?;
@@ -682,7 +686,8 @@ mod tests {
             let pubkey = [1u8; 32];
             let doc = get_attestation(&nonce, Some(&pubkey), Some(b"user")).unwrap();
 
-            let verified = verify_peer_attestation(&doc, &ExpectedPcrs::zero(), &nonce).unwrap();
+            let verified =
+                verify_peer_attestation(&doc, &ExpectedPcrs::zero(), Some(&nonce)).unwrap();
 
             assert_eq!(verified.enclave_pubkey, pubkey.to_vec());
             assert_eq!(verified.user_data.as_deref(), Some(b"user".as_ref()));
@@ -691,11 +696,20 @@ mod tests {
         }
 
         #[test]
+        fn mock_extracts_nonce_when_expected_is_none() {
+            let nonce = [0x5au8; 32];
+            let doc = get_attestation(&nonce, Some(&[0u8; 32]), None).unwrap();
+            let verified = verify_peer_attestation(&doc, &ExpectedPcrs::zero(), None).unwrap();
+            assert_eq!(verified.nonce, nonce.to_vec());
+        }
+
+        #[test]
         fn mock_reject_nonce_mismatch() {
             let nonce = [1u8; 32];
             let other = [2u8; 32];
             let doc = get_attestation(&nonce, Some(&[0u8; 32]), None).unwrap();
-            let err = verify_peer_attestation(&doc, &ExpectedPcrs::zero(), &other).unwrap_err();
+            let err =
+                verify_peer_attestation(&doc, &ExpectedPcrs::zero(), Some(&other)).unwrap_err();
             assert!(matches!(err, EnclaveError::Attestation(_)));
         }
 
@@ -704,7 +718,7 @@ mod tests {
             let nonce = [3u8; 32];
             let doc = get_attestation(&nonce, Some(&[0u8; 32]), None).unwrap();
             let expected = ExpectedPcrs::new([1u8; 48], [0u8; 48], [0u8; 48]);
-            let err = verify_peer_attestation(&doc, &expected, &nonce).unwrap_err();
+            let err = verify_peer_attestation(&doc, &expected, Some(&nonce)).unwrap_err();
             assert!(matches!(err, EnclaveError::PcrMismatch { pcr: 0, .. }));
         }
 
@@ -712,14 +726,16 @@ mod tests {
         fn mock_reject_missing_pubkey() {
             let nonce = [4u8; 32];
             let doc = get_attestation(&nonce, None, None).unwrap();
-            let err = verify_peer_attestation(&doc, &ExpectedPcrs::zero(), &nonce).unwrap_err();
+            let err =
+                verify_peer_attestation(&doc, &ExpectedPcrs::zero(), Some(&nonce)).unwrap_err();
             assert!(matches!(err, EnclaveError::Attestation(_)));
         }
 
         #[test]
         fn mock_reject_corrupted_doc() {
-            let err = verify_peer_attestation(&[0xffu8; 16], &ExpectedPcrs::zero(), &[0u8; 32])
-                .unwrap_err();
+            let err =
+                verify_peer_attestation(&[0xffu8; 16], &ExpectedPcrs::zero(), Some(&[0u8; 32]))
+                    .unwrap_err();
             assert!(matches!(err, EnclaveError::Attestation(_)));
         }
 

--- a/enclave/src/main.rs
+++ b/enclave/src/main.rs
@@ -25,6 +25,17 @@ fn main() {
 
     let state = EnclaveState::new(bitcoin_network);
 
+    // Donor-side cloning secret. Optional: only required for enclaves that
+    // will serve `GetClone` requests. Pre-shared across the operator's
+    // cluster. Never logged, wrapped in `SecretBox` for zeroize-on-drop.
+    if let Ok(secret) = std::env::var("UTEXO_CLONING_SECRET") {
+        if let Err(e) = state.set_donor_cloning_secret(secret) {
+            tracing::error!("failed to set donor cloning secret: {e}");
+        } else {
+            tracing::info!("donor cloning secret configured from UTEXO_CLONING_SECRET");
+        }
+    }
+
     // Start vsock-to-TCP forwarder for Esplora access (production only).
     // The host must run: vsock-proxy <ESPLORA_VSOCK_PORT> <esplora-host> <esplora-port>
     #[cfg(all(feature = "vsock", target_os = "linux"))]

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -68,6 +68,18 @@ fn dispatch(request: EnclaveRequest, ctx: &ServerContext) -> EnclaveResponse {
             tracing::info!("request: ProxyFederation");
             handle_proxy_federation(req)
         }
+        Some(Request::InitiateCloning(req)) => {
+            tracing::info!("request: InitiateCloning");
+            handle_initiate_cloning(&ctx.state, req)
+        }
+        Some(Request::GetClone(req)) => {
+            tracing::info!("request: GetClone");
+            handle_get_clone(&ctx.state, req)
+        }
+        Some(Request::SetClone(req)) => {
+            tracing::info!("request: SetClone");
+            handle_set_clone(&ctx.state, req)
+        }
         None => {
             tracing::warn!("received empty request (no oneof variant set)");
             return EnclaveResponse {
@@ -314,5 +326,229 @@ fn handle_proxy_federation(_req: ProxyFederationRequest) -> Result<EnclaveRespon
             code: 2, // NOT_READY
             message: "federation proxy not yet connected to Listener".into(),
         })),
+    })
+}
+
+// ============================================================================
+// Cloning handshake
+// ============================================================================
+//
+// See proto/enclave.proto for the full protocol description.
+
+use crate::attestation;
+use crate::cloning::{self, CloneSession};
+use crate::state::CloningSession;
+
+fn fresh_nonce() -> Result<[u8; 32]> {
+    let mut n = [0u8; 32];
+    getrandom::fill(&mut n)
+        .map_err(|e| EnclaveError::Internal(format!("entropy generation failed: {}", e)))?;
+    Ok(n)
+}
+
+/// Requester side. Transitions `Initial -> Cloning`. Generates an
+/// ephemeral X25519 keypair, binds it into an NSM attestation together
+/// with the HMAC digest of (cloning_secret, pubkey), and returns the
+/// three fields the parent needs to relay to the donor.
+fn handle_initiate_cloning(
+    state: &EnclaveState,
+    req: InitiateCloningRequest,
+) -> Result<EnclaveResponse> {
+    if req.cloning_secret.is_empty() {
+        return Err(EnclaveError::InvalidRequest(
+            "cloning_secret is required".into(),
+        ));
+    }
+    let cluster_public_key: [u8; 20] =
+        req.cluster_public_key.as_slice().try_into().map_err(|_| {
+            EnclaveError::InvalidRequest(format!(
+                "cluster_public_key must be 20 bytes, got {}",
+                req.cluster_public_key.len()
+            ))
+        })?;
+
+    let session = CloneSession::new();
+    let encryption_pubkey = session.public_key();
+
+    let nonce = fresh_nonce()?;
+    let cloning_digest = cloning::make_cloning_digest(&req.cloning_secret, &encryption_pubkey);
+
+    // Bind both the X25519 pubkey and the digest into the NSM signature:
+    // the parent cannot rewrite either without invalidating the attestation.
+    let attestation =
+        attestation::get_attestation(&nonce, Some(&encryption_pubkey), Some(&cloning_digest))?;
+
+    state.enter_cloning(CloningSession::new(session, cluster_public_key))?;
+
+    tracing::info!(
+        cluster_pk = %hex::encode(cluster_public_key),
+        "InitiateCloning: entered Cloning phase"
+    );
+
+    Ok(EnclaveResponse {
+        response: Some(Response::InitiateCloning(InitiateCloningResponse {
+            requester_attestation: attestation,
+            encryption_pubkey: encryption_pubkey.to_vec(),
+            cloning_digest: cloning_digest.to_vec(),
+        })),
+    })
+}
+
+/// Donor side. Stays in `Phase::Active`. Verifies the requester's
+/// attestation, matches PCRs, records the nonce against replay, checks
+/// pubkey + digest binding, verifies the digest against the configured
+/// donor-side cloning secret, and only then seals the seed.
+fn handle_get_clone(state: &EnclaveState, req: GetCloneRequest) -> Result<EnclaveResponse> {
+    let req_cluster_pk: [u8; 20] = req.cluster_public_key.as_slice().try_into().map_err(|_| {
+        EnclaveError::InvalidRequest(format!(
+            "cluster_public_key must be 20 bytes, got {}",
+            req.cluster_public_key.len()
+        ))
+    })?;
+    let req_encryption_pk: [u8; 32] =
+        req.encryption_pubkey.as_slice().try_into().map_err(|_| {
+            EnclaveError::InvalidRequest(format!(
+                "encryption_pubkey must be 32 bytes, got {}",
+                req.encryption_pubkey.len()
+            ))
+        })?;
+    let req_digest: [u8; 32] = req.cloning_digest.as_slice().try_into().map_err(|_| {
+        EnclaveError::InvalidRequest(format!(
+            "cloning_digest must be 32 bytes, got {}",
+            req.cloning_digest.len()
+        ))
+    })?;
+
+    // 1. Donor identity check: the request must address *this* enclave's
+    //    public key. Prevents the parent from fanning one request out to
+    //    unintended donors.
+    let our_evm = state.evm_address()?;
+    if req_cluster_pk != our_evm {
+        return Err(EnclaveError::Clone(format!(
+            "cluster_public_key {} does not match this enclave's address {}",
+            hex::encode(req_cluster_pk),
+            hex::encode(our_evm)
+        )));
+    }
+
+    // 2. Verify the requester attestation chain + PCRs. `None` for the
+    //    expected nonce: we have not seen the requester's nonce before,
+    //    so freshness is enforced by the replay guard immediately after.
+    let expected_pcrs = attestation::get_own_pcrs()?;
+    let verified =
+        attestation::verify_peer_attestation(&req.requester_attestation, &expected_pcrs, None)?;
+
+    // 3. Replay-check the nonce pulled from the verified document.
+    let nonce_array: [u8; 32] = verified
+        .nonce
+        .as_slice()
+        .try_into()
+        .map_err(|_| EnclaveError::Attestation("attestation nonce has wrong length".into()))?;
+    state.replay_guard.check_and_record(nonce_array)?;
+
+    // 4. Pubkey binding: the attestation's `public_key` field must equal
+    //    the one the parent put on the wire. Otherwise the parent could
+    //    have swapped it for a key it controls.
+    if verified.enclave_pubkey.as_slice() != req_encryption_pk {
+        return Err(EnclaveError::PubkeyMismatch);
+    }
+
+    // 5. Digest binding: the attestation's `user_data` must equal the
+    //    digest on the wire — NSM-signed, so parent-proof.
+    let user_data = verified.user_data.as_deref().ok_or_else(|| {
+        EnclaveError::Attestation("requester attestation missing user_data (cloning digest)".into())
+    })?;
+    if user_data != req_digest {
+        return Err(EnclaveError::DigestMismatch);
+    }
+
+    // 6. Digest authenticity: HMAC(donor_secret, encryption_pubkey) must
+    //    match. Proves the requester was issued by the same operator.
+    state.with_donor_cloning_secret(|secret| {
+        if !cloning::verify_cloning_digest(secret, &req_encryption_pk, &req_digest) {
+            return Err(EnclaveError::DigestMismatch);
+        }
+        Ok(())
+    })?;
+
+    // 7. Seal the seed under a fresh donor ephemeral keypair.
+    let (encrypted_seed, donor_pubkey) =
+        state.with_seed(|seed| cloning::encrypt_seed_for_peer(&req_encryption_pk, seed))?;
+
+    // 8. Donor's own attestation. Fresh nonce, binds the donor pubkey we
+    //    just produced so the requester can be sure this response is
+    //    not an old one replayed by the parent.
+    let donor_nonce = fresh_nonce()?;
+    let donor_attestation = attestation::get_attestation(&donor_nonce, Some(&donor_pubkey), None)?;
+
+    tracing::info!(
+        cluster_pk = %hex::encode(our_evm),
+        "GetClone: sealed seed for requester"
+    );
+
+    Ok(EnclaveResponse {
+        response: Some(Response::GetClone(GetCloneResponse {
+            encrypted_seed,
+            donor_pubkey: donor_pubkey.to_vec(),
+            donor_attestation,
+        })),
+    })
+}
+
+/// Requester side. Transitions `Cloning -> Active`. Verifies the donor's
+/// attestation, unseals the ciphertext, and commits the derived keys
+/// only if the resulting EVM address matches `cluster_public_key`.
+fn handle_set_clone(state: &EnclaveState, req: SetCloneRequest) -> Result<EnclaveResponse> {
+    let donor_pubkey: [u8; 32] = req.donor_pubkey.as_slice().try_into().map_err(|_| {
+        EnclaveError::InvalidRequest(format!(
+            "donor_pubkey must be 32 bytes, got {}",
+            req.donor_pubkey.len()
+        ))
+    })?;
+
+    // 1. Verify donor attestation chain + PCRs (no nonce match — we
+    //    enforce freshness via the replay guard).
+    let expected_pcrs = attestation::get_own_pcrs()?;
+    let verified =
+        attestation::verify_peer_attestation(&req.donor_attestation, &expected_pcrs, None)?;
+
+    let nonce_array: [u8; 32] = verified
+        .nonce
+        .as_slice()
+        .try_into()
+        .map_err(|_| EnclaveError::Attestation("attestation nonce has wrong length".into()))?;
+    state.replay_guard.check_and_record(nonce_array)?;
+
+    // 2. Pubkey binding: the donor's pubkey on the wire must equal the
+    //    one inside their signed attestation.
+    if verified.enclave_pubkey.as_slice() != donor_pubkey {
+        return Err(EnclaveError::PubkeyMismatch);
+    }
+
+    // 3. Decrypt seed, derive KeyManager, identity check, and commit the
+    //    Cloning -> Active transition — all atomically under the state
+    //    lock via `complete_cloning`. On any failure the state stays in
+    //    Cloning and the handshake can be retried.
+    let network = state.network();
+    let mut cluster_public_key = [0u8; 20];
+    state.complete_cloning(|session| {
+        let seed = session
+            .session
+            .decrypt_seed_from_peer(&donor_pubkey, &req.encrypted_seed)?;
+        let km = crate::keys::KeyManager::from_seed(*seed, network)?;
+        if km.evm_address() != &session.cluster_public_key {
+            return Err(EnclaveError::IdentityMismatch);
+        }
+        cluster_public_key = session.cluster_public_key;
+        Ok(km)
+    })?;
+
+    tracing::info!(
+        cluster_pk = %hex::encode(cluster_public_key),
+        "SetClone: cloned, transitioned to Active"
+    );
+
+    Ok(EnclaveResponse {
+        response: Some(Response::SetClone(SetCloneResponse {})),
     })
 }

--- a/enclave/src/state.rs
+++ b/enclave/src/state.rs
@@ -1,18 +1,91 @@
+use std::collections::HashSet;
 use std::sync::Mutex;
 
 use bip39::Mnemonic;
 use bitcoin::Network;
+use secrecy::{ExposeSecret, SecretBox};
 
+use crate::cloning::CloneSession;
 use crate::error::{EnclaveError, Result};
 use crate::keys::{KeyInfo, KeyManager};
 
-/// Placeholder for cloning session state.
+/// All of the per-handshake state the requester must hold between
+/// receiving `InitiateCloning` and receiving `SetClone`.
 ///
-/// PR 3 (cloning crypto primitives) will replace this with the real type
-/// from `crate::cloning` carrying the X25519 ephemeral keypair, stored
-/// cloning secret, target cluster public key, and attestation nonce.
-#[derive(Debug, Default)]
-pub struct CloningSession {}
+/// The X25519 secret inside `session` is zeroized on drop.
+pub struct CloningSession {
+    /// Ephemeral X25519 keypair we advertised in `InitiateCloningResponse`.
+    pub session: CloneSession,
+    /// 20-byte EVM address of the donor we intend to clone from.
+    pub cluster_public_key: [u8; 20],
+}
+
+impl CloningSession {
+    pub fn new(session: CloneSession, cluster_public_key: [u8; 20]) -> Self {
+        Self {
+            session,
+            cluster_public_key,
+        }
+    }
+}
+
+impl std::fmt::Debug for CloningSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CloningSession")
+            .field("session", &self.session)
+            .field("cluster_public_key", &hex::encode(self.cluster_public_key))
+            .finish()
+    }
+}
+
+/// Bounded replay guard for attestation nonces.
+///
+/// Every incoming peer attestation contributes its nonce to this set;
+/// duplicate nonces are rejected. Enclaves are short-lived so unbounded
+/// growth is rare, but we cap the set at 10k to prevent a pathological
+/// attacker from exhausting memory. On overflow we reject new entries
+/// rather than silently rolling the window — a safer default.
+pub struct NonceReplayGuard {
+    inner: Mutex<HashSet<[u8; 32]>>,
+    max: usize,
+}
+
+impl Default for NonceReplayGuard {
+    fn default() -> Self {
+        Self::with_capacity(10_000)
+    }
+}
+
+impl NonceReplayGuard {
+    pub fn with_capacity(max: usize) -> Self {
+        Self {
+            inner: Mutex::new(HashSet::new()),
+            max,
+        }
+    }
+
+    pub fn check_and_record(&self, nonce: [u8; 32]) -> Result<()> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|e| EnclaveError::Internal(format!("replay guard poisoned: {}", e)))?;
+        if guard.contains(&nonce) {
+            return Err(EnclaveError::NonceReplay);
+        }
+        if guard.len() >= self.max {
+            return Err(EnclaveError::Clone(
+                "replay guard full; refusing new attestations".into(),
+            ));
+        }
+        guard.insert(nonce);
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub fn seen_count(&self) -> usize {
+        self.inner.lock().map(|g| g.len()).unwrap_or(0)
+    }
+}
 
 /// Enclave lifecycle phase.
 ///
@@ -50,6 +123,12 @@ impl Phase {
 pub struct EnclaveState {
     inner: Mutex<Phase>,
     network: Network,
+    /// Operator-configured cloning secret for the *donor* role. Required
+    /// when serving `GetClone`; not used in the requester role (the
+    /// requester receives the secret via `InitiateCloningRequest`).
+    donor_cloning_secret: Mutex<Option<SecretBox<String>>>,
+    /// Replay guard for nonces in peer attestations.
+    pub replay_guard: NonceReplayGuard,
 }
 
 impl Default for EnclaveState {
@@ -63,11 +142,42 @@ impl EnclaveState {
         Self {
             inner: Mutex::new(Phase::Initial),
             network,
+            donor_cloning_secret: Mutex::new(None),
+            replay_guard: NonceReplayGuard::default(),
         }
     }
 
     pub fn network(&self) -> Network {
         self.network
+    }
+
+    /// Configure the donor-side cloning secret. Called at startup from an
+    /// operator-provided env var (e.g. `UTEXO_CLONING_SECRET`). Idempotent
+    /// and overwrites any previous value. The secret is wrapped in
+    /// `SecretBox` for zeroize-on-drop.
+    pub fn set_donor_cloning_secret(&self, secret: String) -> Result<()> {
+        let mut guard = self
+            .donor_cloning_secret
+            .lock()
+            .map_err(|e| EnclaveError::Internal(format!("lock poisoned: {}", e)))?;
+        *guard = Some(SecretBox::new(Box::new(secret)));
+        Ok(())
+    }
+
+    /// Read the configured donor cloning secret, if any, and apply `f` to
+    /// it while holding the lock so the plaintext never escapes the
+    /// closure frame.
+    pub fn with_donor_cloning_secret<T>(&self, f: impl FnOnce(&str) -> Result<T>) -> Result<T> {
+        let guard = self
+            .donor_cloning_secret
+            .lock()
+            .map_err(|e| EnclaveError::Internal(format!("lock poisoned: {}", e)))?;
+        match guard.as_ref() {
+            Some(secret) => f(secret.expose_secret()),
+            None => Err(EnclaveError::NotReady {
+                state: "donor cloning secret not configured".into(),
+            }),
+        }
     }
 
     /// Returns the name of the current phase ("initial", "cloning", "active").
@@ -108,6 +218,43 @@ impl EnclaveState {
         Ok(())
     }
 
+    /// Transition `Initial -> Cloning`, consuming the supplied session.
+    /// Rejected from any other phase.
+    pub fn enter_cloning(&self, session: CloningSession) -> Result<()> {
+        let mut guard = self.lock_phase()?;
+        ensure_initial(&guard)?;
+        *guard = Phase::Cloning(session);
+        Ok(())
+    }
+
+    /// Run `f` against the live `CloningSession` while holding the state
+    /// lock. Errors with `NotReady` if the state is not `Cloning`. The
+    /// closure cannot keep a reference to the session past its return.
+    pub fn with_cloning_session<T>(
+        &self,
+        f: impl FnOnce(&CloningSession) -> Result<T>,
+    ) -> Result<T> {
+        let guard = self.lock_phase()?;
+        match &*guard {
+            Phase::Cloning(s) => f(s),
+            other => Err(EnclaveError::NotReady {
+                state: other.name().into(),
+            }),
+        }
+    }
+
+    /// Active-phase accessor for the donor side of `GetClone` — the donor
+    /// is in `Phase::Active` and needs to read the seed to seal it.
+    pub fn with_seed<T>(&self, f: impl FnOnce(&[u8; 64]) -> Result<T>) -> Result<T> {
+        self.with_active(|km| f(km.expose_seed()))
+    }
+
+    /// Donor-side accessor for the EVM address used in the `GetClone`
+    /// identity check (`cluster_public_key`).
+    pub fn evm_address(&self) -> Result<[u8; 20]> {
+        self.with_active(|km| Ok(*km.evm_address()))
+    }
+
     /// Initialize from a seed obtained via the cloning handshake.
     ///
     /// This is the production path for cloned enclaves and is NOT gated on
@@ -126,6 +273,36 @@ impl EnclaveState {
             }
         }
         let manager = KeyManager::from_seed(seed, self.network)?;
+        *guard = Phase::Active(Box::new(manager));
+        Ok(())
+    }
+
+    /// Complete the cloning handshake atomically.
+    ///
+    /// The closure is given a reference to the current `CloningSession`
+    /// and must return a fully-constructed `KeyManager` built from the
+    /// unsealed seed. The closure is responsible for any identity check
+    /// (e.g. derived-address vs `cluster_public_key`). On `Ok(km)`, the
+    /// phase transitions atomically to `Active(km)`. On error, the state
+    /// stays in `Cloning` so the operator can retry if desired.
+    ///
+    /// Locking the phase for the entire decrypt-derive-check-commit
+    /// sequence keeps the seed in memory for the shortest possible window
+    /// and makes the transition observably atomic from other threads.
+    pub fn complete_cloning(
+        &self,
+        f: impl FnOnce(&CloningSession) -> Result<KeyManager>,
+    ) -> Result<()> {
+        let mut guard = self.lock_phase()?;
+        let session = match &*guard {
+            Phase::Cloning(s) => s,
+            other => {
+                return Err(EnclaveError::NotReady {
+                    state: other.name().into(),
+                });
+            }
+        };
+        let manager = f(session)?;
         *guard = Phase::Active(Box::new(manager));
         Ok(())
     }
@@ -251,7 +428,8 @@ mod tests {
     #[test]
     fn cloning_phase_is_not_initialized() {
         let state = EnclaveState::new(Network::Bitcoin);
-        *state.inner.lock().unwrap() = Phase::Cloning(CloningSession::default());
+        *state.inner.lock().unwrap() =
+            Phase::Cloning(CloningSession::new(CloneSession::new(), [0u8; 20]));
         assert_eq!(state.phase_name(), "cloning");
         assert!(!state.is_initialized());
         assert!(matches!(
@@ -263,7 +441,8 @@ mod tests {
     #[test]
     fn initialize_from_cloning_phase_rejected() {
         let state = EnclaveState::new(Network::Bitcoin);
-        *state.inner.lock().unwrap() = Phase::Cloning(CloningSession::default());
+        *state.inner.lock().unwrap() =
+            Phase::Cloning(CloningSession::new(CloneSession::new(), [0u8; 20]));
         let err = state.initialize_from_seed([42u8; 64]).unwrap_err();
         assert!(matches!(err, EnclaveError::AlreadyInitialized));
     }

--- a/enclave/tests/common/mod.rs
+++ b/enclave/tests/common/mod.rs
@@ -10,11 +10,22 @@ use utexo_bridge_enclave::state::EnclaveState;
 /// Start a test server on a random TCP port. Returns the port number.
 /// The server runs in a background thread and handles connections until
 /// the test process exits.
+#[allow(dead_code)]
 pub fn start_test_server() -> u16 {
+    start_test_server_with(|_| {})
+}
+
+/// Start a test server, running the provided configuration closure against
+/// the fresh `EnclaveState` before the listener accepts connections. Used
+/// by the cloning integration test to seed the donor with a known seed
+/// and a cloning secret before the first client request arrives.
+pub fn start_test_server_with(configure: impl FnOnce(&EnclaveState)) -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let port = listener.local_addr().unwrap().port();
+    let state = EnclaveState::new(bitcoin::Network::Bitcoin);
+    configure(&state);
     let ctx = Arc::new(ServerContext {
-        state: EnclaveState::new(bitcoin::Network::Bitcoin),
+        state,
         #[cfg(feature = "rgb-validation")]
         rgb_validator: None,
     });

--- a/enclave/tests/test_clone.rs
+++ b/enclave/tests/test_clone.rs
@@ -1,0 +1,292 @@
+//! Integration tests for the cloning handshake (T5 PR 4).
+//!
+//! These tests run with `--features mock-attestation,allow-seed-import`.
+//! Mock attestation skips NSM / COSE / cert-chain validation but still
+//! enforces pubkey, digest, nonce, and PCR binding. `allow-seed-import`
+//! is only used to give the *donor* a known fixed seed.
+//!
+//! The cloning path itself does NOT require `allow-seed-import` — PR 3's
+//! `initialize_from_cloned_seed` is production-available and guarded by
+//! the `Phase::Cloning` state, not a feature flag.
+
+#![cfg(all(feature = "mock-attestation", feature = "allow-seed-import"))]
+
+mod common;
+
+use common::{send_request, start_test_server_with};
+use utexo_bridge_enclave::proto::enclave_request::Request as Req;
+use utexo_bridge_enclave::proto::enclave_response::Response as Resp;
+use utexo_bridge_enclave::proto::*;
+
+// Known BIP-39 test vector from the key-manager unit tests. Produces a
+// stable, non-secret seed we can embed in integration tests.
+const DONOR_MNEMONIC: &str =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+const CLONING_SECRET: &str = "test-operator-cloning-secret";
+
+fn initialize_key_from_mnemonic(port: u16, mnemonic: &str) -> PublicKeysResponse {
+    let resp = send_request(
+        port,
+        &EnclaveRequest {
+            request: Some(Req::InitializeKey(InitializeKeyRequest {
+                seed: vec![],
+                mnemonic: mnemonic.into(),
+            })),
+        },
+    );
+    match resp.response {
+        Some(Resp::InitializeKey(r)) => PublicKeysResponse {
+            evm_address: r.evm_address,
+            btc_compressed_pub: r.btc_compressed_pub,
+            btc_xpub: r.btc_xpub,
+            master_fingerprint: r.master_fingerprint,
+            account_xpub_vanilla: r.account_xpub_vanilla,
+            account_xpub_colored: r.account_xpub_colored,
+        },
+        other => panic!("expected InitializeKey response, got {:?}", other),
+    }
+}
+
+fn get_public_keys(port: u16) -> PublicKeysResponse {
+    let resp = send_request(
+        port,
+        &EnclaveRequest {
+            request: Some(Req::GetPublicKey(GetPublicKeyRequest {})),
+        },
+    );
+    match resp.response {
+        Some(Resp::PublicKeys(r)) => r,
+        other => panic!("expected PublicKeys response, got {:?}", other),
+    }
+}
+
+fn start_donor() -> (u16, PublicKeysResponse) {
+    let port = start_test_server_with(|state| {
+        state
+            .set_donor_cloning_secret(CLONING_SECRET.into())
+            .expect("set_donor_cloning_secret");
+    });
+    let keys = initialize_key_from_mnemonic(port, DONOR_MNEMONIC);
+    (port, keys)
+}
+
+fn start_requester() -> u16 {
+    // Requester does not need a donor secret configured — it receives
+    // the secret via InitiateCloningRequest. But set it anyway to match
+    // a realistic deployment where both roles are possible.
+    start_test_server_with(|state| {
+        state
+            .set_donor_cloning_secret(CLONING_SECRET.into())
+            .expect("set_donor_cloning_secret");
+    })
+}
+
+fn initiate_cloning(
+    requester_port: u16,
+    secret: &str,
+    cluster_public_key: &[u8],
+) -> InitiateCloningResponse {
+    let resp = send_request(
+        requester_port,
+        &EnclaveRequest {
+            request: Some(Req::InitiateCloning(InitiateCloningRequest {
+                cloning_secret: secret.into(),
+                cluster_public_key: cluster_public_key.to_vec(),
+            })),
+        },
+    );
+    match resp.response {
+        Some(Resp::InitiateCloning(r)) => r,
+        other => panic!("expected InitiateCloning response, got {:?}", other),
+    }
+}
+
+fn request_get_clone(
+    donor_port: u16,
+    donor_evm: &[u8],
+    init: &InitiateCloningResponse,
+) -> Result<GetCloneResponse, ErrorResponse> {
+    let resp = send_request(
+        donor_port,
+        &EnclaveRequest {
+            request: Some(Req::GetClone(GetCloneRequest {
+                cluster_public_key: donor_evm.to_vec(),
+                cloning_digest: init.cloning_digest.clone(),
+                encryption_pubkey: init.encryption_pubkey.clone(),
+                requester_attestation: init.requester_attestation.clone(),
+            })),
+        },
+    );
+    match resp.response {
+        Some(Resp::GetClone(r)) => Ok(r),
+        Some(Resp::Error(e)) => Err(e),
+        other => panic!("expected GetClone or Error response, got {:?}", other),
+    }
+}
+
+fn request_set_clone(requester_port: u16, clone: &GetCloneResponse) -> Result<(), ErrorResponse> {
+    let resp = send_request(
+        requester_port,
+        &EnclaveRequest {
+            request: Some(Req::SetClone(SetCloneRequest {
+                encrypted_seed: clone.encrypted_seed.clone(),
+                donor_pubkey: clone.donor_pubkey.clone(),
+                donor_attestation: clone.donor_attestation.clone(),
+            })),
+        },
+    );
+    match resp.response {
+        Some(Resp::SetClone(_)) => Ok(()),
+        Some(Resp::Error(e)) => Err(e),
+        other => panic!("expected SetClone or Error response, got {:?}", other),
+    }
+}
+
+// ---- happy path ----
+
+#[test]
+fn clone_happy_path_copies_donor_identity_to_requester() {
+    let (donor_port, donor_keys) = start_donor();
+    let requester_port = start_requester();
+
+    let init = initiate_cloning(requester_port, CLONING_SECRET, &donor_keys.evm_address);
+    assert_eq!(init.encryption_pubkey.len(), 32);
+    assert_eq!(init.cloning_digest.len(), 32);
+    assert!(!init.requester_attestation.is_empty());
+
+    let clone = request_get_clone(donor_port, &donor_keys.evm_address, &init)
+        .expect("GetClone should succeed");
+    assert_eq!(clone.donor_pubkey.len(), 32);
+    assert_eq!(clone.encrypted_seed.len(), 64 + 16); // seed + Poly1305 tag
+    assert!(!clone.donor_attestation.is_empty());
+
+    request_set_clone(requester_port, &clone).expect("SetClone should succeed");
+
+    // Requester is now Active and should report the donor's identity.
+    let requester_keys = get_public_keys(requester_port);
+    assert_eq!(requester_keys.evm_address, donor_keys.evm_address);
+    assert_eq!(
+        requester_keys.btc_compressed_pub,
+        donor_keys.btc_compressed_pub
+    );
+    assert_eq!(requester_keys.btc_xpub, donor_keys.btc_xpub);
+    assert_eq!(
+        requester_keys.master_fingerprint,
+        donor_keys.master_fingerprint
+    );
+    assert_eq!(
+        requester_keys.account_xpub_vanilla,
+        donor_keys.account_xpub_vanilla
+    );
+    assert_eq!(
+        requester_keys.account_xpub_colored,
+        donor_keys.account_xpub_colored
+    );
+}
+
+// ---- error cases ----
+
+#[test]
+fn clone_rejects_wrong_cloning_secret() {
+    let (donor_port, donor_keys) = start_donor();
+    let requester_port = start_requester();
+
+    // Requester uses a DIFFERENT secret than the donor was configured with.
+    let init = initiate_cloning(requester_port, "wrong-secret", &donor_keys.evm_address);
+    let err = request_get_clone(donor_port, &donor_keys.evm_address, &init)
+        .expect_err("GetClone should reject a mismatched digest");
+    assert!(
+        err.message.contains("digest") || err.message.contains("cloning"),
+        "unexpected error: {}",
+        err.message
+    );
+}
+
+#[test]
+fn clone_rejects_wrong_cluster_public_key() {
+    let (donor_port, _donor_keys) = start_donor();
+    let requester_port = start_requester();
+
+    // Requester targets an EVM address that is not the donor's.
+    let wrong_target = [0xDEu8; 20];
+    let init = initiate_cloning(requester_port, CLONING_SECRET, &wrong_target);
+    let err = request_get_clone(donor_port, &wrong_target, &init)
+        .expect_err("GetClone should reject mismatched cluster address");
+    assert!(
+        err.message.contains("cluster_public_key") || err.message.contains("does not match"),
+        "unexpected error: {}",
+        err.message
+    );
+}
+
+#[test]
+fn clone_rejects_tampered_ciphertext() {
+    let (donor_port, donor_keys) = start_donor();
+    let requester_port = start_requester();
+
+    let init = initiate_cloning(requester_port, CLONING_SECRET, &donor_keys.evm_address);
+    let mut clone = request_get_clone(donor_port, &donor_keys.evm_address, &init)
+        .expect("GetClone should succeed");
+    // Flip a byte in the Poly1305 tag (last 16 bytes of the ciphertext).
+    let len = clone.encrypted_seed.len();
+    clone.encrypted_seed[len - 1] ^= 0x01;
+
+    let err = request_set_clone(requester_port, &clone)
+        .expect_err("SetClone should reject a tampered ciphertext");
+    assert!(
+        err.message.contains("unseal") || err.message.contains("clone"),
+        "unexpected error: {}",
+        err.message
+    );
+}
+
+#[test]
+fn clone_rejects_duplicate_requester_attestation_nonce_on_donor() {
+    let (donor_port, donor_keys) = start_donor();
+    let requester_port = start_requester();
+
+    let init = initiate_cloning(requester_port, CLONING_SECRET, &donor_keys.evm_address);
+
+    // First GetClone succeeds.
+    let _ok = request_get_clone(donor_port, &donor_keys.evm_address, &init)
+        .expect("first GetClone should succeed");
+
+    // Replaying the same GetClone (same nonce inside the attestation)
+    // must fail on the donor's replay guard.
+    let err = request_get_clone(donor_port, &donor_keys.evm_address, &init)
+        .expect_err("second GetClone should hit replay guard");
+    assert!(
+        err.message.contains("replay") || err.message.contains("nonce"),
+        "unexpected error: {}",
+        err.message
+    );
+}
+
+#[test]
+fn cannot_initialize_after_entering_cloning() {
+    let requester_port = start_requester();
+    // Start a clone session using a throwaway donor address.
+    let _init = initiate_cloning(requester_port, CLONING_SECRET, &[0x11u8; 20]);
+
+    // Attempting a fresh InitializeKey must now fail — the enclave is in
+    // Phase::Cloning, not Phase::Initial.
+    let resp = send_request(
+        requester_port,
+        &EnclaveRequest {
+            request: Some(Req::InitializeKey(InitializeKeyRequest {
+                seed: vec![],
+                mnemonic: DONOR_MNEMONIC.into(),
+            })),
+        },
+    );
+    match resp.response {
+        Some(Resp::Error(e)) => {
+            assert!(
+                e.message.contains("already") || e.message.contains("initialized"),
+                "unexpected error: {}",
+                e.message
+            );
+        }
+        other => panic!("expected Error, got {:?}", other),
+    }
+}

--- a/proto/enclave.proto
+++ b/proto/enclave.proto
@@ -6,30 +6,34 @@ package utexo_bridge.enclave;
 
 message EnclaveRequest {
   oneof request {
-    InitializeKeyRequest   initialize_key   = 1;
-    GetPublicKeyRequest    get_public_key   = 2;
-    SignEvmRequest         sign_evm         = 3;
-    SignPsbtRequest        sign_psbt        = 4;
-    SignRawMessageRequest  sign_raw_message = 5;
-    ProxyFederationRequest proxy_federation = 6;
+    InitializeKeyRequest   initialize_key    = 1;
+    GetPublicKeyRequest    get_public_key    = 2;
+    SignEvmRequest         sign_evm          = 3;
+    SignPsbtRequest        sign_psbt         = 4;
+    SignRawMessageRequest  sign_raw_message  = 5;
+    ProxyFederationRequest proxy_federation  = 6;
+    InitiateCloningRequest initiate_cloning  = 7;
+    GetCloneRequest        get_clone         = 8;
+    SetCloneRequest        set_clone         = 9;
     // Reserved for future:
-    // GetAttestationRequest get_attestation = 7;
-    // CloneRequest         clone_request    = 8;
-    // HealthCheckRequest   health_check     = 9;
+    // HealthCheckRequest  health_check     = 10;
   }
 }
 
 message EnclaveResponse {
   oneof response {
-    InitializeKeyResponse  initialize_key   = 1;
-    PublicKeysResponse     public_keys      = 2;
-    EvmSignatureResponse   evm_signature    = 3;
-    SignedPsbtResponse     signed_psbt      = 4;
-    RawSignatureResponse   raw_signature    = 5;
+    InitializeKeyResponse   initialize_key   = 1;
+    PublicKeysResponse      public_keys      = 2;
+    EvmSignatureResponse    evm_signature    = 3;
+    SignedPsbtResponse      signed_psbt      = 4;
+    RawSignatureResponse    raw_signature    = 5;
     FederationSignatureResponse federation_sig = 6;
+    InitiateCloningResponse initiate_cloning = 7;
+    GetCloneResponse        get_clone        = 8;
+    SetCloneResponse        set_clone        = 9;
     // Reserved for future:
-    // HealthCheckResponse  health_check     = 7;
-    ErrorResponse          error            = 15;
+    // HealthCheckResponse  health_check     = 10;
+    ErrorResponse           error            = 15;
   }
 }
 
@@ -144,6 +148,76 @@ message ProxyFederationRequest {
 
 message FederationSignatureResponse {
   bytes signature = 1;        // 65-byte ECDSA from Listener's federation key
+}
+
+// === Cloning Handshake ===
+//
+// Internal three-message protocol for enclave-to-enclave seed cloning:
+//
+//   1. Parent -> new (requester) enclave: InitiateCloningRequest.
+//      Requester generates an X25519 ephemeral keypair, HMACs the pubkey
+//      with the cloning secret, asks NSM to attest the pubkey (embedded in
+//      the public_key field) and the digest (embedded in user_data).
+//      Returns attestation + pubkey + digest so the parent can relay to
+//      a donor.
+//
+//   2. Parent -> donor enclave (relayed): GetCloneRequest.
+//      Donor verifies the attestation chain, PCRs, that the pubkey inside
+//      the attestation equals the one claimed on the wire, that the digest
+//      inside user_data equals the one on the wire, that the digest verifies
+//      against its configured cloning secret, and that cluster_public_key
+//      matches its own EVM address. It then seals its seed via X25519 +
+//      HKDF + ChaCha20Poly1305 and returns (ciphertext, its own ephemeral
+//      pubkey, its own attestation).
+//
+//   3. Parent -> requester enclave (relayed): SetCloneRequest.
+//      Requester verifies the donor attestation, unseals the ciphertext,
+//      derives a KeyManager from the seed, and checks the derived EVM
+//      address matches the cluster_public_key it was told to clone.
+//      Transitions to Active. Response is empty — the parent infers
+//      success by calling GetPublicKey afterwards.
+//
+// The Go `listener-enclave.proto` contract at the gRPC boundary only has
+// `Initialize(cloning_secret)` and `Clone(attestation, encryption_pubkey)`.
+// The parent adapter translates: Initialize -> InitiateCloning,
+// Clone -> GetClone, and drives SetClone over vsock internally.
+// The cloning_digest never crosses the gRPC boundary — it is bound into
+// the attestation's user_data and extracted by the donor post-verify.
+
+message InitiateCloningRequest {
+  string cloning_secret       = 1;  // Pre-shared operator secret (never sent to donor)
+  bytes  cluster_public_key   = 2;  // 20-byte EVM address of the donor we intend to clone
+}
+
+message InitiateCloningResponse {
+  bytes  requester_attestation = 1;  // NSM doc binding the X25519 pubkey + digest
+  bytes  encryption_pubkey     = 2;  // 32-byte X25519 public key
+  bytes  cloning_digest        = 3;  // 32-byte HMAC-SHA256(secret, encryption_pubkey)
+}
+
+message GetCloneRequest {
+  bytes  cluster_public_key    = 1;  // 20 bytes — must match donor's EVM address
+  bytes  cloning_digest        = 2;  // 32 bytes — verified against donor's own cloning secret
+  bytes  encryption_pubkey     = 3;  // 32 bytes — requester's X25519 pubkey
+  bytes  requester_attestation = 4;  // Signed doc binding both of the above
+}
+
+message GetCloneResponse {
+  bytes  encrypted_seed        = 1;  // ChaCha20Poly1305(HKDF(X25519(donor_eph, requester_pub)), seed)
+  bytes  donor_pubkey          = 2;  // 32-byte donor ephemeral X25519 pubkey
+  bytes  donor_attestation     = 3;  // Signed doc binding donor_pubkey
+}
+
+message SetCloneRequest {
+  bytes  encrypted_seed        = 1;
+  bytes  donor_pubkey          = 2;
+  bytes  donor_attestation     = 3;
+}
+
+// SetClone has a response purely so the envelope oneof stays non-empty on
+// the wire (matching every other request). The body is intentionally empty
+// — a successful SetClone is silent and the caller probes GetPublicKey.
+message SetCloneResponse {
 }
 
 // === Error ===


### PR DESCRIPTION
Final PR of the T5 series. Ties PRs #18, #19, #20 together into a working three-message cloning protocol with NSM attestation binding and donor-side identity checks.

## Proto additions
Three request/response variants at fields 7/8/9:
- \`InitiateCloningRequest\` -> \`InitiateCloningResponse\` (requester)
- \`GetCloneRequest\` -> \`GetCloneResponse\` (donor)
- \`SetCloneRequest\` -> \`SetCloneResponse\` (requester, empty body)

\`SetCloneResponse\` is intentionally empty — a successful \`SetClone\` is silent (matching enclave-msig), but the envelope still carries a variant so the wire oneof is well-formed.

## Go gRPC contract alignment
The Go \`listener-enclave.proto\` only exposes \`Initialize(secret)\` / \`Clone(attestation, pubkey)\` at the external boundary. The parent adapter translates into the internal three-message flow, and the cloning digest never crosses the gRPC boundary — it is bound into the NSM attestation's \`user_data\` and extracted by the donor post-verify. This was the design question from PR #1's description; this PR implements it.

## State machine
- \`Phase::Cloning\` now carries a real \`CloningSession\` (X25519 keypair + target EVM address), replacing PR #1's empty placeholder.
- New transitions: \`enter_cloning\` (Initial -> Cloning), \`complete_cloning\` (atomic Cloning -> Active with a user-supplied KeyManager-building closure), \`with_seed\`, \`evm_address\`.
- New \`NonceReplayGuard\` (bounded \`HashSet<[u8; 32]>\`, cap 10k) for attestation nonce replay protection on both sides.
- New donor-side cloning secret storage (\`SecretBox<String>\`) with \`set_donor_cloning_secret\` / \`with_donor_cloning_secret\`.

## Attestation
\`verify_peer_attestation\` now takes \`Option<&[u8; 32]>\` for the expected nonce:
- \`Some\` -> exact match (previous behavior).
- \`None\` -> require present, return extracted nonce for the caller to replay-check.
Both cloning handlers use \`None\` and enforce freshness via \`NonceReplayGuard\`.

## Handlers (in \`enclave/src/server.rs\`)
**InitiateCloning** (requester, Initial -> Cloning):
- Validate secret + 20-byte cluster_public_key.
- Fresh X25519 keypair + 32-byte nonce.
- \`digest = HMAC(secret, pubkey)\`.
- NSM attestation binds \`public_key=pubkey\` + \`user_data=digest\`; parent cannot rewrite either without invalidating the signature.

**GetClone** (donor, stays Active) — 8 checks:
1. Length validation.
2. \`cluster_public_key == our EVM address\`.
3. Verify attestation chain + PCRs.
4. Replay-check extracted nonce.
5. Attestation \`public_key\` == wire \`encryption_pubkey\`.
6. Attestation \`user_data\` == wire \`cloning_digest\`.
7. HMAC(donor_secret, pubkey) == digest.
8. Seal seed under a fresh donor ephemeral.

**SetClone** (requester, Cloning -> Active):
- Verify donor attestation + replay check.
- Pubkey binding.
- Atomic \`complete_cloning\`: decrypt, derive KeyManager, require derived EVM address matches the session's \`cluster_public_key\`, commit. On any failure the state stays in Cloning (retryable).

## Tests
New \`enclave/tests/test_clone.rs\` (behind \`mock-attestation\` + \`allow-seed-import\`) — 6 tests:
- \`clone_happy_path_copies_donor_identity_to_requester\`
- \`clone_rejects_wrong_cloning_secret\` (HMAC mismatch)
- \`clone_rejects_wrong_cluster_public_key\` (donor identity check)
- \`clone_rejects_tampered_ciphertext\` (Poly1305 tag flip)
- \`clone_rejects_duplicate_requester_attestation_nonce_on_donor\` (replay guard)
- \`cannot_initialize_after_entering_cloning\` (phase transition guard)

\`allow-seed-import\` is only used to give the donor a known fixed mnemonic for the test setup. **The cloning flow itself does NOT require \`allow-seed-import\`** — PR #20's \`initialize_from_cloned_seed\` is gated by \`Phase::Cloning\`, not a feature flag.

## Operator interface
\`enclave/src/main.rs\` reads \`UTEXO_CLONING_SECRET\` at startup and configures the donor side. Optional — requester-only enclaves can leave it unset.

## Test plan
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --workspace -- -D warnings\` clean
- [x] \`cargo test --features mock-attestation,allow-seed-import\` — 129 tests pass
- [x] \`cargo test --features mock-attestation\` — 113 tests pass
- [x] \`cargo test\` (default features, production) — 113 tests pass