### PR TITLE
feat(proto): wire SPV header sync surface (PR 1/4)

### DIFF
--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -80,6 +80,18 @@ fn dispatch(request: EnclaveRequest, ctx: &ServerContext) -> EnclaveResponse {
             tracing::info!("request: SetClone");
             handle_set_clone(&ctx.state, req)
         }
+        Some(Request::SubmitHeaders(req)) => {
+            tracing::info!(
+                headers_len = req.headers.len(),
+                start_height = req.start_height,
+                "request: SubmitHeaders"
+            );
+            handle_submit_headers(req)
+        }
+        Some(Request::GetLastSavedBlock(req)) => {
+            tracing::info!("request: GetLastSavedBlock");
+            handle_get_last_saved_block(req)
+        }
         None => {
             tracing::warn!("received empty request (no oneof variant set)");
             return EnclaveResponse {
@@ -327,6 +339,27 @@ fn handle_proxy_federation(_req: ProxyFederationRequest) -> Result<EnclaveRespon
         response: Some(Response::Error(ErrorResponse {
             code: 2, // NOT_READY
             message: "federation proxy not yet connected to Listener".into(),
+        })),
+    })
+}
+
+// SPV header sync stubs. The proto + grpc surface is wired so the Listener's
+// header-sync daemon can compile and connect, but header validation +
+// in-memory chain land in PR 2; Merkle proof verification lands in PR 3.
+fn handle_submit_headers(_req: SubmitHeadersRequest) -> Result<EnclaveResponse> {
+    Ok(EnclaveResponse {
+        response: Some(Response::Error(ErrorResponse {
+            code: 2, // NOT_READY
+            message: "SPV header chain not yet implemented (see docs/spv-review.md)".into(),
+        })),
+    })
+}
+
+fn handle_get_last_saved_block(_req: GetLastSavedBlockRequest) -> Result<EnclaveResponse> {
+    Ok(EnclaveResponse {
+        response: Some(Response::Error(ErrorResponse {
+            code: 2, // NOT_READY
+            message: "SPV header chain not yet implemented (see docs/spv-review.md)".into(),
         })),
     })
 }

--- a/parent/src/grpc_server.rs
+++ b/parent/src/grpc_server.rs
@@ -11,8 +11,9 @@ use crate::enriched;
 const ENCLAVE_TIMEOUT: Duration = Duration::from_secs(30);
 use crate::grpc_proto::enclave_service_server::EnclaveService;
 use crate::grpc_proto::{
-    CloneRequest, CloneResponse, DataType, InitializeRequest, InitializeResponse, PublicKeyRequest,
-    PublicKeyResponse, SignRequest, Signature,
+    CloneRequest, CloneResponse, DataType, GetLastSavedBlockRequest, GetLastSavedBlockResponse,
+    InitializeRequest, InitializeResponse, PublicKeyRequest, PublicKeyResponse, SignRequest,
+    Signature, SubmitHeadersRequest, SubmitHeadersResponse,
 };
 
 /// Enclave connection target — either TCP address or vsock CID+port.
@@ -295,5 +296,78 @@ impl EnclaveService for ParentAdapterService {
         Err(Status::unimplemented(
             "Clone not yet implemented (cluster cloning)",
         ))
+    }
+
+    /// GetLastSavedBlock — forwards to enclave. PR 1 wires the surface only;
+    /// the enclave currently returns NOT_READY until the SPV header chain
+    /// lands in PR 2 (see docs/spv-review.md).
+    async fn get_last_saved_block(
+        &self,
+        _request: Request<GetLastSavedBlockRequest>,
+    ) -> Result<Response<GetLastSavedBlockResponse>, Status> {
+        tracing::info!("gRPC GetLastSavedBlock called");
+
+        let enclave_req = EnclaveRequest {
+            request: Some(enclave_request::Request::GetLastSavedBlock(
+                enclave_proto::GetLastSavedBlockRequest {},
+            )),
+        };
+
+        let resp = self.send_to_enclave(enclave_req).await?;
+
+        match resp.response {
+            Some(enclave_response::Response::GetLastSavedBlock(r)) => {
+                Ok(Response::new(GetLastSavedBlockResponse {
+                    block_height: r.block_height,
+                    block_hash: r.block_hash,
+                }))
+            }
+            Some(enclave_response::Response::Error(e)) => Err(Self::enclave_error_to_status(&e)),
+            other => Err(Status::internal(format!(
+                "unexpected enclave response for GetLastSavedBlock: {:?}",
+                other
+            ))),
+        }
+    }
+
+    /// SubmitHeaders — forwards a batch of raw 80-byte Bitcoin headers to the
+    /// enclave. PR 1 wires the surface only; the enclave currently returns
+    /// NOT_READY until the SPV header chain lands in PR 2.
+    async fn submit_headers(
+        &self,
+        request: Request<SubmitHeadersRequest>,
+    ) -> Result<Response<SubmitHeadersResponse>, Status> {
+        let inner = request.into_inner();
+        tracing::info!(
+            headers_len = inner.headers.len(),
+            start_height = inner.start_height,
+            "gRPC SubmitHeaders called"
+        );
+
+        let enclave_req = EnclaveRequest {
+            request: Some(enclave_request::Request::SubmitHeaders(
+                enclave_proto::SubmitHeadersRequest {
+                    headers: inner.headers,
+                    start_height: inner.start_height,
+                },
+            )),
+        };
+
+        let resp = self.send_to_enclave(enclave_req).await?;
+
+        match resp.response {
+            Some(enclave_response::Response::SubmitHeaders(r)) => {
+                Ok(Response::new(SubmitHeadersResponse {
+                    last_block_height: r.last_block_height,
+                    last_block_hash: r.last_block_hash,
+                    headers_accepted: r.headers_accepted,
+                }))
+            }
+            Some(enclave_response::Response::Error(e)) => Err(Self::enclave_error_to_status(&e)),
+            other => Err(Status::internal(format!(
+                "unexpected enclave response for SubmitHeaders: {:?}",
+                other
+            ))),
+        }
     }
 }

--- a/parent/tests/test_grpc_bridge.rs
+++ b/parent/tests/test_grpc_bridge.rs
@@ -78,6 +78,23 @@ fn start_mock_enclave() -> u16 {
                         },
                     )),
                 },
+                Some(enclave_request::Request::GetLastSavedBlock(_)) => EnclaveResponse {
+                    response: Some(enclave_response::Response::GetLastSavedBlock(
+                        enclave_proto::GetLastSavedBlockResponse {
+                            block_height: 215_000,
+                            block_hash: vec![0x11; 32],
+                        },
+                    )),
+                },
+                Some(enclave_request::Request::SubmitHeaders(req)) => EnclaveResponse {
+                    response: Some(enclave_response::Response::SubmitHeaders(
+                        enclave_proto::SubmitHeadersResponse {
+                            last_block_height: req.start_height + req.headers.len() as u32 - 1,
+                            last_block_hash: vec![0x22; 32],
+                            headers_accepted: req.headers.len() as u32,
+                        },
+                    )),
+                },
                 _ => EnclaveResponse {
                     response: Some(enclave_response::Response::Error(
                         enclave_proto::ErrorResponse {
@@ -192,6 +209,7 @@ async fn grpc_sign_evm_roundtrip() {
         calldata_commission: 0,
         consignment: vec![],
         consignment_hash: vec![],
+        merkle_proofs: vec![],
     };
 
     let req = SignRequest {
@@ -293,6 +311,7 @@ async fn grpc_evm_passes_enriched_fields_through() {
         calldata_commission: 5,
         consignment: consignment_bytes.clone(),
         consignment_hash: consignment_hash.clone(),
+        merkle_proofs: vec![],
     };
 
     let req = SignRequest {
@@ -366,6 +385,7 @@ async fn grpc_evm_forwards_raw_consignment_bytes() {
         calldata_commission: 0,
         consignment: consignment_bytes.clone(),
         consignment_hash: consignment_hash.clone(),
+        merkle_proofs: vec![],
     };
 
     let req = SignRequest {
@@ -456,4 +476,47 @@ async fn grpc_initialize_roundtrip() {
         33,
         "public_key should be BTC compressed pubkey"
     );
+}
+
+#[tokio::test]
+async fn grpc_get_last_saved_block_roundtrip() {
+    let enclave_port = start_mock_enclave();
+    let grpc_port = start_grpc_server(enclave_port).await;
+
+    let mut client = EnclaveServiceClient::connect(format!("http://127.0.0.1:{grpc_port}"))
+        .await
+        .unwrap();
+
+    let resp = client
+        .get_last_saved_block(utexo_bridge_parent::grpc_proto::GetLastSavedBlockRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(resp.block_height, 215_000);
+    assert_eq!(resp.block_hash, vec![0x11; 32]);
+}
+
+#[tokio::test]
+async fn grpc_submit_headers_roundtrip() {
+    let enclave_port = start_mock_enclave();
+    let grpc_port = start_grpc_server(enclave_port).await;
+
+    let mut client = EnclaveServiceClient::connect(format!("http://127.0.0.1:{grpc_port}"))
+        .await
+        .unwrap();
+
+    let headers = vec![vec![0xAB; 80], vec![0xCD; 80], vec![0xEF; 80]];
+    let resp = client
+        .submit_headers(utexo_bridge_parent::grpc_proto::SubmitHeadersRequest {
+            headers: headers.clone(),
+            start_height: 215_001,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(resp.last_block_height, 215_003);
+    assert_eq!(resp.last_block_hash, vec![0x22; 32]);
+    assert_eq!(resp.headers_accepted, 3);
 }

--- a/proto/enclave.proto
+++ b/proto/enclave.proto
@@ -15,6 +15,8 @@ message EnclaveRequest {
     InitiateCloningRequest initiate_cloning  = 7;
     GetCloneRequest        get_clone         = 8;
     SetCloneRequest        set_clone         = 9;
+    SubmitHeadersRequest      submit_headers        = 11;
+    GetLastSavedBlockRequest  get_last_saved_block  = 12;
     // Reserved for future:
     // HealthCheckRequest  health_check     = 10;
   }
@@ -31,6 +33,8 @@ message EnclaveResponse {
     InitiateCloningResponse initiate_cloning = 7;
     GetCloneResponse        get_clone        = 8;
     SetCloneResponse        set_clone        = 9;
+    SubmitHeadersResponse      submit_headers       = 11;
+    GetLastSavedBlockResponse  get_last_saved_block = 12;
     // Reserved for future:
     // HealthCheckResponse  health_check     = 10;
     ErrorResponse           error            = 15;
@@ -220,6 +224,40 @@ message SetCloneRequest {
 // the wire (matching every other request). The body is intentionally empty
 // — a successful SetClone is silent and the caller probes GetPublicKey.
 message SetCloneResponse {
+}
+
+// === SPV — Bitcoin header sync ===
+//
+// Listener pushes block headers into the enclave's in-memory chain so the
+// enclave can verify Merkle inclusion proofs (delivered alongside
+// EnrichedEvmPayload.merkle_proofs) before signing. The enclave is passive:
+// the Listener drives sync, the enclave validates and stores.
+//
+// PR 1 wires up the proto + grpc surface only; the handlers return
+// ErrorResponse(NOT_READY). Header validation, in-memory chain, and Merkle
+// proof verification land in subsequent PRs (see docs/spv-review.md).
+
+message SubmitHeadersRequest {
+  // Raw 80-byte Bitcoin headers (batch, contiguous, in ascending height order).
+  // Listener typically batches up to ~500 to keep gRPC messages small.
+  repeated bytes headers      = 1;
+  // Block height of headers[0]. Headers must connect to the enclave's stored
+  // chain (i.e. start_height == last_saved_height + 1) — except for the very
+  // first batch which connects to the compiled-in checkpoint.
+  uint32         start_height = 2;
+}
+
+message SubmitHeadersResponse {
+  uint32 last_block_height = 1;  // enclave's tip after applying this batch
+  bytes  last_block_hash   = 2;  // 32 bytes
+  uint32 headers_accepted  = 3;  // number of headers from the batch that validated
+}
+
+message GetLastSavedBlockRequest {}
+
+message GetLastSavedBlockResponse {
+  uint32 block_height = 1;       // height of the latest header the enclave has
+  bytes  block_hash   = 2;       // 32 bytes
 }
 
 // === Error ===

--- a/proto/enriched-payload.proto
+++ b/proto/enriched-payload.proto
@@ -59,4 +59,18 @@ message EnrichedEvmPayload {
   bytes consignment = 11;
   // keccak256(consignment) — 32 bytes; Enclave integrity check (see SignEvmRequest).
   bytes consignment_hash = 12;
+
+  // SPV proofs for consignment anchor txids (one entry per witness tx in the consignment).
+  // Listener fetches each from Esplora; Enclave verifies each against its cached header chain
+  // before signing. See proto/enclave.proto MerkleProofEntry for the wire format.
+  repeated MerkleProofEntry merkle_proofs = 13;
+}
+
+// Proof that a Bitcoin transaction is included in a specific block.
+// Listener fetches these from Esplora and passes to Enclave inside EnrichedEvmPayload.
+message MerkleProofEntry {
+  bytes  txid         = 1;  // 32 bytes — transaction being proven
+  uint32 block_height = 2;  // block number where the tx was included
+  uint32 tx_position  = 3;  // position of tx in the block's tx list
+  repeated bytes merkle_path = 4;  // sibling hashes from leaf to root (each 32 bytes)
 }

--- a/proto/parentadapter.proto
+++ b/proto/parentadapter.proto
@@ -22,6 +22,14 @@ service EnclaveService {
 
   // Requests HD seed from peer enclave (cluster cloning with attestation).
   rpc Clone(CloneRequest) returns (CloneResponse);
+
+  // Returns the last block header stored in enclave's in-memory cache.
+  // Listener calls this to know from where to resume header sync.
+  rpc GetLastSavedBlock(GetLastSavedBlockRequest) returns (GetLastSavedBlockResponse);
+
+  // Pushes a batch of Bitcoin block headers into the enclave's cache.
+  // Listener fetches from Esplora and feeds them in ascending-height batches.
+  rpc SubmitHeaders(SubmitHeadersRequest) returns (SubmitHeadersResponse);
 }
 
 message InitializeRequest {
@@ -40,4 +48,26 @@ message CloneRequest {
 
 message CloneResponse {
   bytes encrypted_seed = 1;
+}
+
+// --- SPV: Bitcoin header sync ---
+// Mirrors enclave.proto SubmitHeaders / GetLastSavedBlock. The Parent Adapter
+// forwards these unchanged to the enclave wire protocol.
+
+message GetLastSavedBlockRequest {}
+
+message GetLastSavedBlockResponse {
+  uint32 block_height = 1;
+  bytes  block_hash   = 2;   // 32 bytes
+}
+
+message SubmitHeadersRequest {
+  repeated bytes headers      = 1;   // raw 80-byte Bitcoin headers (batch of up to ~500)
+  uint32         start_height = 2;   // block number of the first header in this batch
+}
+
+message SubmitHeadersResponse {
+  uint32 last_block_height = 1;      // enclave's latest block after processing
+  bytes  last_block_hash   = 2;      // 32 bytes
+  uint32 headers_accepted  = 3;      // how many from the batch were valid
 }


### PR DESCRIPTION
## Summary

PR 1 of 4 in the SPV verification stack. Wires the proto + gRPC surface so [federated-signer-node #35/#36/#37](https://github.com/UTEXO-Protocol/federated-signer-node/pulls?q=is%3Apr+is%3Aopen+spv) can compile and connect end-to-end. **Wire only** — no header validation, no in-memory chain, no Merkle verification yet. The enclave returns `NOT_READY` for both new RPCs until PR 2 lands.

See `docs/spv-review.md` (gitignored locally) for the full design review and the staging plan.

## Changes

- **`proto/enriched-payload.proto`** — new `MerkleProofEntry` message; `merkle_proofs` field 13 on `EnrichedEvmPayload`. 1:1 with the listener's `tricorn.enriched.MerkleProofEntry`.
- **`proto/enclave.proto`** — new `SubmitHeadersRequest/Response` and `GetLastSavedBlockRequest/Response` messages; oneof tags 11/12 on both `EnclaveRequest` and `EnclaveResponse`.
- **`proto/parentadapter.proto`** — matching `GetLastSavedBlock` and `SubmitHeaders` RPCs on `EnclaveService`, plus their request/response messages.
- **`enclave/src/server.rs`** — dispatch arms + stub handlers returning `ErrorResponse { code: 2 (NOT_READY) }`.
- **`parent/src/grpc_server.rs`** — gRPC handlers that forward to the enclave. Field names are 1:1 between gRPC and wire so there is no translation, just envelope wrapping.
- **`parent/tests/test_grpc_bridge.rs`** — backfill `merkle_proofs: vec![]` on the three existing `EnrichedEvmPayload` fixtures; two new smoke tests (`grpc_get_last_saved_block_roundtrip`, `grpc_submit_headers_roundtrip`) that lock in the field mappings via a happy-path mock enclave.

## Why this is safe to land before the rest

- Additive proto changes only. No existing field renumbered or removed.
- Listener side defaults `SPV_ENABLED=false`, so existing flows don't call the new RPCs.
- Stub returns `NOT_READY` — if the listener does call them with SPV enabled, it gets a clean error rather than hanging.

## Follow-ups (separate PRs)

- **PR 2** — header chain module: in-memory store, signet (BIP-325) + mainnet (PoW + retarget) header validation via the `bitcoin` crate, Merkle proof verifier. Pure logic, heavy unit tests.
- **PR 3** — wire into `handle_sign_evm`: extract witness txids from `Transfer::bundles`, require `merkle_proofs` covers all of them, verify each against the header chain, enforce `SPV_MIN_CONFIRMATIONS`. Behind `spv` cargo feature; default off.
- **PR 4** — header staleness rule (refuse to sign if newest header is too old vs wall clock).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test --workspace` — all green
- [x] `cargo test -p utexo-bridge-enclave --features rgb-validation` — 91 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] Listener-side smoke: pull federated-signer-node spv-header-sync, point at a parent-adapter built from this branch, verify `header_sync.go` gets `NOT_READY` (code 2) and logs the warning rather than hanging