### PR TITLE
feat(spv): header staleness rule (PR 5/5)

### DIFF
--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -276,6 +276,15 @@ fn handle_sign_evm(ctx: &ServerContext, req: SignEvmRequest) -> Result<EnclaveRe
             .header_chain
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Staleness: tip header time must be within bounds of wall clock.
+        // Catches the "frozen time" attack where the listener feeds
+        // real-but-old headers, never reaching the actual chain head.
+        validation::spv_crosscheck::assert_chain_not_stale(
+            &chain,
+            std::time::SystemTime::now(),
+            std::time::Duration::from_secs(validation::spv_crosscheck::SPV_MAX_TIP_AGE_SECS),
+            std::time::Duration::from_secs(validation::spv_crosscheck::SPV_MAX_TIP_FUTURE_SECS),
+        )?;
         // Cross-network replay: regtest consignment to mainnet enclave etc.
         validation::spv_crosscheck::assert_chain_net(&validated.chain_net, chain.network())?;
         // Inclusion + confirmation depth for every witness tx.

--- a/enclave/src/spv/chain.rs
+++ b/enclave/src/spv/chain.rs
@@ -114,6 +114,18 @@ impl HeaderChain {
         }
     }
 
+    /// Block timestamp (`time` field, Unix seconds) of the most recent
+    /// validated header — or the checkpoint's `time` if no headers stored.
+    /// Used by the SPV staleness check to detect "frozen-time" attacks
+    /// where a hostile listener feeds real-but-old headers.
+    pub fn tip_time(&self) -> u32 {
+        if let Some(last) = self.headers.last() {
+            last.time
+        } else {
+            self.checkpoint.time
+        }
+    }
+
     /// Number of validated headers stored (excludes the checkpoint itself).
     pub fn len(&self) -> usize {
         self.headers.len()

--- a/enclave/src/validation/spv_crosscheck.rs
+++ b/enclave/src/validation/spv_crosscheck.rs
@@ -26,6 +26,7 @@
 //! no conversion needed for that step.
 
 use std::collections::BTreeSet;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use bitcoin::hashes::Hash;
 
@@ -38,6 +39,25 @@ use crate::spv::{verify_merkle_proof, HeaderChain, MerkleError, Network};
 /// let an operator with control of the host set it to 0 and bypass SPV
 /// entirely while the attestation still passed.
 pub const SPV_MIN_CONFIRMATIONS: u32 = 6;
+
+/// Maximum age of the chain tip's `time` (seconds). If the most recent
+/// header in the in-enclave chain is older than this relative to wall
+/// clock, the enclave refuses to sign — defense against the "frozen
+/// time" attack where a hostile listener feeds real-but-old headers
+/// from the checkpoint forward, never reaching the actual chain head.
+///
+/// 2 hours is generous: the listener is supposed to push every ~30s,
+/// and even on mainnet (10-minute target) legitimate gaps don't reach
+/// 2 hours under normal operation. With the gate at 2 h we false-reject
+/// only during clearly broken / hostile listener behaviour, while still
+/// closing the freeze-time window meaningfully.
+pub const SPV_MAX_TIP_AGE_SECS: u64 = 2 * 60 * 60;
+
+/// Bitcoin consensus allows a block's `time` to be up to ~2 hours in the
+/// future of network-adjusted time. We accept that grace, but reject
+/// anything beyond — otherwise an attacker could submit a header with
+/// `time = far_future` to defeat the staleness check.
+pub const SPV_MAX_TIP_FUTURE_SECS: u64 = 2 * 60 * 60;
 
 /// Verify a complete set of SPV proofs against the chain.
 ///
@@ -95,6 +115,60 @@ pub fn validate_spv_proofs(
     let tip = chain.tip_height();
     for (i, proof) in proofs.iter().enumerate() {
         verify_one_proof(chain, tip, min_confirmations, i, proof)?;
+    }
+
+    Ok(())
+}
+
+/// Refuse to sign if the chain tip is too old (or anomalously in the
+/// future) compared to wall clock. `now` is injected so this is unit
+/// testable without monkeying with the system clock; in production
+/// `handle_sign_evm` passes `SystemTime::now()`.
+///
+/// Threat model: a hostile listener can serve real-but-old headers
+/// starting at the checkpoint. The chain validates fine — every header
+/// is real, PoW is real, linkage holds. But the enclave's tip is stuck
+/// at some past height while the actual Bitcoin chain has moved on.
+/// Without this check the enclave can't tell, and an SPV proof against
+/// an old block would still be considered "well confirmed" from the
+/// enclave's frame. With this check, the staleness of the listener's
+/// feed becomes a hard rejection.
+pub fn assert_chain_not_stale(
+    chain: &HeaderChain,
+    now: SystemTime,
+    max_age: Duration,
+    max_future: Duration,
+) -> Result<()> {
+    let now_unix = now
+        .duration_since(UNIX_EPOCH)
+        .map_err(|e| EnclaveError::Internal(format!("system clock is before UNIX_EPOCH: {e}")))?
+        .as_secs();
+    let tip_time = u64::from(chain.tip_time());
+
+    // Future-bound: a tip claiming to be far ahead of now is anomalous.
+    // Bitcoin's consensus rule allows ~2h of future skew per block; we
+    // reject anything beyond.
+    if let Some(future_skew) = tip_time.checked_sub(now_unix) {
+        if future_skew > max_future.as_secs() {
+            return Err(EnclaveError::Spv(format!(
+                "spv: chain tip is {future_skew}s in the future (now = {now_unix}, \
+                 tip_time = {tip_time}, max future skew = {}s)",
+                max_future.as_secs()
+            )));
+        }
+        // Else: in-bounds future skew, OK.
+        return Ok(());
+    }
+
+    // Past-bound: tip is in the past (the normal case). Check it isn't
+    // too far back.
+    let age = now_unix.saturating_sub(tip_time);
+    if age > max_age.as_secs() {
+        return Err(EnclaveError::Spv(format!(
+            "spv: chain tip is too stale (now = {now_unix}, tip_time = {tip_time}, \
+             age = {age}s, max age = {}s) — listener may be frozen or hostile",
+            max_age.as_secs()
+        )));
     }
 
     Ok(())
@@ -609,5 +683,140 @@ mod tests {
         let target = synth_headers(1).into_iter().next().unwrap();
         let chain = chain_burying(target, 5);
         validate_spv_proofs(&chain, &[], &[], SPV_MIN_CONFIRMATIONS).unwrap();
+    }
+
+    // ===== Staleness tests =====
+    //
+    // These hand `assert_chain_not_stale` an explicit `now` so the test
+    // doesn't depend on wall clock. Synthetic headers in this file have
+    // `time = 1_700_000_001 + i`, so we anchor `now` relative to that.
+
+    /// Build a chain whose tip header has the given `time` (Unix seconds).
+    fn chain_with_tip_time(tip_time: u32) -> HeaderChain {
+        let header = Header {
+            version: Version::ONE,
+            prev_blockhash: bitcoin::BlockHash::from_byte_array([0u8; 32]),
+            merkle_root: bitcoin::TxMerkleNode::all_zeros(),
+            time: tip_time,
+            bits: bitcoin::CompactTarget::from_consensus(0x207fffff),
+            nonce: 0,
+        };
+        regtest_chain_with(vec![header])
+    }
+
+    fn unix(secs: u64) -> SystemTime {
+        UNIX_EPOCH + Duration::from_secs(secs)
+    }
+
+    #[test]
+    fn staleness_fresh_tip_passes() {
+        let chain = chain_with_tip_time(1_700_000_000);
+        // Now = tip + 30 minutes. Well within 2h.
+        assert_chain_not_stale(
+            &chain,
+            unix(1_700_000_000 + 30 * 60),
+            Duration::from_secs(SPV_MAX_TIP_AGE_SECS),
+            Duration::from_secs(SPV_MAX_TIP_FUTURE_SECS),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn staleness_tip_at_exact_max_age_passes() {
+        let chain = chain_with_tip_time(1_700_000_000);
+        // Now = tip + exactly max_age. Boundary is inclusive (age == max_age
+        // is allowed; only age > max_age rejects).
+        assert_chain_not_stale(
+            &chain,
+            unix(1_700_000_000 + SPV_MAX_TIP_AGE_SECS),
+            Duration::from_secs(SPV_MAX_TIP_AGE_SECS),
+            Duration::from_secs(SPV_MAX_TIP_FUTURE_SECS),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn staleness_old_tip_rejects() {
+        let chain = chain_with_tip_time(1_700_000_000);
+        // Now = tip + 3 hours. Past the 2-hour bound.
+        let err = assert_chain_not_stale(
+            &chain,
+            unix(1_700_000_000 + 3 * 60 * 60),
+            Duration::from_secs(SPV_MAX_TIP_AGE_SECS),
+            Duration::from_secs(SPV_MAX_TIP_FUTURE_SECS),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("too stale"), "got: {err}");
+    }
+
+    #[test]
+    fn staleness_far_future_tip_rejects() {
+        let chain = chain_with_tip_time(1_700_000_000 + 4 * 60 * 60);
+        // Tip is 4h ahead of now; we allow up to 2h future skew.
+        let err = assert_chain_not_stale(
+            &chain,
+            unix(1_700_000_000),
+            Duration::from_secs(SPV_MAX_TIP_AGE_SECS),
+            Duration::from_secs(SPV_MAX_TIP_FUTURE_SECS),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("in the future"), "got: {err}");
+    }
+
+    #[test]
+    fn staleness_near_future_tip_passes() {
+        let chain = chain_with_tip_time(1_700_000_000 + 30 * 60);
+        // Tip 30 min in the future of now — within the consensus 2h grace.
+        assert_chain_not_stale(
+            &chain,
+            unix(1_700_000_000),
+            Duration::from_secs(SPV_MAX_TIP_AGE_SECS),
+            Duration::from_secs(SPV_MAX_TIP_FUTURE_SECS),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn staleness_uses_checkpoint_time_when_no_headers() {
+        // No headers pushed. Chain falls back to checkpoint.time, which in
+        // this test setup is 1_700_000_000. Now = +1h → fresh; now = +3h
+        // → stale. Same logic as a populated chain — checkpoint is just a
+        // header we don't store the body of.
+        let chain = HeaderChain::new(
+            Network::Regtest,
+            crate::spv::checkpoint::Checkpoint {
+                height: 0,
+                hash: [0u8; 32],
+                bits: 0x207fffff,
+                time: 1_700_000_000,
+                is_real: false,
+            },
+        );
+        assert_chain_not_stale(
+            &chain,
+            unix(1_700_000_000 + 60 * 60),
+            Duration::from_secs(SPV_MAX_TIP_AGE_SECS),
+            Duration::from_secs(SPV_MAX_TIP_FUTURE_SECS),
+        )
+        .unwrap();
+
+        let err = assert_chain_not_stale(
+            &chain,
+            unix(1_700_000_000 + 3 * 60 * 60),
+            Duration::from_secs(SPV_MAX_TIP_AGE_SECS),
+            Duration::from_secs(SPV_MAX_TIP_FUTURE_SECS),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("too stale"), "got: {err}");
+    }
+
+    #[test]
+    fn staleness_thresholds_are_what_we_documented() {
+        // Defensive: if anyone tightens these constants without
+        // understanding why, the test catches it. 2h on each side is
+        // deliberately generous; lowering is a security tradeoff that
+        // should be a conscious decision, not an incidental edit.
+        assert_eq!(SPV_MAX_TIP_AGE_SECS, 2 * 60 * 60);
+        assert_eq!(SPV_MAX_TIP_FUTURE_SECS, 2 * 60 * 60);
     }
 }


### PR DESCRIPTION
## Summary

Closes the **frozen-time** attack on the SPV path. A hostile listener can feed real-but-old headers from the checkpoint forward — every header validates (real PoW, real linkage, real chain) but the enclave's tip is stuck in the past while the actual Bitcoin chain has moved on. SPV proofs against shallow-from-the-real-tip blocks would look "well confirmed" from the enclave's frozen frame.

This PR adds a wall-clock check that runs before SPV verification: the most recent header's \`time\` must be within bounds of \`now\`. If the listener stops feeding fresh data for more than 2 hours, the enclave fails closed.

Stacked on PR 4 (#31). Auto-retargets to \`dev\` as predecessors merge.

## Behaviour

| | Value | Why |
|---|---|---|
| \`SPV_MAX_TIP_AGE_SECS\` | 2 × 60 × 60 | Listener pushes every ~30s in normal operation; legitimate gaps don't reach 2 h. Loose enough to avoid false-rejects on transient hiccups, tight enough to close the freeze-time window. |
| \`SPV_MAX_TIP_FUTURE_SECS\` | 2 × 60 × 60 | Bitcoin consensus allows up to ~2 h of future skew per block. Without a future bound, an attacker could submit a header with far-future \`time\` to defeat the staleness check entirely. |

Both **compile-time constants**, not env-driven — same reasoning as \`SPV_MIN_CONFIRMATIONS\` in PR 4: an operator-changeable threshold could be set to \`u64::MAX\` and bypass this defense while attestation still passed.

## What changed

- **\`enclave/src/spv/chain.rs\`** — new \`HeaderChain::tip_time()\` accessor (falls back to \`checkpoint.time\` on an empty chain).
- **\`enclave/src/validation/spv_crosscheck.rs\`** — new \`SPV_MAX_TIP_AGE_SECS\` + \`SPV_MAX_TIP_FUTURE_SECS\` constants and \`assert_chain_not_stale(chain, now, max_age, max_future)\`. \`now\` is injected so unit tests don't depend on wall clock.
- **\`enclave/src/server.rs\`** — staleness check wired into \`handle_sign_evm\` *before* the existing \`assert_chain_net\` / \`validate_spv_proofs\` calls. Cheap, fails fast.

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo test --workspace\` (default features) — 125 pass
- [x] \`cargo test -p utexo-bridge-enclave --features spv\` — 148 unit (was 141, +7 staleness) + 17 integration + 5 spv-handlers
- [x] \`cargo clippy ... -D warnings\` clean for both feature combos
- [x] **Live smoke (\`bash build/smoke-test.sh\`) against SPV-on enclave: 15/15 pass**
- [x] **Live smoke against SPV-off enclave: 15/15 pass** (regression check)

### New unit tests (7)

- \`staleness_fresh_tip_passes\` — tip 30 min old, well within 2h
- \`staleness_tip_at_exact_max_age_passes\` — boundary is inclusive (age == max_age allowed)
- \`staleness_old_tip_rejects\` — 3 h old, past the 2 h bound, "too stale"
- \`staleness_far_future_tip_rejects\` — 4 h ahead, past the 2 h grace, "in the future"
- \`staleness_near_future_tip_passes\` — 30 min ahead, within consensus grace
- \`staleness_uses_checkpoint_time_when_no_headers\` — empty chain falls back to checkpoint.time
- \`staleness_thresholds_are_what_we_documented\` — defensive: catches accidental constant changes

## After this PR

**SPV verification proper is functionally complete.** The full stack:

| PR | Scope |
|---|---|
| #25 | proto stub |
| #26 | chain + Merkle verifier |
| #27 | bounded reorg |
| #29 | handler wiring |
| #30 | CLI + smoke + polish |
| #31 | sign-path SPV verification |
| **this** | header staleness rule |

## Out of scope (different epic)

- Real checkpoint constants (one-line config flip once available)
- Default-features flip to \`["spv"]\` (tiny follow-up)
- PR 6+ dual-mode work: amount + OpId extraction via \`rgb-consignment-parser\`
- BIP-325 signet signature verification (deferred — production = mainnet)