### PR TITLE
fix(signing): anchor PSBT cosigner check to script_pubkey

### DIFF
--- a/enclave/src/keys.rs
+++ b/enclave/src/keys.rs
@@ -306,19 +306,27 @@ impl KeyManager {
         let mut sighash_cache = SighashCache::new(&unsigned_tx);
 
         for i in 0..psbt.inputs.len() {
-            if !crate::signing::psbt::should_sign_segwit_input(&psbt, i, &our_pubkey) {
+            let crate::signing::psbt::SegwitSignDecision::SignP2wsh { witness_script } =
+                crate::signing::psbt::should_sign_segwit_input(&psbt, i, &our_pubkey)
+            else {
                 continue;
-            }
+            };
 
-            let witness_utxo = psbt.inputs[i].witness_utxo.as_ref().ok_or_else(|| {
-                EnclaveError::Signing(format!("missing witness_utxo for input {i}"))
-            })?;
-            let witness_script = psbt.inputs[i].witness_script.as_ref().ok_or_else(|| {
-                EnclaveError::Signing(format!("missing witness_script for input {i}"))
-            })?;
+            // SAFETY: SignP2wsh is only returned when witness_utxo is present
+            // and committed to witness_script.
+            let witness_utxo_value = psbt.inputs[i]
+                .witness_utxo
+                .as_ref()
+                .expect("SignP2wsh implies witness_utxo present")
+                .value;
 
             let sighash = sighash_cache
-                .p2wsh_signature_hash(i, witness_script, witness_utxo.value, EcdsaSighashType::All)
+                .p2wsh_signature_hash(
+                    i,
+                    &witness_script,
+                    witness_utxo_value,
+                    EcdsaSighashType::All,
+                )
                 .map_err(|e| EnclaveError::Signing(format!("sighash: {e}")))?;
 
             let msg = Message::from_digest(sighash.to_byte_array());
@@ -723,6 +731,161 @@ mod tests {
         assert_eq!(count, 0);
     }
 
+    /// Adversarial: 2-of-3 P2WSH where the TEE is NOT a cosigner, but the PSBT
+    /// places our pubkey in `bip32_derivation`. The pre-fix code signed; the
+    /// post-fix code must refuse.
+    #[test]
+    fn adversarial_psbt_forged_bip32_derivation_is_not_signed() {
+        use bitcoin::blockdata::opcodes::all::*;
+        use bitcoin::blockdata::script::Builder as ScriptBuilder;
+        use bitcoin::{Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid};
+
+        let seed = [0x42u8; 64];
+        let km = KeyManager::from_seed(seed, Network::Bitcoin).unwrap();
+        let our_pk = PublicKey::from_slice(km.btc_compressed_pubkey()).unwrap();
+        let our_btc_pk = bitcoin::PublicKey::new(our_pk);
+
+        let secp = Secp256k1::new();
+        let pk_other = |b: u8| {
+            bitcoin::PublicKey::new(SecretKey::from_slice(&[b; 32]).unwrap().public_key(&secp))
+        };
+        let mut others = [pk_other(0xA1), pk_other(0xA2), pk_other(0xA3)];
+        others.sort_by_key(|k| k.to_bytes());
+
+        let witness_script = ScriptBuilder::new()
+            .push_int(2)
+            .push_key(&others[0])
+            .push_key(&others[1])
+            .push_key(&others[2])
+            .push_int(3)
+            .push_opcode(OP_CHECKMULTISIG)
+            .into_script();
+
+        let unsigned_tx = Transaction {
+            version: bitcoin::transaction::Version(2),
+            lock_time: bitcoin::blockdata::locktime::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([0xAA; 32]),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: bitcoin::Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: ScriptBuf::new_p2wpkh(&bitcoin::WPubkeyHash::from_byte_array(
+                    [0xBB; 20],
+                )),
+            }],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+        let ws_hash = bitcoin::WScriptHash::hash(witness_script.as_bytes());
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey: ScriptBuf::new_p2wsh(&ws_hash),
+        });
+        psbt.inputs[0].witness_script = Some(witness_script);
+
+        // Plant our pubkey in bip32_derivation — the lie.
+        psbt.inputs[0].bip32_derivation.insert(
+            our_pk,
+            (
+                *km.master_fingerprint(),
+                bitcoin::bip32::DerivationPath::from(vec![]),
+            ),
+        );
+
+        let (signed_bytes, count) = km.sign_psbt(&psbt.serialize()).unwrap();
+        assert_eq!(
+            count, 0,
+            "TEE must not sign when it is not in witness_script"
+        );
+        let signed = Psbt::deserialize(&signed_bytes).unwrap();
+        assert!(!signed.inputs[0].partial_sigs.contains_key(&our_btc_pk));
+    }
+
+    /// Adversarial: `script_pubkey` commits to script A (not containing us) but
+    /// the PSBT ships script B (containing our pubkey) as `witness_script`.
+    /// Pre-fix sliding-window/bip32 paths could accept; post-fix must refuse
+    /// because sha256(B) != script_pubkey's witness program.
+    #[test]
+    fn adversarial_psbt_witness_script_mismatch_is_not_signed() {
+        use bitcoin::blockdata::opcodes::all::*;
+        use bitcoin::blockdata::script::Builder as ScriptBuilder;
+        use bitcoin::{Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid};
+
+        let seed = [0x42u8; 64];
+        let km = KeyManager::from_seed(seed, Network::Bitcoin).unwrap();
+        let our_pk = PublicKey::from_slice(km.btc_compressed_pubkey()).unwrap();
+        let our_btc_pk = bitcoin::PublicKey::new(our_pk);
+
+        let secp = Secp256k1::new();
+        let pk_other = |b: u8| {
+            bitcoin::PublicKey::new(SecretKey::from_slice(&[b; 32]).unwrap().public_key(&secp))
+        };
+
+        // Script A — what the on-chain UTXO actually commits to (no us).
+        let mut keys_a = [pk_other(0xA1), pk_other(0xA2), pk_other(0xA3)];
+        keys_a.sort_by_key(|k| k.to_bytes());
+        let script_a = ScriptBuilder::new()
+            .push_int(2)
+            .push_key(&keys_a[0])
+            .push_key(&keys_a[1])
+            .push_key(&keys_a[2])
+            .push_int(3)
+            .push_opcode(OP_CHECKMULTISIG)
+            .into_script();
+        let real_spk = ScriptBuf::new_p2wsh(&bitcoin::WScriptHash::hash(script_a.as_bytes()));
+
+        // Script B — what the attacker ships in PSBT (contains us).
+        let mut keys_b = [our_btc_pk, pk_other(0xA2), pk_other(0xA3)];
+        keys_b.sort_by_key(|k| k.to_bytes());
+        let script_b = ScriptBuilder::new()
+            .push_int(2)
+            .push_key(&keys_b[0])
+            .push_key(&keys_b[1])
+            .push_key(&keys_b[2])
+            .push_int(3)
+            .push_opcode(OP_CHECKMULTISIG)
+            .into_script();
+
+        let unsigned_tx = Transaction {
+            version: bitcoin::transaction::Version(2),
+            lock_time: bitcoin::blockdata::locktime::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([0xAA; 32]),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: bitcoin::Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: ScriptBuf::new_p2wpkh(&bitcoin::WPubkeyHash::from_byte_array(
+                    [0xBB; 20],
+                )),
+            }],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey: real_spk,
+        });
+        psbt.inputs[0].witness_script = Some(script_b);
+
+        let (signed_bytes, count) = km.sign_psbt(&psbt.serialize()).unwrap();
+        assert_eq!(
+            count, 0,
+            "TEE must not sign when witness_script does not hash to script_pubkey"
+        );
+        let signed = Psbt::deserialize(&signed_bytes).unwrap();
+        assert!(!signed.inputs[0].partial_sigs.contains_key(&our_btc_pk));
+    }
+
     /// Build a taproot multi_a(2, pk1, pk2, pk3) PSBT for testing.
     /// The signer's key is derived at m/86'/1'/0'/0/0 (vanilla testnet).
     fn build_test_taproot_psbt(km: &KeyManager) -> Vec<u8> {
@@ -915,5 +1078,257 @@ mod tests {
 
         let msg = bitcoin::secp256k1::Message::from_digest(*sighash.as_byte_array());
         assert!(secp.verify_schnorr(schnorr_sig, &msg, xonly_pk).is_ok());
+    }
+
+    /// Adversarial taproot: the committed leaf does NOT push our xonly key,
+    /// but `tap_key_origins` lies and claims our key participates. Pre-fix
+    /// code (which iterated origins) would sign; post-fix must refuse.
+    #[test]
+    fn adversarial_taproot_psbt_forged_origins_is_not_signed() {
+        use bitcoin::bip32::ChildNumber;
+        use bitcoin::blockdata::opcodes::all::*;
+        use bitcoin::blockdata::script::Builder as ScriptBuilder;
+        use bitcoin::taproot::{LeafVersion, TapLeafHash, TaprootBuilder};
+        use bitcoin::{
+            Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, XOnlyPublicKey,
+        };
+
+        let km = KeyManager::from_seed([0x42u8; 64], Network::Testnet).unwrap();
+        let secp = Secp256k1::new();
+
+        // Our xonly (BIP-86 vanilla testnet 0/0).
+        let our_secret = km
+            .derive_btc_child(
+                AccountType::Vanilla,
+                &[
+                    ChildNumber::Normal { index: 0 },
+                    ChildNumber::Normal { index: 0 },
+                ],
+            )
+            .unwrap();
+        let our_kp = bitcoin::secp256k1::Keypair::from_secret_key(&secp, &our_secret);
+        let (our_xonly, _) = XOnlyPublicKey::from_keypair(&our_kp);
+
+        // Build a leaf containing three FOREIGN xonly keys.
+        let foreign = |b: u8| {
+            let kp = bitcoin::secp256k1::Keypair::from_secret_key(
+                &secp,
+                &SecretKey::from_slice(&[b; 32]).unwrap(),
+            );
+            XOnlyPublicKey::from_keypair(&kp).0
+        };
+        let mut keys = [foreign(0xB1), foreign(0xB2), foreign(0xB3)];
+        keys.sort();
+        let leaf = ScriptBuilder::new()
+            .push_x_only_key(&keys[0])
+            .push_opcode(OP_CHECKSIG)
+            .push_x_only_key(&keys[1])
+            .push_opcode(OP_CHECKSIGADD)
+            .push_x_only_key(&keys[2])
+            .push_opcode(OP_CHECKSIGADD)
+            .push_int(2)
+            .push_opcode(OP_NUMEQUAL)
+            .into_script();
+        let leaf_hash = TapLeafHash::from_script(&leaf, LeafVersion::TapScript);
+
+        let internal_key = XOnlyPublicKey::from_slice(&[
+            0x50, 0x92, 0x9b, 0x74, 0xc1, 0xa0, 0x49, 0x54, 0xb7, 0x8b, 0x4b, 0x60, 0x35, 0xe9,
+            0x7a, 0x5e, 0x07, 0x8a, 0x5a, 0x0f, 0x28, 0xec, 0x96, 0xd5, 0x47, 0xbf, 0xee, 0x9a,
+            0xce, 0x80, 0x3a, 0xc0,
+        ])
+        .unwrap();
+        let info = TaprootBuilder::new()
+            .add_leaf(0, leaf.clone())
+            .unwrap()
+            .finalize(&secp, internal_key)
+            .unwrap();
+        let cb = info
+            .control_block(&(leaf.clone(), LeafVersion::TapScript))
+            .unwrap();
+
+        let unsigned_tx = Transaction {
+            version: bitcoin::transaction::Version(2),
+            lock_time: bitcoin::blockdata::locktime::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([0xAA; 32]),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: bitcoin::Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: ScriptBuf::new_p2tr_tweaked(info.output_key()),
+            }],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey: ScriptBuf::new_p2tr_tweaked(info.output_key()),
+        });
+        psbt.inputs[0].tap_internal_key = Some(internal_key);
+        psbt.inputs[0]
+            .tap_scripts
+            .insert(cb, (leaf, LeafVersion::TapScript));
+
+        // The lie: claim our xonly is in this leaf, with our fingerprint and
+        // a real BIP-86 derivation that *does* derive to our xonly.
+        let our_path = bitcoin::bip32::DerivationPath::from(vec![
+            ChildNumber::from_hardened_idx(86).unwrap(),
+            ChildNumber::from_hardened_idx(1).unwrap(),
+            ChildNumber::from_hardened_idx(0).unwrap(),
+            ChildNumber::Normal { index: 0 },
+            ChildNumber::Normal { index: 0 },
+        ]);
+        psbt.inputs[0].tap_key_origins.insert(
+            our_xonly,
+            (vec![leaf_hash], (*km.master_fingerprint(), our_path)),
+        );
+
+        let (signed_bytes, count) = km.sign_psbt(&psbt.serialize()).unwrap();
+        assert_eq!(
+            count, 0,
+            "TEE must not sign when leaf does not push our key"
+        );
+        let signed = Psbt::deserialize(&signed_bytes).unwrap();
+        assert!(signed.inputs[0].tap_script_sigs.is_empty());
+    }
+
+    /// Adversarial taproot: `script_pubkey` commits to leaf A, but the PSBT
+    /// ships a different leaf B (which DOES push our xonly) under a control
+    /// block from an unrelated tree. `verify_taproot_commitment` must reject.
+    #[test]
+    fn adversarial_taproot_psbt_unverified_control_block_is_not_signed() {
+        use bitcoin::bip32::ChildNumber;
+        use bitcoin::blockdata::opcodes::all::*;
+        use bitcoin::blockdata::script::Builder as ScriptBuilder;
+        use bitcoin::taproot::{LeafVersion, TapLeafHash, TaprootBuilder};
+        use bitcoin::{
+            Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, XOnlyPublicKey,
+        };
+
+        let km = KeyManager::from_seed([0x42u8; 64], Network::Testnet).unwrap();
+        let secp = Secp256k1::new();
+
+        let our_secret = km
+            .derive_btc_child(
+                AccountType::Vanilla,
+                &[
+                    ChildNumber::Normal { index: 0 },
+                    ChildNumber::Normal { index: 0 },
+                ],
+            )
+            .unwrap();
+        let our_kp = bitcoin::secp256k1::Keypair::from_secret_key(&secp, &our_secret);
+        let (our_xonly, _) = XOnlyPublicKey::from_keypair(&our_kp);
+
+        let foreign = |b: u8| {
+            let kp = bitcoin::secp256k1::Keypair::from_secret_key(
+                &secp,
+                &SecretKey::from_slice(&[b; 32]).unwrap(),
+            );
+            XOnlyPublicKey::from_keypair(&kp).0
+        };
+
+        // Tree REAL: committed leaf A (no us). This produces the on-chain output key.
+        let mut keys_a = [foreign(0xA1), foreign(0xA2), foreign(0xA3)];
+        keys_a.sort();
+        let leaf_a = ScriptBuilder::new()
+            .push_x_only_key(&keys_a[0])
+            .push_opcode(OP_CHECKSIG)
+            .push_x_only_key(&keys_a[1])
+            .push_opcode(OP_CHECKSIGADD)
+            .push_x_only_key(&keys_a[2])
+            .push_opcode(OP_CHECKSIGADD)
+            .push_int(2)
+            .push_opcode(OP_NUMEQUAL)
+            .into_script();
+        let internal_key_a = XOnlyPublicKey::from_slice(&[
+            0x50, 0x92, 0x9b, 0x74, 0xc1, 0xa0, 0x49, 0x54, 0xb7, 0x8b, 0x4b, 0x60, 0x35, 0xe9,
+            0x7a, 0x5e, 0x07, 0x8a, 0x5a, 0x0f, 0x28, 0xec, 0x96, 0xd5, 0x47, 0xbf, 0xee, 0x9a,
+            0xce, 0x80, 0x3a, 0xc0,
+        ])
+        .unwrap();
+        let info_a = TaprootBuilder::new()
+            .add_leaf(0, leaf_a.clone())
+            .unwrap()
+            .finalize(&secp, internal_key_a)
+            .unwrap();
+
+        // Tree FAKE: separate tree containing leaf B (with us). Its control
+        // block is valid for FAKE's output key but NOT for REAL's.
+        let mut keys_b = [our_xonly, foreign(0xB2), foreign(0xB3)];
+        keys_b.sort();
+        let leaf_b = ScriptBuilder::new()
+            .push_x_only_key(&keys_b[0])
+            .push_opcode(OP_CHECKSIG)
+            .push_x_only_key(&keys_b[1])
+            .push_opcode(OP_CHECKSIGADD)
+            .push_x_only_key(&keys_b[2])
+            .push_opcode(OP_CHECKSIGADD)
+            .push_int(2)
+            .push_opcode(OP_NUMEQUAL)
+            .into_script();
+        let leaf_b_hash = TapLeafHash::from_script(&leaf_b, LeafVersion::TapScript);
+        let internal_key_b = foreign(0xC0);
+        let info_b = TaprootBuilder::new()
+            .add_leaf(0, leaf_b.clone())
+            .unwrap()
+            .finalize(&secp, internal_key_b)
+            .unwrap();
+        let bad_cb = info_b
+            .control_block(&(leaf_b.clone(), LeafVersion::TapScript))
+            .unwrap();
+
+        let unsigned_tx = Transaction {
+            version: bitcoin::transaction::Version(2),
+            lock_time: bitcoin::blockdata::locktime::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([0xAA; 32]),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: bitcoin::Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: ScriptBuf::new_p2tr_tweaked(info_a.output_key()),
+            }],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+        // script_pubkey is REAL's output key (commits to leaf A).
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey: ScriptBuf::new_p2tr_tweaked(info_a.output_key()),
+        });
+        psbt.inputs[0].tap_internal_key = Some(internal_key_a);
+        // Attacker ships leaf B + bad_cb (which is for FAKE).
+        psbt.inputs[0]
+            .tap_scripts
+            .insert(bad_cb, (leaf_b, LeafVersion::TapScript));
+
+        let our_path = bitcoin::bip32::DerivationPath::from(vec![
+            ChildNumber::from_hardened_idx(86).unwrap(),
+            ChildNumber::from_hardened_idx(1).unwrap(),
+            ChildNumber::from_hardened_idx(0).unwrap(),
+            ChildNumber::Normal { index: 0 },
+            ChildNumber::Normal { index: 0 },
+        ]);
+        psbt.inputs[0].tap_key_origins.insert(
+            our_xonly,
+            (vec![leaf_b_hash], (*km.master_fingerprint(), our_path)),
+        );
+
+        let (signed_bytes, count) = km.sign_psbt(&psbt.serialize()).unwrap();
+        assert_eq!(
+            count, 0,
+            "TEE must not sign when control block fails to verify"
+        );
+        let signed = Psbt::deserialize(&signed_bytes).unwrap();
+        assert!(signed.inputs[0].tap_script_sigs.is_empty());
     }
 }

--- a/enclave/src/signing/psbt.rs
+++ b/enclave/src/signing/psbt.rs
@@ -1,35 +1,287 @@
+use bitcoin::blockdata::script::Instruction;
+use bitcoin::hashes::Hash;
 use bitcoin::psbt::Psbt;
 use bitcoin::secp256k1::PublicKey;
+use bitcoin::{ScriptBuf, WScriptHash};
 
-/// Determine whether we should sign a specific PSBT input.
-/// Checks (in order):
-/// 1. If our pubkey already has a partial_sig — skip (already signed)
-/// 2. If our pubkey is in bip32_derivation — sign
-/// 3. If the witness_script contains our compressed pubkey bytes — sign
-/// 4. Otherwise — skip
-pub fn should_sign_segwit_input(psbt: &Psbt, input_index: usize, our_pubkey: &PublicKey) -> bool {
+/// Decision returned by [`should_sign_segwit_input`].
+///
+/// A `SignP2wsh` carries the validated `witness_script` so callers don't have
+/// to re-fetch and re-trust the PSBT field.
+pub enum SegwitSignDecision {
+    Skip,
+    SignP2wsh { witness_script: ScriptBuf },
+}
+
+/// Decide whether to sign a PSBT input as P2WSH for `our_pubkey`.
+///
+/// Authorization is anchored to `witness_utxo.script_pubkey` — the only PSBT
+/// field committed to by the BIP-143 sighash and therefore the only one we
+/// can trust. We require:
+///
+///   1. `witness_utxo` is present and its `script_pubkey` is P2WSH.
+///   2. `partial_sigs` does not already contain our key.
+///   3. `witness_script` is present and `sha256(witness_script)` matches the
+///      witness program in `script_pubkey` — closing the "fabricated
+///      witness_script" hole.
+///   4. `our_pubkey` appears as an exact 33-byte push (opcode-aware) inside
+///      `witness_script` — closing the "key bytes hidden inside a larger
+///      push" hole.
+///
+/// Hint fields (`bip32_derivation`, etc.) are coordinator-supplied and are
+/// not consulted: their presence is necessary neither nor sufficient.
+pub fn should_sign_segwit_input(
+    psbt: &Psbt,
+    input_index: usize,
+    our_pubkey: &PublicKey,
+) -> SegwitSignDecision {
     let input = &psbt.inputs[input_index];
+
+    let Some(witness_utxo) = input.witness_utxo.as_ref() else {
+        return SegwitSignDecision::Skip;
+    };
+
     let our_bitcoin_pubkey = bitcoin::PublicKey::new(*our_pubkey);
-
-    // Already signed? Skip.
     if input.partial_sigs.contains_key(&our_bitcoin_pubkey) {
-        return false;
+        return SegwitSignDecision::Skip;
     }
 
-    // In BIP-32 derivation map? Sign.
-    // Note: bip32_derivation uses secp256k1::PublicKey as key type
-    if input.bip32_derivation.contains_key(our_pubkey) {
-        return true;
+    let Some(witness_script) = input.witness_script.as_ref() else {
+        return SegwitSignDecision::Skip;
+    };
+
+    let expected = ScriptBuf::new_p2wsh(&WScriptHash::hash(witness_script.as_bytes()));
+    if witness_utxo.script_pubkey != expected {
+        return SegwitSignDecision::Skip;
     }
 
-    // In witness script? Sign (sliding window over script bytes for 33-byte compressed pubkey).
-    if let Some(script) = &input.witness_script {
-        let script_bytes = script.as_bytes();
-        let pubkey_bytes = our_pubkey.serialize(); // 33-byte compressed
-        if script_bytes.windows(33).any(|w| w == pubkey_bytes) {
-            return true;
+    let our_bytes = our_pubkey.serialize();
+    let found = witness_script
+        .instructions()
+        .filter_map(Result::ok)
+        .any(|insn| matches!(insn, Instruction::PushBytes(b) if b.as_bytes() == our_bytes));
+
+    if found {
+        SegwitSignDecision::SignP2wsh {
+            witness_script: witness_script.clone(),
+        }
+    } else {
+        SegwitSignDecision::Skip
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::blockdata::opcodes::all::*;
+    use bitcoin::blockdata::script::Builder as ScriptBuilder;
+    use bitcoin::secp256k1::{Secp256k1, SecretKey};
+    use bitcoin::{
+        Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, WScriptHash,
+    };
+
+    fn pk_from_byte(b: u8) -> bitcoin::PublicKey {
+        let secp = Secp256k1::new();
+        let sk = SecretKey::from_slice(&[b; 32]).unwrap();
+        bitcoin::PublicKey::new(sk.public_key(&secp))
+    }
+
+    fn ours() -> (PublicKey, bitcoin::PublicKey) {
+        let secp = Secp256k1::new();
+        let sk = SecretKey::from_slice(&[0x01; 32]).unwrap();
+        let pk = sk.public_key(&secp);
+        (pk, bitcoin::PublicKey::new(pk))
+    }
+
+    fn build_2of3_witness_script(keys: &[bitcoin::PublicKey; 3]) -> ScriptBuf {
+        let mut sorted = *keys;
+        sorted.sort_by_key(|k| k.to_bytes());
+        ScriptBuilder::new()
+            .push_int(2)
+            .push_key(&sorted[0])
+            .push_key(&sorted[1])
+            .push_key(&sorted[2])
+            .push_int(3)
+            .push_opcode(OP_CHECKMULTISIG)
+            .into_script()
+    }
+
+    fn p2wsh_for(script: &ScriptBuf) -> ScriptBuf {
+        ScriptBuf::new_p2wsh(&WScriptHash::hash(script.as_bytes()))
+    }
+
+    fn build_psbt(witness_script: ScriptBuf, script_pubkey: ScriptBuf) -> Psbt {
+        let unsigned_tx = Transaction {
+            version: bitcoin::transaction::Version(2),
+            lock_time: bitcoin::blockdata::locktime::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([0xAA; 32]),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: bitcoin::Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: ScriptBuf::new_p2wpkh(&bitcoin::WPubkeyHash::from_byte_array(
+                    [0xBB; 20],
+                )),
+            }],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey,
+        });
+        psbt.inputs[0].witness_script = Some(witness_script);
+        psbt
+    }
+
+    fn dummy_ecdsa_sig() -> bitcoin::ecdsa::Signature {
+        let secp = Secp256k1::new();
+        let sk = SecretKey::from_slice(&[0x55; 32]).unwrap();
+        let msg = bitcoin::secp256k1::Message::from_digest([0u8; 32]);
+        bitcoin::ecdsa::Signature {
+            signature: secp.sign_ecdsa(&msg, &sk),
+            sighash_type: bitcoin::sighash::EcdsaSighashType::All,
         }
     }
 
-    false
+    #[test]
+    fn signs_when_pubkey_in_legitimate_2of3_script() {
+        let (pk, btc_pk) = ours();
+        let ws = build_2of3_witness_script(&[btc_pk, pk_from_byte(0x02), pk_from_byte(0x03)]);
+        let spk = p2wsh_for(&ws);
+        let psbt = build_psbt(ws, spk);
+        assert!(matches!(
+            should_sign_segwit_input(&psbt, 0, &pk),
+            SegwitSignDecision::SignP2wsh { .. }
+        ));
+    }
+
+    #[test]
+    fn skips_when_witness_utxo_missing() {
+        let (pk, btc_pk) = ours();
+        let ws = build_2of3_witness_script(&[btc_pk, pk_from_byte(0x02), pk_from_byte(0x03)]);
+        let spk = p2wsh_for(&ws);
+        let mut psbt = build_psbt(ws, spk);
+        psbt.inputs[0].witness_utxo = None;
+        assert!(matches!(
+            should_sign_segwit_input(&psbt, 0, &pk),
+            SegwitSignDecision::Skip
+        ));
+    }
+
+    #[test]
+    fn skips_when_witness_script_missing() {
+        let (pk, btc_pk) = ours();
+        let ws = build_2of3_witness_script(&[btc_pk, pk_from_byte(0x02), pk_from_byte(0x03)]);
+        let spk = p2wsh_for(&ws);
+        let mut psbt = build_psbt(ws, spk);
+        psbt.inputs[0].witness_script = None;
+        assert!(matches!(
+            should_sign_segwit_input(&psbt, 0, &pk),
+            SegwitSignDecision::Skip
+        ));
+    }
+
+    #[test]
+    fn skips_when_already_partial_signed() {
+        let (pk, btc_pk) = ours();
+        let ws = build_2of3_witness_script(&[btc_pk, pk_from_byte(0x02), pk_from_byte(0x03)]);
+        let spk = p2wsh_for(&ws);
+        let mut psbt = build_psbt(ws, spk);
+        psbt.inputs[0]
+            .partial_sigs
+            .insert(btc_pk, dummy_ecdsa_sig());
+        assert!(matches!(
+            should_sign_segwit_input(&psbt, 0, &pk),
+            SegwitSignDecision::Skip
+        ));
+    }
+
+    /// Attacker ships a `witness_script` containing our key but
+    /// `witness_utxo.script_pubkey` commits to a different script.
+    #[test]
+    fn skips_when_witness_script_does_not_hash_to_script_pubkey() {
+        let (pk, btc_pk) = ours();
+        let real_ws = build_2of3_witness_script(&[
+            pk_from_byte(0x02),
+            pk_from_byte(0x03),
+            pk_from_byte(0x04),
+        ]);
+        let real_spk = p2wsh_for(&real_ws);
+        let fake_ws = build_2of3_witness_script(&[btc_pk, pk_from_byte(0x02), pk_from_byte(0x03)]);
+        let psbt = build_psbt(fake_ws, real_spk);
+        assert!(matches!(
+            should_sign_segwit_input(&psbt, 0, &pk),
+            SegwitSignDecision::Skip
+        ));
+    }
+
+    #[test]
+    fn skips_when_script_pubkey_is_p2wpkh() {
+        let (pk, btc_pk) = ours();
+        let ws = build_2of3_witness_script(&[btc_pk, pk_from_byte(0x02), pk_from_byte(0x03)]);
+        let p2wpkh = ScriptBuf::new_p2wpkh(&bitcoin::WPubkeyHash::from_byte_array([0xCC; 20]));
+        let psbt = build_psbt(ws, p2wpkh);
+        assert!(matches!(
+            should_sign_segwit_input(&psbt, 0, &pk),
+            SegwitSignDecision::Skip
+        ));
+    }
+
+    /// Our pubkey bytes appear inside a 64-byte push but never as a 33-byte
+    /// push on their own. A sliding-window byte search would falsely match.
+    #[test]
+    fn skips_when_pubkey_bytes_only_appear_inside_a_larger_push() {
+        let (pk, _) = ours();
+        let our = pk.serialize();
+        let mut blob = Vec::with_capacity(64);
+        blob.extend_from_slice(&our);
+        blob.extend_from_slice(&[0xFFu8; 31]);
+        let push: &bitcoin::script::PushBytes = blob.as_slice().try_into().unwrap();
+
+        let mut others = [pk_from_byte(0x02), pk_from_byte(0x03), pk_from_byte(0x04)];
+        others.sort_by_key(|k| k.to_bytes());
+        let ws = ScriptBuilder::new()
+            .push_slice(push)
+            .push_opcode(OP_DROP)
+            .push_int(2)
+            .push_key(&others[0])
+            .push_key(&others[1])
+            .push_key(&others[2])
+            .push_int(3)
+            .push_opcode(OP_CHECKMULTISIG)
+            .into_script();
+        let spk = p2wsh_for(&ws);
+        let psbt = build_psbt(ws, spk);
+        assert!(matches!(
+            should_sign_segwit_input(&psbt, 0, &pk),
+            SegwitSignDecision::Skip
+        ));
+    }
+
+    /// The boss's exact bug: 2-of-3 multisig of three OTHER keys, but
+    /// `bip32_derivation` lists our pubkey. Must NOT sign.
+    #[test]
+    fn skips_when_bip32_derivation_lies_and_script_excludes_us() {
+        let (pk, _) = ours();
+        let ws = build_2of3_witness_script(&[
+            pk_from_byte(0x02),
+            pk_from_byte(0x03),
+            pk_from_byte(0x04),
+        ]);
+        let spk = p2wsh_for(&ws);
+        let mut psbt = build_psbt(ws, spk);
+        let fp = bitcoin::bip32::Fingerprint::from([0u8; 4]);
+        let path = bitcoin::bip32::DerivationPath::from(vec![]);
+        psbt.inputs[0].bip32_derivation.insert(pk, (fp, path));
+        assert!(matches!(
+            should_sign_segwit_input(&psbt, 0, &pk),
+            SegwitSignDecision::Skip
+        ));
+    }
 }

--- a/enclave/src/signing/taproot.rs
+++ b/enclave/src/signing/taproot.rs
@@ -1,4 +1,7 @@
+use std::collections::HashSet;
+
 use bitcoin::bip32::Fingerprint;
+use bitcoin::blockdata::script::Instruction;
 use bitcoin::hashes::Hash;
 use bitcoin::psbt::Psbt;
 use bitcoin::secp256k1::{Keypair, Message, Secp256k1};
@@ -19,46 +22,102 @@ pub struct TaprootSignJob {
     pub child_path: Vec<bitcoin::bip32::ChildNumber>,
 }
 
-/// Scan all PSBT inputs for taproot inputs our key can sign.
-/// Returns a list of sign jobs.
+/// Scan all PSBT inputs for taproot script-path leaves whose script contains
+/// one of our keys, and emit a sign job per (input, leaf, xonly) triple.
+///
+/// Authorization is anchored to `witness_utxo.script_pubkey` — for each
+/// `(control_block, script)` entry in `tap_scripts`, the control block must
+/// prove the script's inclusion under the on-chain output key (BIP-341). The
+/// candidate xonly key must (1) appear as a 32-byte push inside the verified
+/// leaf script, (2) be claimed by a `tap_key_origins` entry whose fingerprint
+/// matches ours, (3) appear in that entry's `leaf_hashes` for *this* leaf,
+/// and (4) match the xonly pubkey our claimed BIP-86 derivation actually
+/// derives — closing the gap where a coordinator could forge `tap_key_origins`
+/// to point our fingerprint at someone else's key.
 pub fn find_taproot_sign_jobs(
     psbt: &Psbt,
     master_fingerprint: &Fingerprint,
     key_manager: &KeyManager,
 ) -> Vec<TaprootSignJob> {
+    let secp = Secp256k1::new();
     let mut jobs = Vec::new();
+    let mut emitted: HashSet<(usize, TapLeafHash, XOnlyPublicKey)> = HashSet::new();
 
-    for (i, input) in psbt.inputs.iter().enumerate() {
-        // Iterate tap_key_origins looking for our fingerprint
-        for (xonly_pubkey, (leaf_hashes, (fingerprint, derivation_path))) in &input.tap_key_origins
-        {
-            if fingerprint != master_fingerprint {
+    for (input_idx, input) in psbt.inputs.iter().enumerate() {
+        let Some(witness_utxo) = input.witness_utxo.as_ref() else {
+            continue;
+        };
+        if !witness_utxo.script_pubkey.is_p2tr() {
+            continue;
+        }
+        let spk_bytes = witness_utxo.script_pubkey.as_bytes();
+        // P2TR is exactly OP_1 (0x51) + 0x20 + 32-byte program.
+        if spk_bytes.len() != 34 {
+            continue;
+        }
+        let Ok(output_key) = XOnlyPublicKey::from_slice(&spk_bytes[2..34]) else {
+            continue;
+        };
+
+        for (control_block, (script, leaf_version)) in &input.tap_scripts {
+            if !control_block.verify_taproot_commitment(&secp, output_key, script) {
                 continue;
             }
+            let leaf_hash = TapLeafHash::from_script(script, *leaf_version);
 
-            // Resolve account type and child path from the full derivation path
-            let resolved = key_manager.resolve_account_and_child_path(derivation_path);
-            let (account_type, child_path) = match resolved {
-                Some(r) => r,
-                None => continue, // Path doesn't match our BIP-86 accounts
-            };
+            for insn in script.instructions().filter_map(|r| r.ok()) {
+                let Instruction::PushBytes(bytes) = insn else {
+                    continue;
+                };
+                if bytes.as_bytes().len() != 32 {
+                    continue;
+                }
+                let Ok(xonly_pk) = XOnlyPublicKey::from_slice(bytes.as_bytes()) else {
+                    continue;
+                };
 
-            // Sign for each leaf hash where our key participates
-            for leaf_hash in leaf_hashes {
-                // Skip if already signed for this (pubkey, leaf_hash) pair
-                if input
-                    .tap_script_sigs
-                    .contains_key(&(*xonly_pubkey, *leaf_hash))
-                {
+                let Some((leaf_hashes, (fingerprint, derivation_path))) =
+                    input.tap_key_origins.get(&xonly_pk)
+                else {
+                    continue;
+                };
+                if fingerprint != master_fingerprint {
+                    continue;
+                }
+                if !leaf_hashes.contains(&leaf_hash) {
+                    continue;
+                }
+
+                let Some((account_type, child_path)) =
+                    key_manager.resolve_account_and_child_path(derivation_path)
+                else {
+                    continue;
+                };
+
+                let Ok(child_secret) = key_manager.derive_btc_child(account_type, &child_path)
+                else {
+                    continue;
+                };
+                let kp = Keypair::from_secret_key(&secp, &child_secret);
+                let (derived_xonly, _) = XOnlyPublicKey::from_keypair(&kp);
+                if derived_xonly != xonly_pk {
+                    continue;
+                }
+
+                if input.tap_script_sigs.contains_key(&(xonly_pk, leaf_hash)) {
+                    continue;
+                }
+
+                if !emitted.insert((input_idx, leaf_hash, xonly_pk)) {
                     continue;
                 }
 
                 jobs.push(TaprootSignJob {
-                    input_index: i,
-                    xonly_pubkey: *xonly_pubkey,
-                    leaf_hash: *leaf_hash,
+                    input_index: input_idx,
+                    xonly_pubkey: xonly_pk,
+                    leaf_hash,
                     account_type,
-                    child_path: child_path.clone(),
+                    child_path,
                 });
             }
         }
@@ -130,4 +189,360 @@ pub fn sign_taproot_inputs(
     }
 
     Ok(signed_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::bip32::{ChildNumber, DerivationPath};
+    use bitcoin::blockdata::opcodes::all::*;
+    use bitcoin::blockdata::script::Builder as ScriptBuilder;
+    use bitcoin::secp256k1::SecretKey;
+    use bitcoin::taproot::{ControlBlock, LeafVersion, TaprootBuilder};
+    use bitcoin::{Amount, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid};
+
+    /// NUMS internal key used for unspendable key-path.
+    const NUMS_INTERNAL: [u8; 32] = [
+        0x50, 0x92, 0x9b, 0x74, 0xc1, 0xa0, 0x49, 0x54, 0xb7, 0x8b, 0x4b, 0x60, 0x35, 0xe9, 0x7a,
+        0x5e, 0x07, 0x8a, 0x5a, 0x0f, 0x28, 0xec, 0x96, 0xd5, 0x47, 0xbf, 0xee, 0x9a, 0xce, 0x80,
+        0x3a, 0xc0,
+    ];
+
+    fn xonly_from_byte(b: u8) -> XOnlyPublicKey {
+        let secp = Secp256k1::new();
+        let sk = SecretKey::from_slice(&[b; 32]).unwrap();
+        let kp = Keypair::from_secret_key(&secp, &sk);
+        XOnlyPublicKey::from_keypair(&kp).0
+    }
+
+    fn our_xonly(km: &KeyManager) -> XOnlyPublicKey {
+        let secp = Secp256k1::new();
+        let sk = km
+            .derive_btc_child(
+                AccountType::Vanilla,
+                &[
+                    ChildNumber::Normal { index: 0 },
+                    ChildNumber::Normal { index: 0 },
+                ],
+            )
+            .unwrap();
+        XOnlyPublicKey::from_keypair(&Keypair::from_secret_key(&secp, &sk)).0
+    }
+
+    fn our_full_path() -> DerivationPath {
+        DerivationPath::from(vec![
+            ChildNumber::from_hardened_idx(86).unwrap(),
+            ChildNumber::from_hardened_idx(1).unwrap(), // testnet
+            ChildNumber::from_hardened_idx(0).unwrap(),
+            ChildNumber::Normal { index: 0 },
+            ChildNumber::Normal { index: 0 },
+        ])
+    }
+
+    fn multi_a_2_of_3(keys: &[XOnlyPublicKey; 3]) -> ScriptBuf {
+        let mut sorted = *keys;
+        sorted.sort();
+        ScriptBuilder::new()
+            .push_x_only_key(&sorted[0])
+            .push_opcode(OP_CHECKSIG)
+            .push_x_only_key(&sorted[1])
+            .push_opcode(OP_CHECKSIGADD)
+            .push_x_only_key(&sorted[2])
+            .push_opcode(OP_CHECKSIGADD)
+            .push_int(2)
+            .push_opcode(OP_NUMEQUAL)
+            .into_script()
+    }
+
+    /// Build a taproot P2TR PSBT for testing.
+    /// Returns: (psbt, output_internal_key, leaf_script, leaf_hash, control_block).
+    fn build_legit_taproot_psbt(
+        km: &KeyManager,
+    ) -> (Psbt, XOnlyPublicKey, ScriptBuf, TapLeafHash, ControlBlock) {
+        let secp = Secp256k1::new();
+        let our = our_xonly(km);
+        let other1 = xonly_from_byte(0xA1);
+        let other2 = xonly_from_byte(0xA2);
+        let leaf_script = multi_a_2_of_3(&[our, other1, other2]);
+        let leaf_hash = TapLeafHash::from_script(&leaf_script, LeafVersion::TapScript);
+
+        let internal_key = XOnlyPublicKey::from_slice(&NUMS_INTERNAL).unwrap();
+        let builder = TaprootBuilder::new()
+            .add_leaf(0, leaf_script.clone())
+            .unwrap();
+        let spend_info = builder.finalize(&secp, internal_key).unwrap();
+        let script_pubkey = ScriptBuf::new_p2tr(&secp, internal_key, spend_info.merkle_root());
+        let control_block = spend_info
+            .control_block(&(leaf_script.clone(), LeafVersion::TapScript))
+            .unwrap();
+
+        let unsigned_tx = Transaction {
+            version: bitcoin::transaction::Version(2),
+            lock_time: bitcoin::blockdata::locktime::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([0xAA; 32]),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: bitcoin::Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: ScriptBuf::new_p2tr_tweaked(spend_info.output_key()),
+            }],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey,
+        });
+        psbt.inputs[0].tap_internal_key = Some(internal_key);
+        psbt.inputs[0].tap_scripts.insert(
+            control_block.clone(),
+            (leaf_script.clone(), LeafVersion::TapScript),
+        );
+        psbt.inputs[0].tap_key_origins.insert(
+            our,
+            (vec![leaf_hash], (*km.master_fingerprint(), our_full_path())),
+        );
+
+        (psbt, internal_key, leaf_script, leaf_hash, control_block)
+    }
+
+    #[test]
+    fn emits_one_job_for_legit_multi_a_leaf() {
+        let km = KeyManager::from_seed([0x42u8; 64], Network::Testnet).unwrap();
+        let (psbt, _, _, leaf_hash, _) = build_legit_taproot_psbt(&km);
+        let jobs = find_taproot_sign_jobs(&psbt, km.master_fingerprint(), &km);
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].leaf_hash, leaf_hash);
+        assert_eq!(jobs[0].xonly_pubkey, our_xonly(&km));
+    }
+
+    /// `tap_scripts` advertises a leaf that does NOT actually sit under
+    /// `script_pubkey`'s output key. Control block fails to verify.
+    #[test]
+    fn skips_when_control_block_does_not_verify() {
+        let km = KeyManager::from_seed([0x42u8; 64], Network::Testnet).unwrap();
+        let secp = Secp256k1::new();
+
+        // Build the legit PSBT (anchored output key).
+        let (mut psbt, _, _, _, _) = build_legit_taproot_psbt(&km);
+
+        // Build an UNRELATED tree whose control_block we'll splice in.
+        let our = our_xonly(&km);
+        let unrelated_leaf = multi_a_2_of_3(&[our, xonly_from_byte(0xB1), xonly_from_byte(0xB2)]);
+        let unrelated_internal = xonly_from_byte(0xC0);
+        let unrelated_builder = TaprootBuilder::new()
+            .add_leaf(0, unrelated_leaf.clone())
+            .unwrap();
+        let unrelated_info = unrelated_builder
+            .finalize(&secp, unrelated_internal)
+            .unwrap();
+        let bad_control = unrelated_info
+            .control_block(&(unrelated_leaf.clone(), LeafVersion::TapScript))
+            .unwrap();
+
+        psbt.inputs[0].tap_scripts.clear();
+        psbt.inputs[0].tap_scripts.insert(
+            bad_control,
+            (unrelated_leaf.clone(), LeafVersion::TapScript),
+        );
+        // Update tap_key_origins to claim the unrelated leaf's hash.
+        let bad_leaf_hash = TapLeafHash::from_script(&unrelated_leaf, LeafVersion::TapScript);
+        psbt.inputs[0].tap_key_origins.insert(
+            our,
+            (
+                vec![bad_leaf_hash],
+                (*km.master_fingerprint(), our_full_path()),
+            ),
+        );
+
+        let jobs = find_taproot_sign_jobs(&psbt, km.master_fingerprint(), &km);
+        assert!(jobs.is_empty());
+    }
+
+    #[test]
+    fn skips_when_origins_fingerprint_wrong() {
+        let km = KeyManager::from_seed([0x42u8; 64], Network::Testnet).unwrap();
+        let (mut psbt, _, _, leaf_hash, _) = build_legit_taproot_psbt(&km);
+        let our = our_xonly(&km);
+        psbt.inputs[0].tap_key_origins.insert(
+            our,
+            (
+                vec![leaf_hash],
+                (Fingerprint::from([0xDE, 0xAD, 0xBE, 0xEF]), our_full_path()),
+            ),
+        );
+        let jobs = find_taproot_sign_jobs(&psbt, km.master_fingerprint(), &km);
+        assert!(jobs.is_empty());
+    }
+
+    /// `tap_key_origins` claims OUR fingerprint at a real BIP-86 path, but
+    /// keys it with someone else's xonly. Without the cryptographic anchor
+    /// (derived xonly == claimed xonly) the signer would sign for a key it
+    /// doesn't own.
+    #[test]
+    fn skips_when_origins_path_derives_to_different_xonly() {
+        let km = KeyManager::from_seed([0x42u8; 64], Network::Testnet).unwrap();
+        let (mut psbt, _, _, leaf_hash, _) = build_legit_taproot_psbt(&km);
+        // Replace origins with a foreign xonly under our fingerprint+path.
+        let foreign = xonly_from_byte(0xEE);
+        psbt.inputs[0].tap_key_origins.clear();
+        psbt.inputs[0].tap_key_origins.insert(
+            foreign,
+            (vec![leaf_hash], (*km.master_fingerprint(), our_full_path())),
+        );
+        // Note: leaf script does not push `foreign`, so even pubkey-in-leaf
+        // catches this. Switch the leaf to one that DOES push `foreign` to
+        // exercise the derivation-mismatch branch specifically.
+        let secp = Secp256k1::new();
+        let foreign_leaf = multi_a_2_of_3(&[foreign, xonly_from_byte(0xB1), xonly_from_byte(0xB2)]);
+        let foreign_leaf_hash = TapLeafHash::from_script(&foreign_leaf, LeafVersion::TapScript);
+        let internal = XOnlyPublicKey::from_slice(&NUMS_INTERNAL).unwrap();
+        let info = TaprootBuilder::new()
+            .add_leaf(0, foreign_leaf.clone())
+            .unwrap()
+            .finalize(&secp, internal)
+            .unwrap();
+        let cb = info
+            .control_block(&(foreign_leaf.clone(), LeafVersion::TapScript))
+            .unwrap();
+        psbt.inputs[0].tap_scripts.clear();
+        psbt.inputs[0]
+            .tap_scripts
+            .insert(cb, (foreign_leaf.clone(), LeafVersion::TapScript));
+        psbt.inputs[0].witness_utxo.as_mut().unwrap().script_pubkey =
+            ScriptBuf::new_p2tr_tweaked(info.output_key());
+        psbt.inputs[0].tap_key_origins.clear();
+        psbt.inputs[0].tap_key_origins.insert(
+            foreign,
+            (
+                vec![foreign_leaf_hash],
+                (*km.master_fingerprint(), our_full_path()),
+            ),
+        );
+
+        let jobs = find_taproot_sign_jobs(&psbt, km.master_fingerprint(), &km);
+        assert!(jobs.is_empty());
+    }
+
+    /// `tap_key_origins` claims our key under our fingerprint, but the verified
+    /// leaf doesn't push our xonly key.
+    #[test]
+    fn skips_when_xonly_in_origins_not_pushed_in_committed_leaf() {
+        let km = KeyManager::from_seed([0x42u8; 64], Network::Testnet).unwrap();
+        let secp = Secp256k1::new();
+
+        // Build a leaf that does NOT contain our xonly.
+        let leaf = multi_a_2_of_3(&[
+            xonly_from_byte(0xB1),
+            xonly_from_byte(0xB2),
+            xonly_from_byte(0xB3),
+        ]);
+        let leaf_hash = TapLeafHash::from_script(&leaf, LeafVersion::TapScript);
+        let internal = XOnlyPublicKey::from_slice(&NUMS_INTERNAL).unwrap();
+        let info = TaprootBuilder::new()
+            .add_leaf(0, leaf.clone())
+            .unwrap()
+            .finalize(&secp, internal)
+            .unwrap();
+        let cb = info
+            .control_block(&(leaf.clone(), LeafVersion::TapScript))
+            .unwrap();
+
+        let unsigned_tx = Transaction {
+            version: bitcoin::transaction::Version(2),
+            lock_time: bitcoin::blockdata::locktime::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([0xAA; 32]),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: bitcoin::Witness::default(),
+            }],
+            output: vec![],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey: ScriptBuf::new_p2tr_tweaked(info.output_key()),
+        });
+        psbt.inputs[0]
+            .tap_scripts
+            .insert(cb, (leaf, LeafVersion::TapScript));
+        // Lying entry: claims our key participates in this leaf.
+        let our = our_xonly(&km);
+        psbt.inputs[0].tap_key_origins.insert(
+            our,
+            (vec![leaf_hash], (*km.master_fingerprint(), our_full_path())),
+        );
+
+        let jobs = find_taproot_sign_jobs(&psbt, km.master_fingerprint(), &km);
+        assert!(jobs.is_empty());
+    }
+
+    #[test]
+    fn skips_when_already_signed_for_leaf() {
+        let km = KeyManager::from_seed([0x42u8; 64], Network::Testnet).unwrap();
+        let (mut psbt, _, _, leaf_hash, _) = build_legit_taproot_psbt(&km);
+        let our = our_xonly(&km);
+        // Insert any tap_script_sig under (our, leaf_hash); content doesn't matter.
+        let secp = Secp256k1::new();
+        let dummy_kp =
+            Keypair::from_secret_key(&secp, &SecretKey::from_slice(&[0x77; 32]).unwrap());
+        let msg = Message::from_digest([0u8; 32]);
+        let sig = secp.sign_schnorr_no_aux_rand(&msg, &dummy_kp);
+        psbt.inputs[0].tap_script_sigs.insert(
+            (our, leaf_hash),
+            taproot::Signature {
+                signature: sig,
+                sighash_type: TapSighashType::Default,
+            },
+        );
+        let jobs = find_taproot_sign_jobs(&psbt, km.master_fingerprint(), &km);
+        assert!(jobs.is_empty());
+    }
+
+    #[test]
+    fn skips_when_path_outside_bip86_accounts() {
+        let km = KeyManager::from_seed([0x42u8; 64], Network::Testnet).unwrap();
+        let (mut psbt, _, _, leaf_hash, _) = build_legit_taproot_psbt(&km);
+        let our = our_xonly(&km);
+        // Replace path with m/44'/0'/...
+        let bad_path = DerivationPath::from(vec![
+            ChildNumber::from_hardened_idx(44).unwrap(),
+            ChildNumber::from_hardened_idx(0).unwrap(),
+            ChildNumber::from_hardened_idx(0).unwrap(),
+        ]);
+        psbt.inputs[0].tap_key_origins.clear();
+        psbt.inputs[0]
+            .tap_key_origins
+            .insert(our, (vec![leaf_hash], (*km.master_fingerprint(), bad_path)));
+        let jobs = find_taproot_sign_jobs(&psbt, km.master_fingerprint(), &km);
+        assert!(jobs.is_empty());
+    }
+
+    #[test]
+    fn skips_when_witness_utxo_missing() {
+        let km = KeyManager::from_seed([0x42u8; 64], Network::Testnet).unwrap();
+        let (mut psbt, _, _, _, _) = build_legit_taproot_psbt(&km);
+        psbt.inputs[0].witness_utxo = None;
+        let jobs = find_taproot_sign_jobs(&psbt, km.master_fingerprint(), &km);
+        assert!(jobs.is_empty());
+    }
+
+    #[test]
+    fn skips_when_witness_utxo_not_p2tr() {
+        let km = KeyManager::from_seed([0x42u8; 64], Network::Testnet).unwrap();
+        let (mut psbt, _, _, _, _) = build_legit_taproot_psbt(&km);
+        psbt.inputs[0].witness_utxo.as_mut().unwrap().script_pubkey =
+            ScriptBuf::new_p2wpkh(&bitcoin::WPubkeyHash::from_byte_array([0xCC; 20]));
+        let jobs = find_taproot_sign_jobs(&psbt, km.master_fingerprint(), &km);
+        assert!(jobs.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

PSBT hint fields (`bip32_derivation`, `tap_key_origins`, `witness_script`, `tap_scripts`) are coordinator-supplied and untrusted. Today, the enclave treats them as authorization — so a malicious PSBT can trick the TEE into signing inputs where its key is **not** an actual cosigner, turning the enclave into a signing oracle for arbitrary 32-byte messages. The original symptom (TEE signing inputs whose witness script does not include its pubkey) was reported on Slack.

This PR re-anchors authorization to `witness_utxo.script_pubkey`, the only PSBT field committed to by BIP-143 / BIP-341 sighashes.

### P2WSH (segwit v0)
- `should_sign_segwit_input` returns a `SegwitSignDecision { Skip | SignP2wsh { witness_script } }`.
- Requires `sha256(witness_script)` to equal the witness program in `script_pubkey` — closes the "fabricated witness_script" hole.
- Requires our pubkey to appear as an exact 33-byte push inside the script (opcode-aware via `Script::instructions()`) — closes the "key bytes hidden in a larger push" hole.
- `bip32_derivation` is no longer consulted.

### Taproot script-path
- `find_taproot_sign_jobs` now iterates `tap_scripts`, not `tap_key_origins`.
- Each entry's control block must `verify_taproot_commitment` against the on-chain output key extracted from `script_pubkey`.
- Candidate xonly keys come from 32-byte pushes inside the verified leaf script.
- Each candidate must also match a `tap_key_origins` entry whose fingerprint matches ours, whose `leaf_hashes` contains *this* leaf, whose path resolves under our BIP-86 accounts, and whose derived BIP-86 child key's xonly equals the candidate — closing the gap where origins could point our fingerprint at a foreign key.
- `(input_index, leaf_hash, xonly)` is deduped to avoid emitting the same job twice when a key is pushed multiple times in a leaf.

## Tests

- **8 unit tests** on `should_sign_segwit_input` ([signing/psbt.rs](enclave/src/signing/psbt.rs)): legitimate 2-of-3 multisig, missing fields, already-signed, **witness_script does not hash to script_pubkey**, **script_pubkey is P2WPKH**, **pubkey bytes only inside a larger push**, **bip32_derivation lies and script excludes us**.
- **9 unit tests** on `find_taproot_sign_jobs` ([signing/taproot.rs](enclave/src/signing/taproot.rs)): legit multi_a, **control block does not verify**, wrong fingerprint, **path derives to different xonly**, **xonly in origins not pushed in committed leaf**, already signed, path outside BIP-86, missing/non-P2TR witness_utxo.
- **4 adversarial E2E tests** on `sign_psbt` ([keys.rs](enclave/src/keys.rs)): forged `bip32_derivation` (the original symptom), witness_script mismatch, forged tap_key_origins, unverified control block. All assert `signed_count == 0` and empty `partial_sigs` / `tap_script_sigs`.
- All 6 pre-existing positive sign_psbt tests still pass.

`cargo test --workspace` → 110 lib tests + integration tests, all green. `cargo fmt --all -- --check` and `cargo clippy --workspace -- -D warnings` clean.

## Test plan

- [x] CI: fmt, build, clippy, test all green on this PR
- [ ] Confirm with listener/coordinator team that legitimate PSBTs include a valid `witness_script` matching `script_pubkey` (P2WSH) and valid `tap_scripts` with verifying control blocks (taproot). PSBTs that previously got signed only via the `bip32_derivation` shortcut without those fields will silently produce `signed_count == 0` after this lands.