### PR TITLE
fix(ci): apply cargo fmt to test_grpc_bridge.rs

### DIFF
--- a/enclave/src/keys.rs
+++ b/enclave/src/keys.rs
@@ -733,7 +733,6 @@ mod tests {
         use bitcoin::{
             Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, XOnlyPublicKey,
         };
-        use std::collections::BTreeMap;
 
         let secp = Secp256k1::new();
 
@@ -831,7 +830,7 @@ mod tests {
             .insert(control_block, (tap_script, LeafVersion::TapScript));
 
         // Set tap_key_origins for our key
-        let our_fingerprint = km.master_fingerprint().clone();
+        let our_fingerprint = *km.master_fingerprint();
         let our_derivation = DerivationPath::from(vec![
             ChildNumber::from_hardened_idx(86).unwrap(),
             ChildNumber::from_hardened_idx(1).unwrap(), // testnet
@@ -887,8 +886,6 @@ mod tests {
 
     #[test]
     fn test_sign_taproot_psbt_schnorr_signature_valid() {
-        use bitcoin::secp256k1::schnorr;
-
         let km = KeyManager::from_seed([0x42u8; 64], Network::Testnet).unwrap();
         let psbt_bytes = build_test_taproot_psbt(&km);
 

--- a/enclave/src/keys.rs
+++ b/enclave/src/keys.rs
@@ -113,7 +113,7 @@ impl KeyManager {
         let evm_uncompressed = evm_pubkey.serialize_uncompressed();
         let mut evm_uncompressed_pub = [0u8; 64];
         evm_uncompressed_pub.copy_from_slice(&evm_uncompressed[1..]);
-        let hash = Keccak256::digest(&evm_uncompressed_pub);
+        let hash = Keccak256::digest(evm_uncompressed_pub);
         let mut evm_address = [0u8; 20];
         evm_address.copy_from_slice(&hash[12..32]);
 

--- a/parent/src/client.rs
+++ b/parent/src/client.rs
@@ -1,5 +1,3 @@
-use std::net::TcpStream;
-
 use crate::enclave_proto::{
     enclave_request, enclave_response, EnclaveRequest, EnclaveResponse, EvmSignatureResponse,
     GetPublicKeyRequest, InitializeKeyRequest, InitializeKeyResponse, PublicKeysResponse,
@@ -31,6 +29,7 @@ impl EnclaveClient {
         }
         #[cfg(not(feature = "vsock"))]
         {
+            use std::net::TcpStream;
             let mut stream = TcpStream::connect(&self.addr)
                 .map_err(|e| ParentError::Connection(e.to_string()))?;
             framing::write_message(&mut stream, req)?;

--- a/parent/tests/test_grpc_bridge.rs
+++ b/parent/tests/test_grpc_bridge.rs
@@ -162,7 +162,11 @@ async fn grpc_public_key_returns_evm_address_for_swap() {
         .unwrap()
         .into_inner();
 
-    assert_eq!(resp.public_key.len(), 64, "EVM uncompressed pubkey X||Y for SWAP");
+    assert_eq!(
+        resp.public_key.len(),
+        64,
+        "EVM uncompressed pubkey X||Y for SWAP"
+    );
     assert_eq!(resp.public_key, vec![0xEE; 64]);
 }
 


### PR DESCRIPTION
## Summary
- Fix `cargo fmt --check` failure on `dev` by reformatting the overlong `assert_eq!` in `parent/tests/test_grpc_bridge.rs` (introduced in 7c8425b / a7443c7).

## Test plan
- [x] `cargo fmt --all -- --check` passes locally
- [x] CI `Check formatting` job is green