### PR TITLE
test(spv): CLI subcommands + smoke-test coverage for SPV RPCs (PR 3.5)

### DIFF
--- a/build/smoke-test.sh
+++ b/build/smoke-test.sh
@@ -34,15 +34,18 @@ for arg in "$@"; do
     esac
 done
 
-# Find parent binary: explicit env var > release build > debug build
+# Find parent CLI binary: explicit env var > release build > debug build.
+# NOTE: the binary is utexo-bridge-parent-CLI, not utexo-bridge-parent (the
+# latter is the gRPC server and ignores subcommands). Earlier revisions of
+# this script pointed at the wrong binary.
 if [ -n "${PARENT_BIN:-}" ]; then
     :
-elif [ -f "./target/release/utexo-bridge-parent" ]; then
-    PARENT_BIN="./target/release/utexo-bridge-parent"
-elif [ -f "./target/debug/utexo-bridge-parent" ]; then
-    PARENT_BIN="./target/debug/utexo-bridge-parent"
+elif [ -f "./target/release/utexo-bridge-parent-cli" ]; then
+    PARENT_BIN="./target/release/utexo-bridge-parent-cli"
+elif [ -f "./target/debug/utexo-bridge-parent-cli" ]; then
+    PARENT_BIN="./target/debug/utexo-bridge-parent-cli"
 else
-    PARENT_BIN="utexo-bridge-parent"
+    PARENT_BIN="utexo-bridge-parent-cli"
 fi
 
 log()  { echo -e "${YELLOW}[TEST]${NC} $1"; }
@@ -256,6 +259,140 @@ fi
 log "10. ProxyFederation (stub — should return NOT_READY)"
 # No CLI subcommand for federation yet, so we skip if not available
 skip "ProxyFederation" "no CLI subcommand yet — test via integration tests"
+
+# =============================================================================
+# SPV header sync RPCs (PR 3 wired GetLastSavedBlock + SubmitHeaders).
+# =============================================================================
+# These tests exercise the wire path (CLI -> parent -> enclave -> back) without
+# requiring valid Bitcoin headers. Building a synthetic chain that links to the
+# compiled-in checkpoint is unit-test territory; here we want to prove the RPC
+# surface is reachable, the chain is initialised, the lock isn't deadlocked,
+# and the various failure modes (gap, below-checkpoint, malformed bytes) are
+# rejected on the wire.
+#
+# A future PR can add a `build/spv-fixtures/regtest-headers.txt` file and a
+# happy-path "real header inserted" case; for now we deliberately avoid that
+# fixture so the smoke test stays lightweight and shell-only.
+
+# ─────────────────────────────────────────────
+# 11. GetLastSavedBlock baseline
+# ─────────────────────────────────────────────
+log "11. GetLastSavedBlock — chain initialised at boot"
+LAST_BLOCK_OUTPUT=$(run_parent get-last-saved-block) && RC=$? || RC=$?
+
+if [ $RC -eq 0 ] && echo "$LAST_BLOCK_OUTPUT" | grep -q "Block hash"; then
+    BLOCK_HEIGHT=$(echo "$LAST_BLOCK_OUTPUT" | grep "Block height" | awk '{print $NF}')
+    BLOCK_HASH=$(echo "$LAST_BLOCK_OUTPUT" | grep "Block hash" | awk '{print $NF}')
+    BLOCK_HASH_LEN=$((${#BLOCK_HASH} / 2))
+    if [ "$BLOCK_HASH_LEN" -eq 32 ]; then
+        pass "GetLastSavedBlock — height=$BLOCK_HEIGHT, 32-byte hash"
+    else
+        fail "GetLastSavedBlock" "expected 32-byte hash, got $BLOCK_HASH_LEN bytes"
+    fi
+else
+    fail "GetLastSavedBlock" "$LAST_BLOCK_OUTPUT"
+fi
+
+# Stash the initial tip so test 16 can prove the failed submits left the
+# chain unchanged.
+INITIAL_HEIGHT="$BLOCK_HEIGHT"
+INITIAL_HASH="$BLOCK_HASH"
+
+# Helpers for tests 12–15 — write a temp headers file, clean up at exit.
+TMP_HDR_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_HDR_DIR"' EXIT
+
+empty_headers_file()    { local f="$TMP_HDR_DIR/empty.txt";   : > "$f"; echo "$f"; }
+malformed_headers_file() {
+    # 79 bytes (158 hex chars) — one short of a valid Bitcoin header. The
+    # enclave's deserializer will reject this with HeaderParse.
+    local f="$TMP_HDR_DIR/short.txt"
+    printf '%0.s00' $(seq 1 158) > "$f"
+    echo >> "$f"
+    echo "$f"
+}
+filler_headers_file() {
+    # 80 bytes of zeros — parses, but won't link to the placeholder checkpoint
+    # whose hash is also zeros (because prev_blockhash on the all-zero header
+    # is itself zero, which would link it to the checkpoint — but our chain
+    # rejects start_height <= checkpoint, so we use this for the gap test).
+    local f="$TMP_HDR_DIR/zero.txt"
+    printf '%0.s00' $(seq 1 160) > "$f"
+    echo >> "$f"
+    echo "$f"
+}
+
+# ─────────────────────────────────────────────
+# 12. SubmitHeaders empty batch at tip+1 — no-op success
+# ─────────────────────────────────────────────
+log "12. SubmitHeaders — empty batch at tip+1 returns headers_accepted=0"
+NEXT_HEIGHT=$((INITIAL_HEIGHT + 1))
+EMPTY_FILE="$(empty_headers_file)"
+EMPTY_OUTPUT=$(run_parent submit-headers --start-height "$NEXT_HEIGHT" --headers-file "$EMPTY_FILE") && RC=$? || RC=$?
+
+if [ $RC -eq 0 ] && echo "$EMPTY_OUTPUT" | grep -q "Headers accepted: *0"; then
+    pass "SubmitHeaders empty batch — accepted=0"
+else
+    fail "SubmitHeaders empty batch" "$EMPTY_OUTPUT"
+fi
+
+# ─────────────────────────────────────────────
+# 13. SubmitHeaders with a gap above the tip
+# ─────────────────────────────────────────────
+log "13. SubmitHeaders — gap above tip (start_height=tip+5) is rejected"
+GAP_HEIGHT=$((INITIAL_HEIGHT + 5))
+FILLER_FILE="$(filler_headers_file)"
+GAP_OUTPUT=$(run_parent submit-headers --start-height "$GAP_HEIGHT" --headers-file "$FILLER_FILE") && RC=$? || RC=$?
+
+if [ $RC -ne 0 ] && echo "$GAP_OUTPUT" | grep -qi "gap\|spv\|enclave error"; then
+    pass "SubmitHeaders gap correctly rejected"
+else
+    fail "SubmitHeaders gap" "expected error, got: $GAP_OUTPUT"
+fi
+
+# ─────────────────────────────────────────────
+# 14. SubmitHeaders at-or-below checkpoint
+# ─────────────────────────────────────────────
+log "14. SubmitHeaders — start_height at checkpoint is rejected"
+# Submitting AT the checkpoint height would rewrite the trust anchor.
+BELOW_OUTPUT=$(run_parent submit-headers --start-height "$INITIAL_HEIGHT" --headers-file "$FILLER_FILE") && RC=$? || RC=$?
+
+if [ $RC -ne 0 ] && echo "$BELOW_OUTPUT" | grep -qi "checkpoint\|trust anchor\|spv\|enclave error"; then
+    pass "SubmitHeaders below-checkpoint correctly rejected"
+else
+    fail "SubmitHeaders below-checkpoint" "expected error, got: $BELOW_OUTPUT"
+fi
+
+# ─────────────────────────────────────────────
+# 15. SubmitHeaders with malformed bytes
+# ─────────────────────────────────────────────
+log "15. SubmitHeaders — malformed (79-byte) header is rejected"
+SHORT_FILE="$(malformed_headers_file)"
+MALFORMED_OUTPUT=$(run_parent submit-headers --start-height "$NEXT_HEIGHT" --headers-file "$SHORT_FILE") && RC=$? || RC=$?
+
+if [ $RC -ne 0 ] && echo "$MALFORMED_OUTPUT" | grep -qi "header\|parse\|spv\|enclave error"; then
+    pass "SubmitHeaders malformed header correctly rejected"
+else
+    fail "SubmitHeaders malformed" "expected error, got: $MALFORMED_OUTPUT"
+fi
+
+# ─────────────────────────────────────────────
+# 16. GetLastSavedBlock unchanged after failed submits
+# ─────────────────────────────────────────────
+log "16. GetLastSavedBlock — tip unchanged after failed submits (atomic-on-error)"
+AFTER_OUTPUT=$(run_parent get-last-saved-block) && RC=$? || RC=$?
+
+if [ $RC -eq 0 ]; then
+    AFTER_HEIGHT=$(echo "$AFTER_OUTPUT" | grep "Block height" | awk '{print $NF}')
+    AFTER_HASH=$(echo "$AFTER_OUTPUT" | grep "Block hash" | awk '{print $NF}')
+    if [ "$AFTER_HEIGHT" = "$INITIAL_HEIGHT" ] && [ "$AFTER_HASH" = "$INITIAL_HASH" ]; then
+        pass "Chain tip unchanged ($AFTER_HEIGHT / ${AFTER_HASH:0:16}…)"
+    else
+        fail "Chain tip mutated" "before=($INITIAL_HEIGHT,$INITIAL_HASH) after=($AFTER_HEIGHT,$AFTER_HASH)"
+    fi
+else
+    fail "GetLastSavedBlock (after)" "$AFTER_OUTPUT"
+fi
 
 # ─────────────────────────────────────────────
 # Summary

--- a/build/smoke-test.sh
+++ b/build/smoke-test.sh
@@ -67,10 +67,83 @@ echo ""
 
 # Check binary exists
 if ! command -v "$PARENT_BIN" &>/dev/null && [ ! -f "$PARENT_BIN" ]; then
-    echo -e "${RED}Error: parent binary not found at '$PARENT_BIN'${NC}"
-    echo "Set PARENT_BIN env var or place utexo-bridge-parent in current directory."
+    echo -e "${RED}Error: CLI binary not found at '$PARENT_BIN'${NC}"
+    echo "Run 'cargo build --bin utexo-bridge-parent-cli' or set PARENT_BIN env var."
     exit 1
 fi
+
+# Preflight: prove the peer at $ADDR speaks our wire protocol, not just
+# "something accepts TCP here". A naive `nc -z` is insufficient on macOS
+# because port 5000 is hijacked by AirPlay Receiver — nc happily connects,
+# we then write our length-prefixed protobuf into AirPlay's mouth, and the
+# CLI hangs forever waiting for a response that will never come.
+#
+# Strategy: run `get-keys` once. The enclave responds with one of two
+# stable patterns:
+#   - "EVM address ..."  (initialised — typical re-run state)
+#   - "key not initialized" (fresh enclave — typical first-run state)
+# Any other output (or a timeout from EnclaveClient's READ_TIMEOUT) means
+# we're talking to something that isn't our enclave. Bail with hints.
+preflight_handshake() {
+    local addr="$1"
+    local out
+    out=$("$PARENT_BIN" --addr "$addr" get-keys 2>&1) || true
+    if echo "$out" | grep -qiE "EVM address|key not initialized|not initialized"; then
+        return 0
+    fi
+    echo "$out" >&2
+    return 1
+}
+
+# Friendly diagnostic for the macOS-on-port-5000 case. Detects the
+# AirPlay Receiver process holding port 5000 and tells the user where to
+# turn it off.
+print_airplay_hint_if_relevant() {
+    local addr="$1"
+    case "$(uname -s)" in
+        Darwin) ;;  # continue
+        *) return 0 ;;
+    esac
+    case "$addr" in
+        *:5000) ;;
+        *) return 0 ;;
+    esac
+    if command -v lsof &>/dev/null && lsof -nP -iTCP:5000 -sTCP:LISTEN 2>/dev/null | grep -q "ControlCe"; then
+        echo ""
+        echo -e "${YELLOW}macOS AirPlay Receiver is holding port 5000.${NC}"
+        echo "Either:"
+        echo "  1. Disable AirPlay Receiver:"
+        echo "     System Settings → General → AirDrop & Handoff → AirPlay Receiver → Off"
+        echo "  2. Use a different port (recommended for dev):"
+        echo "     ENCLAVE_LISTEN_ADDR=127.0.0.1:5050 cargo run --bin utexo-bridge-enclave"
+        echo "     ./build/smoke-test.sh --addr=127.0.0.1:5050"
+    fi
+}
+
+case "$ADDR" in
+    vsock://*)
+        # vsock preflight needs nitro-cli describe-enclaves; left to the host.
+        if ! command -v nitro-cli &>/dev/null; then
+            echo -e "${YELLOW}Warning: nitro-cli not in PATH; cannot verify enclave is running${NC}"
+        fi
+        ;;
+    *)
+        echo "Preflight: handshake against $ADDR..."
+        if ! preflight_handshake "$ADDR"; then
+            echo -e "${RED}Error: $ADDR is not responding with our enclave wire protocol.${NC}"
+            echo ""
+            echo "Start the enclave first, then re-run this script:"
+            echo ""
+            echo "  RUST_LOG=info cargo run --bin utexo-bridge-enclave"
+            echo ""
+            echo "(in a separate terminal). For Nitro Enclave / vsock mode use --vsock."
+            print_airplay_hint_if_relevant "$ADDR"
+            exit 1
+        fi
+        echo -e "${GREEN}Preflight OK — peer speaks the enclave wire protocol${NC}"
+        echo ""
+        ;;
+esac
 
 # ─────────────────────────────────────────────
 # 1. Initialize keys

--- a/parent/src/bin/cli.rs
+++ b/parent/src/bin/cli.rs
@@ -1,4 +1,5 @@
 use std::io::{self, BufRead, Write};
+use std::path::PathBuf;
 use std::process;
 
 use clap::{Parser, Subcommand};
@@ -101,6 +102,23 @@ enum Command {
         /// Hex-encoded message bytes
         #[arg(long)]
         message: String,
+    },
+    /// Get the enclave's current SPV chain tip (height + hash).
+    /// Listener calls this on startup to know where to resume header sync.
+    GetLastSavedBlock,
+    /// Push a batch of Bitcoin block headers into the enclave's SPV chain.
+    ///
+    /// Headers are read from a file: one hex-encoded 80-byte header per line,
+    /// in ascending height order. Empty lines and lines starting with `#` are
+    /// ignored. Pass an empty file to send a no-op batch (useful for smoke
+    /// testing — proves the dispatch path without a fixture chain).
+    SubmitHeaders {
+        /// Block height of the first header in the batch.
+        #[arg(long)]
+        start_height: u32,
+        /// Path to a file with one hex-encoded header per line (80 bytes = 160 hex chars).
+        #[arg(long)]
+        headers_file: PathBuf,
     },
     /// Enter interactive REPL mode
     Interactive,
@@ -355,6 +373,64 @@ fn main() {
                 }
             }
         }
+        Command::GetLastSavedBlock => match client.get_last_saved_block() {
+            Ok(r) => {
+                println!("Block height: {}", r.block_height);
+                println!("Block hash:   {}", hex::encode(&r.block_hash));
+            }
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                process::exit(1);
+            }
+        },
+        Command::SubmitHeaders {
+            start_height,
+            headers_file,
+        } => {
+            let headers = match read_headers_file(&headers_file) {
+                Ok(h) => h,
+                Err(e) => {
+                    eprintln!("Error reading {}: {}", headers_file.display(), e);
+                    process::exit(1);
+                }
+            };
+            match client.submit_headers(start_height, headers) {
+                Ok(r) => {
+                    println!("Last block height: {}", r.last_block_height);
+                    println!("Last block hash:   {}", hex::encode(&r.last_block_hash));
+                    println!("Headers accepted:  {}", r.headers_accepted);
+                }
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    process::exit(1);
+                }
+            }
+        }
         Command::Interactive => run_interactive(&client),
     }
+}
+
+/// Parse a headers file: one hex-encoded 80-byte header per line, blank lines
+/// and `#` comments ignored. Wrong-length lines are surfaced as errors so
+/// silent corruption can't sneak in.
+fn read_headers_file(path: &std::path::Path) -> std::io::Result<Vec<Vec<u8>>> {
+    let contents = std::fs::read_to_string(path)?;
+    let mut headers = Vec::new();
+    for (lineno, raw) in contents.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let bytes = hex::decode(line).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("line {}: invalid hex: {}", lineno + 1, e),
+            )
+        })?;
+        // Don't enforce 80 bytes here — the enclave will reject on parse.
+        // Keeping the CLI permissive lets us deliberately send malformed
+        // headers in smoke tests.
+        headers.push(bytes);
+    }
+    Ok(headers)
 }

--- a/parent/src/client.rs
+++ b/parent/src/client.rs
@@ -1,8 +1,9 @@
 use crate::enclave_proto::{
     enclave_request, enclave_response, EnclaveRequest, EnclaveResponse, EvmSignatureResponse,
-    GetPublicKeyRequest, InitializeKeyRequest, InitializeKeyResponse, PublicKeysResponse,
-    RawSignatureResponse, SignEvmRequest, SignPsbtRequest, SignRawMessageRequest,
-    SignedPsbtResponse,
+    GetLastSavedBlockRequest, GetLastSavedBlockResponse, GetPublicKeyRequest, InitializeKeyRequest,
+    InitializeKeyResponse, PublicKeysResponse, RawSignatureResponse, SignEvmRequest,
+    SignPsbtRequest, SignRawMessageRequest, SignedPsbtResponse, SubmitHeadersRequest,
+    SubmitHeadersResponse,
 };
 use crate::error::{ParentError, Result};
 use crate::framing;
@@ -137,6 +138,53 @@ impl EnclaveClient {
         let resp = self.send_request(&req)?;
         match resp.response {
             Some(enclave_response::Response::RawSignature(r)) => Ok(r),
+            Some(enclave_response::Response::Error(e)) => Err(ParentError::EnclaveError {
+                code: e.code,
+                message: e.message,
+            }),
+            other => Err(ParentError::Connection(format!(
+                "unexpected response variant: {:?}",
+                other
+            ))),
+        }
+    }
+
+    pub fn get_last_saved_block(&self) -> Result<GetLastSavedBlockResponse> {
+        let req = EnclaveRequest {
+            request: Some(enclave_request::Request::GetLastSavedBlock(
+                GetLastSavedBlockRequest {},
+            )),
+        };
+        let resp = self.send_request(&req)?;
+        match resp.response {
+            Some(enclave_response::Response::GetLastSavedBlock(r)) => Ok(r),
+            Some(enclave_response::Response::Error(e)) => Err(ParentError::EnclaveError {
+                code: e.code,
+                message: e.message,
+            }),
+            other => Err(ParentError::Connection(format!(
+                "unexpected response variant: {:?}",
+                other
+            ))),
+        }
+    }
+
+    pub fn submit_headers(
+        &self,
+        start_height: u32,
+        headers: Vec<Vec<u8>>,
+    ) -> Result<SubmitHeadersResponse> {
+        let req = EnclaveRequest {
+            request: Some(enclave_request::Request::SubmitHeaders(
+                SubmitHeadersRequest {
+                    headers,
+                    start_height,
+                },
+            )),
+        };
+        let resp = self.send_request(&req)?;
+        match resp.response {
+            Some(enclave_response::Response::SubmitHeaders(r)) => Ok(r),
             Some(enclave_response::Response::Error(e)) => Err(ParentError::EnclaveError {
                 code: e.code,
                 message: e.message,

--- a/parent/src/client.rs
+++ b/parent/src/client.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::enclave_proto::{
     enclave_request, enclave_response, EnclaveRequest, EnclaveResponse, EvmSignatureResponse,
     GetLastSavedBlockRequest, GetLastSavedBlockResponse, GetPublicKeyRequest, InitializeKeyRequest,
@@ -7,6 +9,19 @@ use crate::enclave_proto::{
 };
 use crate::error::{ParentError, Result};
 use crate::framing;
+
+/// Connect timeout. Localhost connect resolves in microseconds; this is
+/// only relevant when reaching across a network (or through a mis-routed
+/// vsock proxy).
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Read timeout for the response. Without this, an unrelated peer that
+/// accepts the TCP connection but never speaks our wire protocol (the
+/// classic case being macOS AirPlay Receiver hijacking port 5000) makes
+/// the CLI hang forever instead of failing fast. Enclave operations that
+/// could legitimately take a while (key generation, RGB consignment
+/// validation against Esplora) still need to fit inside this budget.
+const READ_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct EnclaveClient {
     addr: String,
@@ -30,9 +45,20 @@ impl EnclaveClient {
         }
         #[cfg(not(feature = "vsock"))]
         {
-            use std::net::TcpStream;
-            let mut stream = TcpStream::connect(&self.addr)
+            use std::net::{TcpStream, ToSocketAddrs};
+            let socket_addr = self
+                .addr
+                .to_socket_addrs()
+                .map_err(|e| ParentError::Connection(format!("resolve {}: {}", self.addr, e)))?
+                .next()
+                .ok_or_else(|| {
+                    ParentError::Connection(format!("no addresses for {}", self.addr))
+                })?;
+            let mut stream = TcpStream::connect_timeout(&socket_addr, CONNECT_TIMEOUT)
                 .map_err(|e| ParentError::Connection(e.to_string()))?;
+            stream
+                .set_read_timeout(Some(READ_TIMEOUT))
+                .map_err(|e| ParentError::Connection(format!("set_read_timeout: {e}")))?;
             framing::write_message(&mut stream, req)?;
             framing::read_message(&mut stream)
         }


### PR DESCRIPTION
## Summary

PR 3 wired the \`SubmitHeaders\` / \`GetLastSavedBlock\` handlers but neither had a CLI subcommand or smoke-test case. This PR closes that gap and fixes a stale binary-name reference in the existing smoke script.

Stacked on PR 3 (#29). Auto-retargets to dev as predecessors merge.

## CLI changes

- \`get-last-saved-block\` — prints the enclave's current chain tip (height + hash).
- \`submit-headers --start-height N --headers-file FILE\` — pushes a batch. \`FILE\` is one hex-encoded 80-byte header per line; blank lines and \`#\` comments ignored. Empty file is allowed (the legitimate no-op case). Wrong-length lines are deliberately permitted at the CLI layer so malformed inputs can be sent for negative tests; the enclave does the rejection.
- Matching \`EnclaveClient::{get_last_saved_block, submit_headers}\` wrappers around the wire envelope.

## Smoke-test changes

### Bug fix

\`PARENT_BIN\` was pointing at \`utexo-bridge-parent\` (the gRPC **server** binary) instead of \`utexo-bridge-parent-cli\` (the CLI). The server ignores subcommands, which would have made every test silently do the wrong thing on a fresh checkout. Path now points at the CLI. This wasn't introduced by us — it predates the SPV stack — but worth fixing in passing.

### New SPV cases (tests 11–16)

| # | Test | What it asserts |
|---|---|---|
| 11 | \`GetLastSavedBlock\` baseline | Returns a 32-byte hash; chain initialised at boot; lock not deadlocked. |
| 12 | \`SubmitHeaders\` empty batch at \`tip+1\` | Returns \`headers_accepted=0\` without moving the tip — legitimate no-progress case. |
| 13 | \`SubmitHeaders\` with \`start_height = tip+5\` (gap) | Rejected. |
| 14 | \`SubmitHeaders\` at checkpoint height | Rejected — trust-anchor floor enforced. |
| 15 | \`SubmitHeaders\` with a 79-byte (malformed) header | Rejected — header parser catches it. |
| 16 | \`GetLastSavedBlock\` after the failed submits | Same height/hash as test 11 — proves atomic-on-error. |

The 6 cases deliberately avoid building a synthetic chain that links to the compiled-in checkpoint — that's unit-test territory and would need a fixture file. A future PR can add a regtest fixture + happy-path case.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo test --workspace\` — all green
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] **\`bash build/smoke-test.sh\` against a local TCP enclave — 15 / 15 pass** (1 unrelated SKIP for \`ProxyFederation\` which is still stubbed)

## Out of scope

- PSBT smoke (needs a valid PSBT fixture).
- Cloning RPCs (need two enclaves + mutual attestation).
- Happy-path "real header inserted" smoke case (needs a checked-in regtest fixture).