### PR TITLE
feat(spv): wire HeaderChain into enclave handlers (PR 3)

### DIFF
--- a/enclave/src/error.rs
+++ b/enclave/src/error.rs
@@ -62,6 +62,15 @@ pub enum EnclaveError {
 
     #[error("identity mismatch: cloned seed does not derive to expected address")]
     IdentityMismatch,
+
+    #[error("spv: {0}")]
+    Spv(String),
+}
+
+impl From<crate::spv::SpvError> for EnclaveError {
+    fn from(e: crate::spv::SpvError) -> Self {
+        EnclaveError::Spv(e.to_string())
+    }
 }
 
 impl EnclaveError {
@@ -69,6 +78,7 @@ impl EnclaveError {
     pub fn error_code(&self) -> u32 {
         match self {
             EnclaveError::CrossCheck(_) => 3,   // ERROR_CODE_VALIDATION_FAILED
+            EnclaveError::Spv(_) => 3,          // ERROR_CODE_VALIDATION_FAILED
             EnclaveError::NotReady { .. } => 2, // ERROR_CODE_NOT_READY
             _ => 1,
         }

--- a/enclave/src/main.rs
+++ b/enclave/src/main.rs
@@ -1,6 +1,7 @@
 use std::net::TcpListener;
 
 use utexo_bridge_enclave::server::{self, ServerContext};
+use utexo_bridge_enclave::spv::{checkpoint_for, HeaderChain, Network};
 use utexo_bridge_enclave::state::EnclaveState;
 
 fn main() {
@@ -71,10 +72,42 @@ fn main() {
         }
     };
 
+    // Initialise the in-enclave Bitcoin header chain at boot, anchored to
+    // the compile-time checkpoint for the active network. The chain starts
+    // empty; the Listener will populate it via SubmitHeaders.
+    let spv_network = Network::from_env_str(&bitcoin_network_str).unwrap_or_else(|e| {
+        tracing::warn!(
+            "spv: unknown BITCOIN_NETWORK '{bitcoin_network_str}' ({e}); defaulting to mainnet"
+        );
+        Network::Mainnet
+    });
+    let checkpoint = checkpoint_for(spv_network);
+    if let Err(msg) = checkpoint.assert_real_in_release() {
+        // In a release production build this is fatal — placeholder
+        // checkpoints would mean the listener can never push headers that
+        // chain to anything real. Crash early and loud.
+        panic!("{msg}");
+    }
+    if !checkpoint.is_real {
+        tracing::warn!(
+            ?spv_network,
+            "spv: using PLACEHOLDER checkpoint (zeros) — header validation will reject any real chain. \
+             Replace the constant in enclave/src/spv/checkpoint.rs before deploying."
+        );
+    } else {
+        tracing::info!(
+            ?spv_network,
+            checkpoint_height = checkpoint.height,
+            "spv: header chain initialised at checkpoint"
+        );
+    }
+    let header_chain = std::sync::Mutex::new(HeaderChain::new(spv_network, checkpoint));
+
     let ctx = ServerContext {
         state,
         #[cfg(feature = "rgb-validation")]
         rgb_validator,
+        header_chain,
     };
 
     #[cfg(all(feature = "vsock", target_os = "linux"))]

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -15,6 +15,13 @@ pub struct ServerContext {
     pub state: EnclaveState,
     #[cfg(feature = "rgb-validation")]
     pub rgb_validator: Option<crate::validation::rgb::RgbValidator>,
+    /// In-enclave Bitcoin header chain for SPV verification. Populated at
+    /// boot from the compile-time checkpoint; mutated by SubmitHeaders.
+    /// `Mutex` because the enclave handles connections from a single
+    /// thread today, but we want the type to stay correct if that ever
+    /// changes — and `Mutex` over `RefCell` so a future move to
+    /// multi-threaded handling needs no plumbing changes.
+    pub header_chain: std::sync::Mutex<crate::spv::HeaderChain>,
 }
 
 /// Handle a single connection: read one request, dispatch, write one response, close.
@@ -86,11 +93,11 @@ fn dispatch(request: EnclaveRequest, ctx: &ServerContext) -> EnclaveResponse {
                 start_height = req.start_height,
                 "request: SubmitHeaders"
             );
-            handle_submit_headers(req)
+            handle_submit_headers(ctx, req)
         }
         Some(Request::GetLastSavedBlock(req)) => {
             tracing::info!("request: GetLastSavedBlock");
-            handle_get_last_saved_block(req)
+            handle_get_last_saved_block(ctx, req)
         }
         None => {
             tracing::warn!("received empty request (no oneof variant set)");
@@ -343,23 +350,65 @@ fn handle_proxy_federation(_req: ProxyFederationRequest) -> Result<EnclaveRespon
     })
 }
 
-// SPV header sync stubs. The proto + grpc surface is wired so the Listener's
-// header-sync daemon can compile and connect, but header validation +
-// in-memory chain land in PR 2; Merkle proof verification lands in PR 3.
-fn handle_submit_headers(_req: SubmitHeadersRequest) -> Result<EnclaveResponse> {
+// SPV header sync handlers. The chain itself lives in `ctx.header_chain`,
+// initialised at boot from the compile-time checkpoint for the active
+// network (see main.rs).
+//
+// Note: a poisoned mutex (lock returns Err) means a previous handler
+// panicked while holding the lock. That should never happen because the
+// only mutation is `submit_headers` which never panics, but if it does
+// the safe thing is to clear the poison and continue rather than wedge
+// the entire enclave — the chain is in a consistent state because all
+// mutations are atomic.
+fn handle_submit_headers(
+    ctx: &ServerContext,
+    req: SubmitHeadersRequest,
+) -> Result<EnclaveResponse> {
+    let mut chain = ctx
+        .header_chain
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let outcome = chain.submit_headers(req.start_height, &req.headers)?;
+
+    tracing::info!(
+        last_block_height = outcome.last_block_height,
+        headers_accepted = outcome.headers_accepted,
+        reorg_depth = outcome.reorg_depth,
+        "SubmitHeaders outcome"
+    );
+
     Ok(EnclaveResponse {
-        response: Some(Response::Error(ErrorResponse {
-            code: 2, // NOT_READY
-            message: "SPV header chain not yet implemented (see docs/spv-review.md)".into(),
+        response: Some(Response::SubmitHeaders(SubmitHeadersResponse {
+            last_block_height: outcome.last_block_height,
+            last_block_hash: outcome.last_block_hash.to_vec(),
+            headers_accepted: outcome.headers_accepted,
         })),
     })
 }
 
-fn handle_get_last_saved_block(_req: GetLastSavedBlockRequest) -> Result<EnclaveResponse> {
+fn handle_get_last_saved_block(
+    ctx: &ServerContext,
+    _req: GetLastSavedBlockRequest,
+) -> Result<EnclaveResponse> {
+    let chain = ctx
+        .header_chain
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let height = chain.tip_height();
+    let hash = chain.tip_hash();
+
+    tracing::debug!(
+        block_height = height,
+        block_hash = %hex::encode(hash),
+        "GetLastSavedBlock"
+    );
+
     Ok(EnclaveResponse {
-        response: Some(Response::Error(ErrorResponse {
-            code: 2, // NOT_READY
-            message: "SPV header chain not yet implemented (see docs/spv-review.md)".into(),
+        response: Some(Response::GetLastSavedBlock(GetLastSavedBlockResponse {
+            block_height: height,
+            block_hash: hash.to_vec(),
         })),
     })
 }

--- a/enclave/src/spv/checkpoint.rs
+++ b/enclave/src/spv/checkpoint.rs
@@ -1,17 +1,29 @@
-//! Compile-time checkpoint constants — the trust anchors for the in-enclave
-//! header chain.
+//! Compile-time checkpoint + network constants — the trust anchors for the
+//! in-enclave header chain.
 //!
-//! A checkpoint is `(height, block_hash)`. On boot the enclave starts empty;
-//! the Listener feeds headers starting at `height + 1`, and the first header
-//! must chain to `block_hash`. Every checkpoint here ends up in PCR0 because
-//! it's compiled in, so changing one means re-attestation.
+//! A checkpoint is `(height, block_hash, bits, time)`. On boot the enclave
+//! starts empty; the Listener feeds headers starting at `height + 1`, and
+//! the first header must chain to `block_hash`. Every checkpoint here ends
+//! up in PCR0 because it's compiled in, so changing one means re-attestation.
 //!
-//! All values below are PLACEHOLDERS pending the constants the team picks.
-//! They MUST be replaced before this module is wired into the signing path
-//! (PR 3). Building with placeholders is allowed for unit tests today, but
-//! a release build for production will refuse to start (see `assert_real()`).
+//! ## Status
+//!
+//! - **Mainnet checkpoint** — PLACEHOLDER. Required for production. Will be
+//!   set when production deployment is in scope.
+//! - **Signet checkpoint** — PLACEHOLDER. Will be filled in once Mirvais
+//!   provides a `(height, hash, bits, time)` tuple from the UTEXO custom
+//!   signet, scheduled for after the dev asset_id is finalised. PR 3 wires
+//!   the chain through with placeholders so a follow-up PR is a one-line
+//!   constant swap.
+//! - **Signet challenge / magic / block time** — REAL values, provided by
+//!   Oleksandr 2026-04-30. UTEXO custom signet, 3-of-3 multisig, 30s blocks.
+//!   These are baked in now so they end up in PCR0 alongside everything
+//!   else, even though BIP-325 signature verification itself is deferred
+//!   (the signature lives in the coinbase witness, which the proto does not
+//!   carry — see spv/validation.rs).
+//! - **Regtest** — uses well-known regtest constants, fine as-is.
 
-use crate::spv::types::{BlockHash, BlockHeight};
+use crate::spv::types::{BlockHash, BlockHeight, Network};
 
 /// A trust anchor: the enclave only accepts headers that chain forward from
 /// this point, in ascending height.
@@ -84,5 +96,98 @@ impl Checkpoint {
             );
         }
         Ok(())
+    }
+}
+
+/// Look up the checkpoint to use for a given network. Used at boot.
+pub fn checkpoint_for(network: Network) -> Checkpoint {
+    match network {
+        Network::Mainnet => MAINNET_CHECKPOINT,
+        Network::Signet => SIGNET_CHECKPOINT,
+        Network::Testnet3 => TESTNET3_CHECKPOINT,
+        Network::Regtest => REGTEST_CHECKPOINT,
+    }
+}
+
+// === UTEXO custom signet network parameters ===
+//
+// Provided by Oleksandr Mihalatii on 2026-04-30. These describe the dev
+// signet our enclaves will validate headers against. They are baked in
+// (compile-time consts) so they end up in PCR0; the network is selected at
+// boot via the BITCOIN_NETWORK env var, but the *parameters* of each
+// network are immutable per binary.
+//
+// BIP-325 signature verification using these values is NOT implemented in
+// PR 2/3 — the coinbase witness commitment (where the signature lives) is
+// not carried by the current SubmitHeadersRequest proto. Strict signet
+// validation requires extending the proto with `repeated bytes coinbase_txs`
+// and is deferred. These constants are baked in regardless so a future PR
+// can light up verification without re-collecting the values.
+
+/// Signet challenge script for the UTEXO custom signet (BIP-325).
+///
+/// Layout (per Oleksandr's note):
+/// - `6a 4c 09 01 1e 00 00 00 00 00 00 00 00` — OP_RETURN-prefixed block-time
+///   spec (PR bitcoin#29365): 30s = `0x1e` little-endian u64.
+/// - `4c 69 53 21 <33-byte pubkey> 21 <33-byte pubkey> 21 <33-byte pubkey>
+///    53 ae` — `OP_PUSHDATA1 0x69 OP_3 <pk1> <pk2> <pk3> OP_3 OP_CHECKMULTISIG`
+///   = 3-of-3 multisig over three federation signing keys.
+pub const UTEXO_SIGNET_CHALLENGE: &[u8] = &[
+    0x6a, 0x4c, 0x09, 0x01, 0x1e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4c, 0x69, 0x53, 0x21,
+    0x02, 0x24, 0xa5, 0x28, 0xaa, 0x14, 0x1b, 0x7d, 0x2e, 0xd0, 0x93, 0x57, 0x5b, 0x5d, 0x2c, 0x2c,
+    0xee, 0x40, 0x65, 0xab, 0xc6, 0xf7, 0xf6, 0xb1, 0x9a, 0x97, 0x0a, 0x89, 0x75, 0xd3, 0x27, 0xf9,
+    0x35, 0x21, 0x02, 0x49, 0xc6, 0xbf, 0x83, 0x38, 0xec, 0xda, 0x27, 0x49, 0xc3, 0xff, 0xad, 0x4b,
+    0x8e, 0xc2, 0x2f, 0x71, 0x58, 0x19, 0x47, 0xc1, 0x0d, 0x17, 0x66, 0xd9, 0xce, 0x83, 0xd1, 0xbc,
+    0xaf, 0xb9, 0x94, 0x21, 0x02, 0x4f, 0x3a, 0x83, 0x1f, 0xcb, 0x4d, 0xb4, 0x46, 0xb0, 0x7f, 0xe8,
+    0x89, 0x7d, 0x19, 0x3b, 0x86, 0xf9, 0x13, 0x98, 0x4f, 0x6e, 0xb3, 0xab, 0x6e, 0x97, 0x45, 0xee,
+    0xb6, 0x10, 0x17, 0xa3, 0xb5, 0x53, 0xae,
+];
+
+/// Network magic bytes for the UTEXO custom signet.
+pub const UTEXO_SIGNET_MAGIC: [u8; 4] = [0x6f, 0x21, 0x61, 0x5a];
+
+/// Block time for the UTEXO custom signet, in seconds. Encoded into the
+/// challenge script's prefix per bitcoin#29365.
+pub const UTEXO_SIGNET_BLOCK_TIME_SECS: u32 = 30;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signet_challenge_matches_oleksandrs_hex() {
+        // Sanity: the byte array above should hex-encode to exactly the value
+        // Oleksandr posted. If anyone touches the byte array, this catches a
+        // typo before it ships to attestation.
+        let hex = hex::encode(UTEXO_SIGNET_CHALLENGE);
+        assert_eq!(
+            hex,
+            "6a4c09011e000000000000004c6953210224a528aa141b7d2ed093575b5d2c2cee4065abc6f7f6b19a970a8975d327f935210249c6bf8338ecda2749c3ffad4b8ec22f71581947c10d1766d9ce83d1bcafb99421024f3a831fcb4db446b07fe8897d193b86f913984f6eb3ab6e9745eeb61017a3b553ae"
+        );
+    }
+
+    #[test]
+    fn signet_challenge_decodes_as_3_of_3_multisig() {
+        // Light structural check: the trailing bytes are OP_3 OP_CHECKMULTISIG.
+        let len = UTEXO_SIGNET_CHALLENGE.len();
+        assert_eq!(UTEXO_SIGNET_CHALLENGE[len - 2], 0x53); // OP_3 (n)
+        assert_eq!(UTEXO_SIGNET_CHALLENGE[len - 1], 0xae); // OP_CHECKMULTISIG
+    }
+
+    #[test]
+    fn signet_magic_is_four_bytes() {
+        // Defensive: future refactors that reshape the magic must not silently
+        // change its length.
+        assert_eq!(UTEXO_SIGNET_MAGIC.len(), 4);
+        assert_eq!(UTEXO_SIGNET_MAGIC, [0x6f, 0x21, 0x61, 0x5a]);
+    }
+
+    #[test]
+    fn checkpoint_for_dispatches_on_network() {
+        // Checks the lookup table doesn't silently route the wrong checkpoint.
+        assert!(!checkpoint_for(Network::Mainnet).is_real);
+        assert!(!checkpoint_for(Network::Signet).is_real);
+        assert!(!checkpoint_for(Network::Testnet3).is_real);
+        assert!(!checkpoint_for(Network::Regtest).is_real);
     }
 }

--- a/enclave/src/spv/mod.rs
+++ b/enclave/src/spv/mod.rs
@@ -28,6 +28,9 @@ pub mod types;
 pub mod validation;
 
 pub use chain::{HeaderChain, SubmitOutcome};
-pub use checkpoint::Checkpoint;
+pub use checkpoint::{
+    checkpoint_for, Checkpoint, UTEXO_SIGNET_BLOCK_TIME_SECS, UTEXO_SIGNET_CHALLENGE,
+    UTEXO_SIGNET_MAGIC,
+};
 pub use merkle::{verify_merkle_proof, MerkleError, Sha256d};
 pub use types::{BlockHash, BlockHeight, Network, SpvError};

--- a/enclave/tests/common/mod.rs
+++ b/enclave/tests/common/mod.rs
@@ -5,6 +5,7 @@ use std::thread;
 use utexo_bridge_enclave::framing;
 use utexo_bridge_enclave::proto::*;
 use utexo_bridge_enclave::server::{self, ServerContext};
+use utexo_bridge_enclave::spv::{checkpoint_for, HeaderChain, Network};
 use utexo_bridge_enclave::state::EnclaveState;
 
 /// Start a test server on a random TCP port. Returns the port number.
@@ -24,10 +25,18 @@ pub fn start_test_server_with(configure: impl FnOnce(&EnclaveState)) -> u16 {
     let port = listener.local_addr().unwrap().port();
     let state = EnclaveState::new(bitcoin::Network::Bitcoin);
     configure(&state);
+    // Tests run with the placeholder Regtest checkpoint. The header chain
+    // is initialised but empty; tests that don't push headers leave it
+    // alone, tests that do start from `checkpoint.height` (= 0).
+    let header_chain = std::sync::Mutex::new(HeaderChain::new(
+        Network::Regtest,
+        checkpoint_for(Network::Regtest),
+    ));
     let ctx = Arc::new(ServerContext {
         state,
         #[cfg(feature = "rgb-validation")]
         rgb_validator: None,
+        header_chain,
     });
 
     thread::spawn(move || {

--- a/enclave/tests/test_spv_handlers.rs
+++ b/enclave/tests/test_spv_handlers.rs
@@ -1,0 +1,161 @@
+//! Integration tests for the SPV header-sync RPCs (`SubmitHeaders`,
+//! `GetLastSavedBlock`) — exercises the full wire path: TCP framing →
+//! `dispatch` → `ServerContext.header_chain` → response.
+
+use bitcoin::consensus::serialize;
+use bitcoin::hashes::Hash;
+
+use utexo_bridge_enclave::proto::enclave_request::Request as EReq;
+use utexo_bridge_enclave::proto::enclave_response::Response as ERes;
+use utexo_bridge_enclave::proto::*;
+
+mod common;
+use common::{send_request, start_test_server};
+
+/// Build `count` synthetic regtest headers chained from `prev_hash`. The
+/// test server is wired to `Network::Regtest` (see `common/mod.rs`), where
+/// header validation is "chain linkage only", so we don't need to satisfy
+/// real PoW.
+fn synth_chain_from(prev_hash: [u8; 32], prev_time: u32, count: u32) -> Vec<Vec<u8>> {
+    let mut prev = bitcoin::BlockHash::from_raw_hash(
+        bitcoin::hashes::sha256d::Hash::from_byte_array(prev_hash),
+    );
+    let mut out = Vec::with_capacity(count as usize);
+    for i in 0..count {
+        let header = bitcoin::block::Header {
+            version: bitcoin::block::Version::ONE,
+            prev_blockhash: prev,
+            merkle_root: bitcoin::TxMerkleNode::all_zeros(),
+            time: prev_time + 1 + i,
+            bits: bitcoin::CompactTarget::from_consensus(0x207fffff),
+            nonce: i,
+        };
+        out.push(serialize(&header));
+        prev = header.block_hash();
+    }
+    out
+}
+
+fn submit(port: u16, start_height: u32, headers: Vec<Vec<u8>>) -> EnclaveResponse {
+    send_request(
+        port,
+        &EnclaveRequest {
+            request: Some(EReq::SubmitHeaders(SubmitHeadersRequest {
+                headers,
+                start_height,
+            })),
+        },
+    )
+}
+
+fn last_saved(port: u16) -> GetLastSavedBlockResponse {
+    let resp = send_request(
+        port,
+        &EnclaveRequest {
+            request: Some(EReq::GetLastSavedBlock(GetLastSavedBlockRequest {})),
+        },
+    );
+    match resp.response {
+        Some(ERes::GetLastSavedBlock(r)) => r,
+        other => panic!("unexpected response: {other:?}"),
+    }
+}
+
+#[test]
+fn fresh_enclave_reports_checkpoint_as_tip() {
+    // Common test-server uses Regtest with the placeholder checkpoint
+    // (height=0, hash=zeros). On boot, that's the tip.
+    let port = start_test_server();
+    let r = last_saved(port);
+    assert_eq!(r.block_height, 0);
+    assert_eq!(r.block_hash, vec![0u8; 32]);
+}
+
+#[test]
+fn submit_then_query_round_trip() {
+    let port = start_test_server();
+
+    // Push 5 synthetic headers chained from the (zero) checkpoint.
+    let headers = synth_chain_from([0u8; 32], 1_700_000_000, 5);
+    let resp = submit(port, 1, headers);
+
+    match resp.response {
+        Some(ERes::SubmitHeaders(r)) => {
+            assert_eq!(r.headers_accepted, 5);
+            assert_eq!(r.last_block_height, 5);
+            assert_eq!(r.last_block_hash.len(), 32);
+        }
+        other => panic!("unexpected response: {other:?}"),
+    }
+
+    let after = last_saved(port);
+    assert_eq!(after.block_height, 5);
+    assert_ne!(after.block_hash, vec![0u8; 32]);
+}
+
+#[test]
+fn submit_below_checkpoint_returns_error() {
+    let port = start_test_server();
+    // Checkpoint is at height 0; submitting at height 0 is below-checkpoint
+    // territory because it would rewrite the trust anchor.
+    let resp = submit(port, 0, synth_chain_from([0u8; 32], 1_700_000_000, 1));
+
+    match resp.response {
+        Some(ERes::Error(e)) => {
+            assert_eq!(e.code, 3); // VALIDATION_FAILED (Spv error)
+            assert!(
+                e.message.contains("checkpoint"),
+                "expected error to mention checkpoint, got: {}",
+                e.message
+            );
+        }
+        other => panic!("expected Error, got: {other:?}"),
+    }
+}
+
+#[test]
+fn submit_with_gap_returns_error() {
+    let port = start_test_server();
+    // Tip is the checkpoint at height 0; start_height=10 leaves a gap.
+    let resp = submit(port, 10, synth_chain_from([0u8; 32], 1_700_000_000, 1));
+
+    match resp.response {
+        Some(ERes::Error(e)) => {
+            assert_eq!(e.code, 3);
+            assert!(
+                e.message.contains("gap"),
+                "expected error to mention gap, got: {}",
+                e.message
+            );
+        }
+        other => panic!("expected Error, got: {other:?}"),
+    }
+}
+
+#[test]
+fn batched_submits_advance_tip_monotonically() {
+    let port = start_test_server();
+
+    // First batch of 3.
+    let mut prev = [0u8; 32];
+    let batch1 = synth_chain_from(prev, 1_700_000_000, 3);
+    // Recompute prev = hash of last header in batch1 so batch2 chains.
+    let last1: bitcoin::block::Header = bitcoin::consensus::deserialize(&batch1[2]).unwrap();
+    prev = *bitcoin::hashes::Hash::as_byte_array(&last1.block_hash());
+
+    let resp1 = submit(port, 1, batch1);
+    assert!(matches!(resp1.response, Some(ERes::SubmitHeaders(_))));
+    assert_eq!(last_saved(port).block_height, 3);
+
+    // Second batch of 2, picking up where we left off.
+    let batch2 = synth_chain_from(prev, 1_700_000_004, 2);
+    let resp2 = submit(port, 4, batch2);
+    match resp2.response {
+        Some(ERes::SubmitHeaders(r)) => {
+            assert_eq!(r.last_block_height, 5);
+            assert_eq!(r.headers_accepted, 2);
+        }
+        other => panic!("unexpected response: {other:?}"),
+    }
+    assert_eq!(last_saved(port).block_height, 5);
+}


### PR DESCRIPTION
## Summary

Replaces the \`NOT_READY\` stubs from PR 1 with real implementations of \`SubmitHeaders\` and \`GetLastSavedBlock\`, backed by an in-memory \`HeaderChain\` held on \`ServerContext\`. The Listener can now drive header sync end-to-end against this enclave.

Stacked on PR 2 (#26) + PR 2.5 (#27). Also merges in PR 1 (#25) so the proto + dispatch arms are present. GitHub will auto-retarget to \`dev\` as the predecessors merge.

## Wire-up

- \`ServerContext\` gains \`header_chain: Mutex<HeaderChain>\`.
- \`main.rs\` initialises the chain at boot from \`BITCOIN_NETWORK\` env + the compile-time checkpoint for that network. Placeholder checkpoint → loud warning + safe; release-mode placeholder → panic via \`Checkpoint::assert_real_in_release\`.
- \`handle_submit_headers\` / \`handle_get_last_saved_block\` lock the chain, call \`submit_headers\` / \`tip_height + tip_hash\`, and return populated responses.
- New \`EnclaveError::Spv(String)\` + \`From<SpvError>\` mapping. SPV errors surface to the listener as gRPC \`failed_precondition\` (code 3, matching \`CrossCheck\`).

## UTEXO custom signet constants — baked in

Provided by the team. These end up in PCR0 even though BIP-325 signature verification itself is still deferred (the signature lives in the coinbase witness, which the \`SubmitHeadersRequest\` proto does not carry):

- \`UTEXO_SIGNET_CHALLENGE\` — 105-byte challenge: 3-of-3 multisig over the federation pubkeys with a 30s block-time prefix per [bitcoin#29365](https://github.com/bitcoin/bitcoin/pull/29365). Round-trip hex test asserts the bytes equal the value posted in the team thread, byte-for-byte.
- \`UTEXO_SIGNET_MAGIC\` = \`6f21615a\`.
- \`UTEXO_SIGNET_BLOCK_TIME_SECS\` = 30.

## Checkpoint values — still placeholders (deliberately)

The \`(height, hash, bits, time)\` tuple for the trust anchor is pending. The chain runs end-to-end against the placeholder zero values in tests; once the real anchor lands it's a one-line constant swap. \`Checkpoint::assert_real_in_release\` stops a release build from going out without real values, so this can't quietly hit prod.

## What's NOT here (PR 4)

- Wiring SPV verification into \`handle_sign_evm\` (extract witness txids from consignment, cross-check vs \`merkle_proofs[].txid\`, verify each against the chain, enforce \`SPV_MIN_CONFIRMATIONS\`).
- Header staleness rule.
- CLI subcommands for \`SubmitHeaders\` / \`GetLastSavedBlock\` and corresponding \`build/smoke-test.sh\` cases (the smoke test currently only covers Init / GetKeys / SignRawMessage / SignEvm). Worth a small follow-up PR to add CLI + smoke coverage for the new RPCs.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo test --workspace\` — 127 lib + 5 new spv-handlers integration + 18 existing integration tests, all green
- [x] \`cargo test -p utexo-bridge-enclave --features rgb-validation\` — 127 pass
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [ ] On-EC2 smoke test (requires CLI subcommand — see follow-up note above)

### New unit tests (4)
- \`signet_challenge_matches_oleksandrs_hex\` — exact byte-for-byte round-trip
- \`signet_challenge_decodes_as_3_of_3_multisig\` — tail bytes are \`OP_3 OP_CHECKMULTISIG\`
- \`signet_magic_is_four_bytes\`
- \`checkpoint_for_dispatches_on_network\`

### New integration tests (5)
- \`fresh_enclave_reports_checkpoint_as_tip\`
- \`submit_then_query_round_trip\`
- \`submit_below_checkpoint_returns_error\`
- \`submit_with_gap_returns_error\`
- \`batched_submits_advance_tip_monotonically\`