### PR TITLE
feat(spv): in-enclave Bitcoin header chain + Merkle verifier (PR 2/4)

### DIFF
--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -7,6 +7,7 @@ pub mod framing;
 pub mod keys;
 pub mod server;
 pub mod signing;
+pub mod spv;
 pub mod state;
 pub mod validation;
 #[cfg(all(feature = "vsock", target_os = "linux"))]

--- a/enclave/src/spv/chain.rs
+++ b/enclave/src/spv/chain.rs
@@ -1,0 +1,401 @@
+//! In-memory Bitcoin header chain.
+//!
+//! The chain starts at a compile-time `Checkpoint` (height + hash + bits +
+//! time) and grows forward as the Listener pushes batches of contiguous
+//! 80-byte headers via `submit_headers`. Each header is validated against
+//! its predecessor (chain linkage + PoW + nBits) before being appended.
+//!
+//! ## What this module does NOT do (yet)
+//!
+//! - **Reorgs.** `submit_headers` is strictly append-only. A header that
+//!   doesn't extend the current tip is rejected. Bounded reorg support
+//!   (replace last N headers when a deeper alternative is presented) is a
+//!   follow-up. Confirmation depth ≥ 6 means small reorgs at the tip are
+//!   tolerable for signing decisions.
+//! - **BIP-325 signet signature.** Out of scope for PR 2, see validation.rs.
+//! - **Header staleness.** Refusing to use a stale tip for confirmation
+//!   counts is PR 4.
+
+use bitcoin::block::Header;
+use bitcoin::consensus::deserialize;
+
+use crate::spv::checkpoint::Checkpoint;
+use crate::spv::types::{BlockHash, BlockHeight, Network, Result, SpvError};
+use crate::spv::validation::{
+    expected_bits, is_retarget_height, validate_header_full, RETARGET_INTERVAL,
+};
+
+/// Outcome of pushing a batch of headers.
+#[derive(Debug, Clone, Copy)]
+pub struct SubmitOutcome {
+    pub last_block_height: BlockHeight,
+    pub last_block_hash: BlockHash,
+    /// Number of headers from the batch that were accepted before either the
+    /// batch ran out or one was rejected. The current implementation aborts
+    /// on the first rejection, so this is "headers up to but not including
+    /// the bad one". A future PR may surface partial acceptance differently.
+    pub headers_accepted: u32,
+}
+
+/// In-memory store of validated block headers, anchored to a checkpoint.
+pub struct HeaderChain {
+    network: Network,
+    checkpoint: Checkpoint,
+    /// Validated headers, in ascending height. Index `i` is the header at
+    /// height `checkpoint.height + 1 + i`.
+    headers: Vec<Header>,
+    /// Cached hashes (internal byte order) parallel to `headers`. Avoids
+    /// recomputing on every linkage check.
+    hashes: Vec<BlockHash>,
+}
+
+impl HeaderChain {
+    /// Initialise an empty chain anchored at `checkpoint`. Call
+    /// `submit_headers` to populate.
+    pub fn new(network: Network, checkpoint: Checkpoint) -> Self {
+        Self {
+            network,
+            checkpoint,
+            headers: Vec::new(),
+            hashes: Vec::new(),
+        }
+    }
+
+    pub fn network(&self) -> Network {
+        self.network
+    }
+
+    pub fn checkpoint(&self) -> &Checkpoint {
+        &self.checkpoint
+    }
+
+    /// Height of the most recent validated header (or the checkpoint, if no
+    /// headers have been accepted yet).
+    pub fn tip_height(&self) -> BlockHeight {
+        self.checkpoint.height + self.headers.len() as BlockHeight
+    }
+
+    /// Hash of the most recent validated header (or the checkpoint hash).
+    pub fn tip_hash(&self) -> BlockHash {
+        if let Some(last) = self.hashes.last() {
+            *last
+        } else {
+            self.checkpoint.hash
+        }
+    }
+
+    /// Number of validated headers stored (excludes the checkpoint itself).
+    pub fn len(&self) -> usize {
+        self.headers.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.headers.is_empty()
+    }
+
+    /// Look up a stored header by height. The checkpoint height returns
+    /// `None` because we don't keep the checkpoint header itself, only its
+    /// metadata (we hardcode hash/bits/time).
+    pub fn header_at(&self, height: BlockHeight) -> Option<&Header> {
+        if height <= self.checkpoint.height {
+            return None;
+        }
+        let idx = (height - self.checkpoint.height - 1) as usize;
+        self.headers.get(idx)
+    }
+
+    /// Look up a stored hash by height. Returns the checkpoint hash for its
+    /// own height — useful for chain-linkage checks across the boundary.
+    pub fn hash_at(&self, height: BlockHeight) -> Option<BlockHash> {
+        if height == self.checkpoint.height {
+            return Some(self.checkpoint.hash);
+        }
+        if height < self.checkpoint.height {
+            return None;
+        }
+        let idx = (height - self.checkpoint.height - 1) as usize;
+        self.hashes.get(idx).copied()
+    }
+
+    /// Append a batch of contiguous 80-byte headers starting at
+    /// `start_height`. Each header is parsed, linked to its predecessor,
+    /// and (on networks with PoW) its bits/PoW are checked.
+    ///
+    /// Validation is strict: the first failure aborts the batch and the
+    /// chain is left exactly as it was before this call.
+    pub fn submit_headers(
+        &mut self,
+        start_height: BlockHeight,
+        raw_headers: &[Vec<u8>],
+    ) -> Result<SubmitOutcome> {
+        let expected_start = self.tip_height() + 1;
+        if start_height != expected_start {
+            return Err(SpvError::NonContiguous {
+                got: start_height,
+                expected: expected_start,
+            });
+        }
+
+        // Stage parsed headers + hashes; only commit if the whole batch validates.
+        let mut staged: Vec<(Header, BlockHash)> = Vec::with_capacity(raw_headers.len());
+
+        for (i, raw) in raw_headers.iter().enumerate() {
+            let header: Header = deserialize(raw).map_err(|e| SpvError::HeaderParse {
+                index: i,
+                message: e.to_string(),
+            })?;
+
+            let height = start_height + i as BlockHeight;
+
+            // Predecessor lookup: previous staged item, or the chain tip
+            // (which may be the checkpoint itself if we're staging the
+            // first-ever header).
+            let (prev_hash, prev_bits, prev_time) = if let Some((prev_h, prev_hash)) = staged.last()
+            {
+                (*prev_hash, prev_h.bits.to_consensus(), prev_h.time)
+            } else if let Some(last) = self.headers.last() {
+                let prev_hash = *self.hashes.last().expect("hashes parallel to headers");
+                (prev_hash, last.bits.to_consensus(), last.time)
+            } else {
+                (
+                    self.checkpoint.hash,
+                    self.checkpoint.bits,
+                    self.checkpoint.time,
+                )
+            };
+
+            let epoch_start_time = self.epoch_start_time(height, &staged)?;
+
+            let expected_bits_value =
+                expected_bits(height, prev_bits, prev_time, epoch_start_time, self.network)?;
+
+            validate_header_full(
+                &header,
+                height,
+                &prev_hash,
+                expected_bits_value,
+                self.network,
+            )?;
+
+            let hash: [u8; 32] = *bitcoin::hashes::Hash::as_byte_array(&header.block_hash());
+            staged.push((header, hash));
+        }
+
+        // All-or-nothing: only after every header validates do we mutate state.
+        let accepted = staged.len() as u32;
+        for (header, hash) in staged {
+            self.headers.push(header);
+            self.hashes.push(hash);
+        }
+
+        Ok(SubmitOutcome {
+            last_block_height: self.tip_height(),
+            last_block_hash: self.tip_hash(),
+            headers_accepted: accepted,
+        })
+    }
+
+    /// Find the timestamp of the block at the start of the retarget epoch
+    /// containing `height`. Looks first in the staged batch, then in the
+    /// committed chain, then at the checkpoint (legitimate when the
+    /// checkpoint sits exactly on a retarget boundary).
+    ///
+    /// Only meaningful at retarget boundaries; on non-boundary heights the
+    /// caller ignores the value.
+    fn epoch_start_time(&self, height: BlockHeight, staged: &[(Header, BlockHash)]) -> Result<u32> {
+        if !is_retarget_height(height) {
+            // Sentinel: any value, caller ignores it.
+            return Ok(0);
+        }
+
+        // The epoch start is the block at `height - RETARGET_INTERVAL`.
+        if height < RETARGET_INTERVAL {
+            // Genesis epoch boundary on regtest etc. — ignore.
+            return Ok(0);
+        }
+        let target_height = height - RETARGET_INTERVAL;
+
+        // Staged batch?
+        if target_height > self.tip_height() {
+            let staged_idx = (target_height - self.tip_height() - 1) as usize;
+            if let Some((h, _)) = staged.get(staged_idx) {
+                return Ok(h.time);
+            }
+        }
+
+        // Committed chain?
+        if target_height > self.checkpoint.height {
+            if let Some(h) = self.header_at(target_height) {
+                return Ok(h.time);
+            }
+        }
+
+        // Checkpoint?
+        if target_height == self.checkpoint.height {
+            return Ok(self.checkpoint.time);
+        }
+
+        Err(SpvError::HeaderNotFound(target_height))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::consensus::serialize;
+    use bitcoin::hashes::Hash;
+
+    /// Synthetic mainnet-shaped chain: we mint our own checkpoint + headers,
+    /// each with valid PoW under regtest rules, and run through the chain
+    /// linkage logic. Avoids the cost of fixtures with real-difficulty
+    /// PoW for every block.
+    fn synthetic_regtest_setup() -> (HeaderChain, Vec<Vec<u8>>) {
+        // Regtest is "chain linkage only" in our validator — no PoW or bits
+        // enforcement — so we can build a tiny synthetic chain without
+        // actually mining anything.
+        let mut prev_hash = [0u8; 32];
+        prev_hash[0] = 0xAA; // arbitrary checkpoint hash
+
+        let checkpoint = Checkpoint {
+            height: 100,
+            hash: prev_hash,
+            bits: 0x207fffff,
+            time: 1_700_000_000,
+            is_real: false,
+        };
+        let chain = HeaderChain::new(Network::Regtest, checkpoint);
+
+        let mut raws: Vec<Vec<u8>> = Vec::new();
+        let mut prev = bitcoin::BlockHash::from_raw_hash(
+            bitcoin::hashes::sha256d::Hash::from_byte_array(prev_hash),
+        );
+        for i in 0..5 {
+            let header = Header {
+                version: bitcoin::block::Version::ONE,
+                prev_blockhash: prev,
+                merkle_root: bitcoin::TxMerkleNode::all_zeros(),
+                time: 1_700_000_001 + i,
+                bits: bitcoin::CompactTarget::from_consensus(0x207fffff),
+                nonce: i,
+            };
+            raws.push(serialize(&header));
+            prev = header.block_hash();
+        }
+        (chain, raws)
+    }
+
+    #[test]
+    fn empty_chain_tip_is_checkpoint() {
+        let (chain, _) = synthetic_regtest_setup();
+        assert_eq!(chain.tip_height(), 100);
+        assert_eq!(chain.tip_hash()[0], 0xAA);
+        assert_eq!(chain.len(), 0);
+        assert!(chain.is_empty());
+    }
+
+    #[test]
+    fn submits_contiguous_batch() {
+        let (mut chain, raws) = synthetic_regtest_setup();
+        let outcome = chain.submit_headers(101, &raws).unwrap();
+        assert_eq!(outcome.headers_accepted, 5);
+        assert_eq!(outcome.last_block_height, 105);
+        assert_eq!(chain.tip_height(), 105);
+        assert_eq!(chain.len(), 5);
+    }
+
+    #[test]
+    fn rejects_non_contiguous_batch() {
+        let (mut chain, raws) = synthetic_regtest_setup();
+        let err = chain.submit_headers(102, &raws).unwrap_err();
+        assert!(matches!(
+            err,
+            SpvError::NonContiguous {
+                got: 102,
+                expected: 101
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_broken_linkage() {
+        let (mut chain, raws) = synthetic_regtest_setup();
+        // Submit the first one to advance the tip.
+        chain.submit_headers(101, &raws[..1]).unwrap();
+        // Now submit the FIRST raw again at height 102 — its prev_blockhash
+        // points to the checkpoint, not to height 101's hash.
+        let err = chain.submit_headers(102, &raws[..1]).unwrap_err();
+        assert!(matches!(err, SpvError::ChainLinkage { height: 102 }));
+    }
+
+    #[test]
+    fn header_lookup_by_height() {
+        let (mut chain, raws) = synthetic_regtest_setup();
+        chain.submit_headers(101, &raws).unwrap();
+
+        // Checkpoint height: header() returns None, but hash() returns the
+        // checkpoint hash.
+        assert!(chain.header_at(100).is_none());
+        assert_eq!(chain.hash_at(100).unwrap()[0], 0xAA);
+
+        // Validated heights: both lookups work.
+        assert!(chain.header_at(101).is_some());
+        assert!(chain.header_at(105).is_some());
+        // Out of range:
+        assert!(chain.header_at(106).is_none());
+        assert!(chain.header_at(99).is_none());
+    }
+
+    #[test]
+    fn rejects_garbage_header_bytes() {
+        let (mut chain, _) = synthetic_regtest_setup();
+        let err = chain
+            .submit_headers(101, &[vec![0u8; 79]]) // 79 bytes != 80
+            .unwrap_err();
+        assert!(matches!(err, SpvError::HeaderParse { index: 0, .. }));
+    }
+
+    #[test]
+    fn batch_is_atomic_on_failure() {
+        let (mut chain, mut raws) = synthetic_regtest_setup();
+        // Corrupt the third raw header so it won't parse.
+        raws[2] = vec![0u8; 79];
+
+        let pre_tip = chain.tip_height();
+        let pre_len = chain.len();
+        let err = chain.submit_headers(101, &raws).unwrap_err();
+        assert!(matches!(err, SpvError::HeaderParse { index: 2, .. }));
+
+        // Chain MUST be unchanged: no partial accept.
+        assert_eq!(chain.tip_height(), pre_tip);
+        assert_eq!(chain.len(), pre_len);
+    }
+
+    /// Mainnet PoW + bits checks: feed the real block 1 into a chain whose
+    /// checkpoint claims to be the genesis. Bits at non-boundary blocks must
+    /// equal previous block's bits, and PoW must hold.
+    #[test]
+    fn mainnet_block_1_appends_after_genesis_checkpoint() {
+        // Mainnet genesis facts (well-known):
+        // height=0, hash (internal) below, bits=0x1d00ffff, time=1231006505
+        let genesis_hash_internal: [u8; 32] = [
+            0x6f, 0xe2, 0x8c, 0x0a, 0xb6, 0xf1, 0xb3, 0x72, 0xc1, 0xa6, 0xa2, 0x46, 0xae, 0x63,
+            0xf7, 0x4f, 0x93, 0x1e, 0x83, 0x65, 0xe1, 0x5a, 0x08, 0x9c, 0x68, 0xd6, 0x19, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ];
+        let cp = Checkpoint {
+            height: 0,
+            hash: genesis_hash_internal,
+            bits: 0x1d00ffff,
+            time: 1_231_006_505,
+            is_real: false,
+        };
+        let mut chain = HeaderChain::new(Network::Mainnet, cp);
+
+        let block_1_hex = "010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e36299";
+        let raw = hex::decode(block_1_hex).unwrap();
+
+        let outcome = chain.submit_headers(1, &[raw]).unwrap();
+        assert_eq!(outcome.last_block_height, 1);
+        assert_eq!(outcome.headers_accepted, 1);
+    }
+}

--- a/enclave/src/spv/checkpoint.rs
+++ b/enclave/src/spv/checkpoint.rs
@@ -1,0 +1,88 @@
+//! Compile-time checkpoint constants — the trust anchors for the in-enclave
+//! header chain.
+//!
+//! A checkpoint is `(height, block_hash)`. On boot the enclave starts empty;
+//! the Listener feeds headers starting at `height + 1`, and the first header
+//! must chain to `block_hash`. Every checkpoint here ends up in PCR0 because
+//! it's compiled in, so changing one means re-attestation.
+//!
+//! All values below are PLACEHOLDERS pending the constants the team picks.
+//! They MUST be replaced before this module is wired into the signing path
+//! (PR 3). Building with placeholders is allowed for unit tests today, but
+//! a release build for production will refuse to start (see `assert_real()`).
+
+use crate::spv::types::{BlockHash, BlockHeight};
+
+/// A trust anchor: the enclave only accepts headers that chain forward from
+/// this point, in ascending height.
+#[derive(Debug, Clone, Copy)]
+pub struct Checkpoint {
+    pub height: BlockHeight,
+    pub hash: BlockHash,
+    /// The compact-encoded `nBits` (difficulty target) at this block. Needed
+    /// because the next header's `nBits` must equal this until the next
+    /// retarget boundary.
+    pub bits: u32,
+    /// The block timestamp. Needed when this checkpoint coincides with a
+    /// retarget boundary so we can drive `from_next_work_required()`.
+    pub time: u32,
+    /// Set to true once the values are real (not placeholders). Production
+    /// builds refuse to start otherwise.
+    pub is_real: bool,
+}
+
+/// Mainnet checkpoint. PLACEHOLDER — replace with a real recent finalized
+/// block before production.
+pub const MAINNET_CHECKPOINT: Checkpoint = Checkpoint {
+    height: 0,
+    hash: [0u8; 32],
+    bits: 0,
+    time: 0,
+    is_real: false,
+};
+
+/// Signet checkpoint. PLACEHOLDER — replace once the team confirms
+/// default-signet vs custom-signet (see docs/spv-review.md §4).
+pub const SIGNET_CHECKPOINT: Checkpoint = Checkpoint {
+    height: 0,
+    hash: [0u8; 32],
+    bits: 0,
+    time: 0,
+    is_real: false,
+};
+
+/// Testnet3 checkpoint. PLACEHOLDER — testnet3 isn't a target environment
+/// today, but kept symmetric with the Network enum.
+pub const TESTNET3_CHECKPOINT: Checkpoint = Checkpoint {
+    height: 0,
+    hash: [0u8; 32],
+    bits: 0,
+    time: 0,
+    is_real: false,
+};
+
+/// Regtest checkpoint. Genesis is fine for regtest because anyone can mine.
+pub const REGTEST_CHECKPOINT: Checkpoint = Checkpoint {
+    height: 0,
+    hash: [0u8; 32],
+    bits: 0x207fffff, // regtest min difficulty (1d00ffff << for testnet, 0x207fffff for regtest)
+    time: 1_296_688_602,
+    is_real: false,
+};
+
+impl Checkpoint {
+    /// Refuse to construct a `HeaderChain` against a placeholder checkpoint
+    /// in production-shaped builds. Tests are exempt.
+    pub fn assert_real_in_release(&self) -> Result<(), &'static str> {
+        if cfg!(debug_assertions) || cfg!(test) {
+            return Ok(());
+        }
+        if !self.is_real {
+            return Err(
+                "SPV checkpoint is a placeholder — refuse to start a release build. \
+                 Update enclave/src/spv/checkpoint.rs before deploying.",
+            );
+        }
+        Ok(())
+    }
+}

--- a/enclave/src/spv/merkle.rs
+++ b/enclave/src/spv/merkle.rs
@@ -1,0 +1,209 @@
+//! Bitcoin Merkle inclusion proof verification.
+//!
+//! Reconstructs a block's Merkle root from a single transaction id, its
+//! position in the block, and the sibling hashes along its path. The result
+//! is compared against the Merkle root committed in a validated block header.
+//!
+//! Wire format note: Bitcoin merkle nodes are computed in *internal* (little-
+//! endian) byte order, but block explorers (Esplora included) typically
+//! display txids and sibling hashes in *display* (big-endian) byte order.
+//! The verifier here operates strictly on internal-order bytes — callers are
+//! responsible for reversing display-order hex strings before passing them in.
+//!
+//! Bitcoin's classic Merkle tree has a known degenerate property: when a
+//! level has an odd number of nodes, the last node is duplicated. This is
+//! handled implicitly here because the proof-walk shape encodes the choice
+//! at each step (sibling-on-the-right vs sibling-on-the-left), which the
+//! prover already accounts for. We do not synthesise the duplication
+//! ourselves; we trust the supplied path. The position index is what tells
+//! us whether each sibling is on the left or the right.
+
+use bitcoin::hashes::{sha256d, Hash};
+
+/// 32-byte hash in Bitcoin internal byte order.
+pub type Sha256d = [u8; 32];
+
+/// Result of a Merkle inclusion check. Distinguishes "math is wrong" from
+/// "you fed me garbage" so callers can produce useful errors.
+#[derive(Debug, PartialEq, Eq)]
+pub enum MerkleError {
+    /// A sibling hash in the path was the wrong length.
+    BadSiblingLength { index: usize, len: usize },
+    /// Reconstructed root did not match the header's committed root.
+    RootMismatch {
+        computed: Sha256d,
+        expected: Sha256d,
+    },
+}
+
+/// Verify that `txid` (in internal byte order) is included in a block whose
+/// `merkle_root` (also internal order) we already trust, given its `position`
+/// in the block's tx list and the `path` of sibling hashes from leaf to root.
+///
+/// Returns `Ok(())` on inclusion, an error otherwise.
+///
+/// `path` may be empty — that's the legitimate case where the block contains
+/// exactly one transaction (the coinbase) and the txid *is* the merkle root.
+pub fn verify_merkle_proof(
+    txid: &Sha256d,
+    position: u32,
+    path: &[Sha256d],
+    merkle_root: &Sha256d,
+) -> Result<(), MerkleError> {
+    let mut current = *txid;
+    let mut idx = position;
+
+    for (i, sibling) in path.iter().enumerate() {
+        if sibling.len() != 32 {
+            // unreachable given the [u8; 32] type, but kept defensively for
+            // the day we accept Vec<Vec<u8>> at the boundary
+            return Err(MerkleError::BadSiblingLength {
+                index: i,
+                len: sibling.len(),
+            });
+        }
+
+        // Bottom bit of the position determines which side `current` is on:
+        //   bit == 0 -> we are the LEFT child, sibling is on the right.
+        //   bit == 1 -> we are the RIGHT child, sibling is on the left.
+        let mut buf = [0u8; 64];
+        if idx & 1 == 0 {
+            buf[..32].copy_from_slice(&current);
+            buf[32..].copy_from_slice(sibling);
+        } else {
+            buf[..32].copy_from_slice(sibling);
+            buf[32..].copy_from_slice(&current);
+        }
+
+        current = sha256d::Hash::hash(&buf).to_byte_array();
+        idx >>= 1;
+    }
+
+    if &current == merkle_root {
+        Ok(())
+    } else {
+        Err(MerkleError::RootMismatch {
+            computed: current,
+            expected: *merkle_root,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::hashes::{sha256d, Hash};
+
+    /// Helper: double-SHA256 of two concatenated 32-byte hashes.
+    fn dsha256_pair(left: &Sha256d, right: &Sha256d) -> Sha256d {
+        let mut buf = [0u8; 64];
+        buf[..32].copy_from_slice(left);
+        buf[32..].copy_from_slice(right);
+        sha256d::Hash::hash(&buf).to_byte_array()
+    }
+
+    #[test]
+    fn empty_path_means_txid_equals_root() {
+        // Single-tx block: the txid IS the merkle root.
+        let txid: Sha256d = [0x42; 32];
+        let root = txid;
+        assert!(verify_merkle_proof(&txid, 0, &[], &root).is_ok());
+    }
+
+    #[test]
+    fn empty_path_rejects_when_txid_neq_root() {
+        let txid: Sha256d = [0x42; 32];
+        let root: Sha256d = [0x43; 32];
+        assert!(matches!(
+            verify_merkle_proof(&txid, 0, &[], &root),
+            Err(MerkleError::RootMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn two_tx_block_left_position() {
+        // 2-tx block: root = sha256d(tx0 || tx1).
+        let tx0: Sha256d = [0x11; 32];
+        let tx1: Sha256d = [0x22; 32];
+        let root = dsha256_pair(&tx0, &tx1);
+
+        // Proof for tx0 (position 0): path = [tx1].
+        assert!(verify_merkle_proof(&tx0, 0, &[tx1], &root).is_ok());
+    }
+
+    #[test]
+    fn two_tx_block_right_position() {
+        let tx0: Sha256d = [0x11; 32];
+        let tx1: Sha256d = [0x22; 32];
+        let root = dsha256_pair(&tx0, &tx1);
+
+        // Proof for tx1 (position 1): path = [tx0].
+        assert!(verify_merkle_proof(&tx1, 1, &[tx0], &root).is_ok());
+    }
+
+    #[test]
+    fn four_tx_block_each_position() {
+        // 4-tx block: standard balanced merkle tree.
+        //          root
+        //         /    \
+        //       n01    n23
+        //       / \    / \
+        //      t0 t1  t2 t3
+        let t0: Sha256d = [0x10; 32];
+        let t1: Sha256d = [0x20; 32];
+        let t2: Sha256d = [0x30; 32];
+        let t3: Sha256d = [0x40; 32];
+        let n01 = dsha256_pair(&t0, &t1);
+        let n23 = dsha256_pair(&t2, &t3);
+        let root = dsha256_pair(&n01, &n23);
+
+        // Proof for t0: position 0, path = [t1, n23]
+        assert!(verify_merkle_proof(&t0, 0, &[t1, n23], &root).is_ok());
+        // Proof for t1: position 1, path = [t0, n23]
+        assert!(verify_merkle_proof(&t1, 1, &[t0, n23], &root).is_ok());
+        // Proof for t2: position 2, path = [t3, n01]
+        assert!(verify_merkle_proof(&t2, 2, &[t3, n01], &root).is_ok());
+        // Proof for t3: position 3, path = [t2, n01]
+        assert!(verify_merkle_proof(&t3, 3, &[t2, n01], &root).is_ok());
+    }
+
+    #[test]
+    fn rejects_wrong_position_in_balanced_tree() {
+        let t0: Sha256d = [0x10; 32];
+        let t1: Sha256d = [0x20; 32];
+        let t2: Sha256d = [0x30; 32];
+        let t3: Sha256d = [0x40; 32];
+        let n01 = dsha256_pair(&t0, &t1);
+        let n23 = dsha256_pair(&t2, &t3);
+        let root = dsha256_pair(&n01, &n23);
+
+        // Right path for t0 but claim it's at position 1 — should hash with
+        // t1 on the wrong side and miss the root.
+        assert!(matches!(
+            verify_merkle_proof(&t0, 1, &[t1, n23], &root),
+            Err(MerkleError::RootMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn three_tx_block_with_odd_leaf_duplication() {
+        // Bitcoin's "duplicate the last hash on odd levels" rule:
+        //          root
+        //         /    \
+        //       n01    n22
+        //       / \    / \
+        //      t0 t1  t2 t2   <-- t2 duplicated
+        let t0: Sha256d = [0x10; 32];
+        let t1: Sha256d = [0x20; 32];
+        let t2: Sha256d = [0x30; 32];
+        let n01 = dsha256_pair(&t0, &t1);
+        let n22 = dsha256_pair(&t2, &t2);
+        let root = dsha256_pair(&n01, &n22);
+
+        // Proof for t2 in the 3-tx block: position 2, sibling at level 0 is
+        // t2 itself (the duplicated copy), level 1 sibling is n01.
+        // The prover IS responsible for emitting t2 as the level-0 sibling —
+        // this is Esplora's behaviour and matches Bitcoin Core.
+        assert!(verify_merkle_proof(&t2, 2, &[t2, n01], &root).is_ok());
+    }
+}

--- a/enclave/src/spv/mod.rs
+++ b/enclave/src/spv/mod.rs
@@ -1,0 +1,33 @@
+//! In-enclave Bitcoin SPV: header chain + Merkle inclusion proof
+//! verification.
+//!
+//! ## Scope (PR 2)
+//!
+//! - In-memory append-only header chain anchored to a compile-time checkpoint
+//!   (`chain.rs`).
+//! - Mainnet PoW + retarget enforcement, signet/regtest chain-linkage only
+//!   (`validation.rs`). BIP-325 signet signature verification is NOT
+//!   implemented here — see the module-level note in `validation.rs`.
+//! - Bitcoin Merkle inclusion proof verifier (`merkle.rs`).
+//! - Placeholder checkpoint constants (`checkpoint.rs`) — these MUST be
+//!   replaced with real `(height, hash, bits, time)` values before the
+//!   module is wired into the signing path in PR 3.
+//!
+//! ## What's NOT here
+//!
+//! - Wiring into `handle_sign_evm` / `ServerContext` — that's PR 3.
+//! - Reorg handling — append-only for now.
+//! - Header staleness rule (refuse to sign on stale tip) — PR 4.
+//!
+//! See docs/spv-review.md for the full design + open questions.
+
+pub mod chain;
+pub mod checkpoint;
+pub mod merkle;
+pub mod types;
+pub mod validation;
+
+pub use chain::{HeaderChain, SubmitOutcome};
+pub use checkpoint::Checkpoint;
+pub use merkle::{verify_merkle_proof, MerkleError, Sha256d};
+pub use types::{BlockHash, BlockHeight, Network, SpvError};

--- a/enclave/src/spv/types.rs
+++ b/enclave/src/spv/types.rs
@@ -1,0 +1,89 @@
+//! Common types used across the SPV module.
+
+use thiserror::Error;
+
+/// Bitcoin block height. `u32` is enough for the foreseeable future
+/// (Bitcoin would have to mine for ~80,000 years to overflow).
+pub type BlockHeight = u32;
+
+/// Block hash in Bitcoin internal byte order (32 bytes).
+pub type BlockHash = [u8; 32];
+
+/// Which Bitcoin network we are validating against. Determined at runtime
+/// from the `BITCOIN_NETWORK` env var, but baked into PCR0 because the env
+/// var is set in the Dockerfile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Network {
+    Mainnet,
+    /// Default global signet OR a custom signet, distinguished only by the
+    /// challenge script that's also a compile-time constant. Header
+    /// validation behaviour is identical (signature in coinbase witness,
+    /// not enforced in PR 2 — see `validation.rs`).
+    Signet,
+    Testnet3,
+    Regtest,
+}
+
+impl Network {
+    pub fn from_env_str(s: &str) -> std::result::Result<Self, &'static str> {
+        match s {
+            "bitcoin" | "mainnet" => Ok(Self::Mainnet),
+            "signet" => Ok(Self::Signet),
+            "testnet" | "testnet3" => Ok(Self::Testnet3),
+            "regtest" => Ok(Self::Regtest),
+            _ => Err("unknown network"),
+        }
+    }
+
+    /// Maps to the `bitcoin` crate's network parameters.
+    pub fn as_bitcoin_params(self) -> &'static bitcoin::consensus::params::Params {
+        match self {
+            Self::Mainnet => &bitcoin::consensus::params::MAINNET,
+            Self::Signet => &bitcoin::consensus::params::SIGNET,
+            Self::Testnet3 => &bitcoin::consensus::params::TESTNET3,
+            Self::Regtest => &bitcoin::consensus::params::REGTEST,
+        }
+    }
+
+    /// Whether real PoW is enforced. Mainnet + testnet3 yes; signet has
+    /// trivial PoW (real validation is the BIP-325 signature, see comment
+    /// in `validation.rs`); regtest is local-only and trivial.
+    pub fn enforces_pow(self) -> bool {
+        matches!(self, Self::Mainnet | Self::Testnet3)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SpvError {
+    #[error("header parse failed at index {index}: {message}")]
+    HeaderParse { index: usize, message: String },
+
+    #[error("chain linkage broken at height {height}: prev_blockhash mismatch")]
+    ChainLinkage { height: BlockHeight },
+
+    #[error("header at height {height} fails PoW: hash > target")]
+    PowFailed { height: BlockHeight },
+
+    #[error(
+        "nBits at height {height} mismatch: header has {got:#010x}, expected {expected:#010x}"
+    )]
+    BitsMismatch {
+        height: BlockHeight,
+        got: u32,
+        expected: u32,
+    },
+
+    #[error("batch start_height {got} does not extend tip {expected}")]
+    NonContiguous {
+        got: BlockHeight,
+        expected: BlockHeight,
+    },
+
+    #[error("no header at height {0}")]
+    HeaderNotFound(BlockHeight),
+
+    #[error("checkpoint placeholder — refusing to operate")]
+    CheckpointPlaceholder,
+}
+
+pub type Result<T> = std::result::Result<T, SpvError>;

--- a/enclave/src/spv/validation.rs
+++ b/enclave/src/spv/validation.rs
@@ -1,0 +1,238 @@
+//! Per-header validation primitives. Pure functions; no chain state lives here.
+//!
+//! The `HeaderChain` orchestrates batches and supplies prior-header context;
+//! these helpers answer the small questions: "does this header chain to its
+//! predecessor", "is the PoW met", "is its `nBits` what we expect at this
+//! height".
+//!
+//! ## Network-specific behaviour
+//!
+//! - **Mainnet, testnet3**: full PoW + retarget enforcement.
+//!   `validate_pow` checks `block_hash <= target_from_nBits`; `expected_bits`
+//!   re-derives the expected `nBits` so an attacker can't submit a chain
+//!   with arbitrarily low difficulty.
+//! - **Signet**: PoW is trivial, so this module does NOT verify it. Real
+//!   signet validation is the BIP-325 signature, which lives in the
+//!   *coinbase witness commitment* of each block — a piece of data the
+//!   current `SubmitHeadersRequest` proto does not carry. PR 2 therefore
+//!   only enforces chain linkage on signet. Strict signet validation
+//!   requires extending the proto with `repeated bytes coinbase_txs`; see
+//!   docs/spv-review.md for context.
+//! - **Regtest**: everything is trivial; chain linkage only.
+//!
+//! Testnet3's "min-difficulty-after-20-minutes" exception is *not*
+//! implemented here — testnet3 isn't a target environment. Adding it would
+//! require another branch in `expected_bits` and adjacent fixtures.
+
+use bitcoin::block::Header;
+use bitcoin::pow::CompactTarget;
+
+use crate::spv::types::{BlockHeight, Network, Result, SpvError};
+
+/// Bitcoin's difficulty-retarget interval: every 2016 blocks.
+pub const RETARGET_INTERVAL: BlockHeight = 2016;
+
+/// Returns true when `height` is the start of a new retarget epoch.
+pub fn is_retarget_height(height: BlockHeight) -> bool {
+    height % RETARGET_INTERVAL == 0
+}
+
+/// Verify that `header.prev_blockhash` matches `expected_prev_hash` (in
+/// internal byte order). The byte-array comparison sidesteps any conversion
+/// between `BlockHash` and our `[u8; 32]` alias.
+pub fn check_linkage(
+    header: &Header,
+    expected_prev_hash: &[u8; 32],
+    height: BlockHeight,
+) -> Result<()> {
+    let prev_bytes: [u8; 32] = *header.prev_blockhash.as_ref();
+    if &prev_bytes != expected_prev_hash {
+        return Err(SpvError::ChainLinkage { height });
+    }
+    Ok(())
+}
+
+/// Run PoW check: `block_hash <= target_from_nBits(header.bits)`. Skipped on
+/// networks where PoW is trivial (signet, regtest) — see module docs.
+pub fn check_pow(header: &Header, height: BlockHeight, network: Network) -> Result<()> {
+    if !network.enforces_pow() {
+        return Ok(());
+    }
+    let target = header.target();
+    header
+        .validate_pow(target)
+        .map_err(|_| SpvError::PowFailed { height })?;
+    Ok(())
+}
+
+/// Compute the `nBits` value that `header_at(height)` is required to carry,
+/// given the previous block's bits and (if `height` is a retarget boundary)
+/// the previous epoch's start time.
+///
+/// `prev_bits` is the `nBits` of the block at `height - 1`.
+/// `prev_time` is the `time` of the block at `height - 1`.
+/// `epoch_start_time` is the `time` of the block at `height - RETARGET_INTERVAL`
+/// (only consulted at retarget boundaries; pass any value otherwise).
+///
+/// Returns `Ok(None)` for networks with no retargeting enforcement (signet,
+/// regtest); the caller treats that as "don't check `nBits`".
+pub fn expected_bits(
+    height: BlockHeight,
+    prev_bits: u32,
+    prev_time: u32,
+    epoch_start_time: u32,
+    network: Network,
+) -> Result<Option<u32>> {
+    if !network.enforces_pow() {
+        return Ok(None);
+    }
+    if !is_retarget_height(height) {
+        // Non-boundary block: bits MUST equal previous block's bits.
+        return Ok(Some(prev_bits));
+    }
+
+    // Boundary block: re-derive expected bits from the previous epoch.
+    let actual_timespan = u64::from(prev_time.saturating_sub(epoch_start_time));
+    let prev_compact = CompactTarget::from_consensus(prev_bits);
+    let next = CompactTarget::from_next_work_required(
+        prev_compact,
+        actual_timespan,
+        network.as_bitcoin_params(),
+    );
+    Ok(Some(next.to_consensus()))
+}
+
+/// Compose: linkage + (optional) PoW + (optional) nBits match. Used by
+/// `HeaderChain::submit_headers` once it has gathered the context.
+pub fn validate_header_full(
+    header: &Header,
+    height: BlockHeight,
+    expected_prev_hash: &[u8; 32],
+    expected_bits_value: Option<u32>,
+    network: Network,
+) -> Result<()> {
+    check_linkage(header, expected_prev_hash, height)?;
+
+    if let Some(expected) = expected_bits_value {
+        let got = header.bits.to_consensus();
+        if got != expected {
+            return Err(SpvError::BitsMismatch {
+                height,
+                got,
+                expected,
+            });
+        }
+    }
+
+    check_pow(header, height, network)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::consensus::deserialize;
+    use bitcoin::hashes::Hash;
+
+    /// Real mainnet block 1 header (hex). Used to exercise the parser
+    /// and the mainnet PoW path against authentic data.
+    /// https://blockstream.info/api/block/00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048/header
+    const MAINNET_BLOCK_1_HEADER_HEX: &str = "010000006fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000982051fd1e4ba744bbbe680e1fee14677ba1a3c3540bf7b1cdb606e857233e0e61bc6649ffff001d01e36299";
+
+    /// Real mainnet block 0 (genesis) hash, internal byte order.
+    const MAINNET_GENESIS_HASH_INTERNAL: [u8; 32] = [
+        0x6f, 0xe2, 0x8c, 0x0a, 0xb6, 0xf1, 0xb3, 0x72, 0xc1, 0xa6, 0xa2, 0x46, 0xae, 0x63, 0xf7,
+        0x4f, 0x93, 0x1e, 0x83, 0x65, 0xe1, 0x5a, 0x08, 0x9c, 0x68, 0xd6, 0x19, 0x00, 0x00, 0x00,
+        0x00, 0x00,
+    ];
+
+    fn parse_hex_header(hex: &str) -> Header {
+        let bytes = hex::decode(hex).unwrap();
+        deserialize::<Header>(&bytes).unwrap()
+    }
+
+    #[test]
+    fn mainnet_block_1_links_to_genesis() {
+        let h1 = parse_hex_header(MAINNET_BLOCK_1_HEADER_HEX);
+        check_linkage(&h1, &MAINNET_GENESIS_HASH_INTERNAL, 1).unwrap();
+    }
+
+    #[test]
+    fn mainnet_block_1_pow_passes() {
+        let h1 = parse_hex_header(MAINNET_BLOCK_1_HEADER_HEX);
+        check_pow(&h1, 1, Network::Mainnet).unwrap();
+    }
+
+    #[test]
+    fn linkage_rejects_wrong_prev_hash() {
+        let h1 = parse_hex_header(MAINNET_BLOCK_1_HEADER_HEX);
+        let wrong = [0xAB; 32];
+        let err = check_linkage(&h1, &wrong, 1).unwrap_err();
+        assert!(matches!(err, SpvError::ChainLinkage { height: 1 }));
+    }
+
+    #[test]
+    fn signet_skips_pow_check() {
+        // Construct a header whose hash is bigger than the target — would
+        // fail mainnet PoW, but should pass on signet because PoW is skipped.
+        // Easiest way: take block 1 and mutate the nonce. The resulting
+        // header almost certainly does not satisfy PoW.
+        let mut bytes = hex::decode(MAINNET_BLOCK_1_HEADER_HEX).unwrap();
+        // Flip the last byte (part of nonce) to break PoW.
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0xFF;
+        let bad = deserialize::<Header>(&bytes).unwrap();
+
+        // Mainnet would reject this:
+        assert!(check_pow(&bad, 1, Network::Mainnet).is_err());
+        // Signet must accept (we don't enforce PoW there):
+        check_pow(&bad, 1, Network::Signet).unwrap();
+        // Regtest must also accept:
+        check_pow(&bad, 1, Network::Regtest).unwrap();
+    }
+
+    #[test]
+    fn expected_bits_non_boundary_equals_prev() {
+        // Pick any height that's not a retarget boundary.
+        let bits = 0x1d00ffff;
+        let got = expected_bits(1, bits, 0, 0, Network::Mainnet).unwrap();
+        assert_eq!(got, Some(bits));
+    }
+
+    #[test]
+    fn expected_bits_signet_returns_none() {
+        let got = expected_bits(2016, 0x1d00ffff, 0, 0, Network::Signet).unwrap();
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn expected_bits_regtest_returns_none() {
+        let got = expected_bits(2016, 0x207fffff, 0, 0, Network::Regtest).unwrap();
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn is_retarget_height_boundaries() {
+        assert!(is_retarget_height(0));
+        assert!(is_retarget_height(2016));
+        assert!(is_retarget_height(4032));
+        assert!(!is_retarget_height(1));
+        assert!(!is_retarget_height(2015));
+        assert!(!is_retarget_height(2017));
+    }
+
+    #[test]
+    fn block_hash_round_trip() {
+        // Sanity: block 1's hash, computed from its header, has the well-known
+        // value `00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048`
+        // (display order). Our internal-order representation reverses it.
+        let h1 = parse_hex_header(MAINNET_BLOCK_1_HEADER_HEX);
+        let internal = h1.block_hash().to_byte_array();
+        let mut display = internal;
+        display.reverse();
+        assert_eq!(
+            hex::encode(display),
+            "00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

PR 2 of 4 in the SPV verification stack. Adds the pure-logic side: an in-memory header chain anchored to a compile-time checkpoint, full-Bitcoin header validation (PoW + retarget on mainnet, chain-linkage only on signet/regtest), and an SPV Merkle inclusion proof verifier.

**Not yet wired** — `handle_sign_evm` is unchanged. PR 3 will consume this module.

## What's in here

| Module | Role |
|---|---|
| `spv::merkle` | Verify a Merkle inclusion proof for a single txid. Bitcoin double-SHA256, bottom-bit-of-position walk. Odd-leaf duplication is handled by the prover (Esplora emits the duplicated sibling); we just walk the supplied path. |
| `spv::chain` | `HeaderChain`: append-only in-memory store anchored at a `Checkpoint`. `submit_headers` parses + validates a contiguous batch, all-or-nothing. |
| `spv::validation` | `check_linkage`, `check_pow`, `expected_bits` (with `bitcoin::CompactTarget::from_next_work_required` for retargets), and the composing `validate_header_full`. |
| `spv::types` | `Network` enum (mainnet/signet/testnet3/regtest, resolved at runtime from `BITCOIN_NETWORK` env var, baked into PCR0 because the env var is set in the Dockerfile), `SpvError`, type aliases. |
| `spv::checkpoint` | `Checkpoint` struct + per-network **PLACEHOLDER** constants. Real values pending team confirmation; must be filled in before PR 3 lands. |

## Important caveats

### BIP-325 signet signature verification is NOT done

Signet's "real" validation is the BIP-325 signature, which lives in the **coinbase witness commitment** of each block — *not* in the 80-byte header. Our `SubmitHeadersRequest` proto only carries 80-byte headers, so this PR can't verify it.

For now, signet headers are accepted on **chain-linkage only**. To do strict signet validation in production we would need to extend the proto with `repeated bytes coinbase_txs` (or only run real production on mainnet, where PoW + retarget are fully enforced here).

This is documented in `enclave/src/spv/validation.rs` and called out in `docs/spv-review.md`.

### Checkpoint constants are placeholders

`MAINNET_CHECKPOINT`, `SIGNET_CHECKPOINT` etc. are all zeroed `is_real: false` placeholders. They're enough to compile + run unit tests today (`Checkpoint::assert_real_in_release` exempts debug/test builds). Before PR 3 wires the module into `handle_sign_evm`, the team needs to provide:

1. Signet challenge script (default global signet vs custom UTEXO signet — only matters once we add BIP-325 verification, but worth pinning down now).
2. Per-network checkpoint `(height, hash, bits, time)` for whatever network we deploy first.

### What's NOT here (deliberately)

- **No reorg handling.** `submit_headers` is strictly append-only; non-contiguous batches are rejected. Bounded-depth replacement at the tip is a follow-up.
- **No header staleness check** (refuse to sign on stale tip vs wall clock) — that's PR 4.
- **No wiring into the signing path** — that's PR 3, which depends on PR 1 (proto stub) too.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo test --workspace` — 113 pass, +24 new SPV tests
- [x] `cargo test -p utexo-bridge-enclave --features rgb-validation` — 115 pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

24 unit tests cover:
- Merkle: empty path, balanced 2-/4-tx blocks, all positions, wrong-position rejection, odd-leaf-duplication tree
- Chain: empty-tip = checkpoint, contiguous append, non-contiguous rejection, broken-linkage rejection, atomic batch failure, lookups, garbage-bytes rejection, real mainnet block 1 appended after a genesis-shaped checkpoint
- Validation: real mainnet block 1 PoW + linkage, signet-skips-PoW, retarget-boundary detection, `expected_bits` non-boundary equals prev, network-skip paths, block-hash byte-order round trip