### PR TITLE
feat(attestation): GetAttestedPublicKey RPC + attest-verify CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,10 @@ jobs:
       - name: Build (default features)
         run: cargo build --workspace
 
+      # `--all-targets` so clippy lints test code too — otherwise lints on
+      # files under `tests/` slip through, as happened on the attestation PR.
       - name: Clippy (default features)
-        run: cargo clippy --workspace -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Test (default features)
         run: cargo test --workspace
@@ -52,7 +54,7 @@ jobs:
         run: cargo build -p utexo-bridge-enclave --features vsock,rgb-validation,spv
 
       - name: Clippy (production combo)
-        run: cargo clippy -p utexo-bridge-enclave --features vsock,rgb-validation,spv -- -D warnings
+        run: cargo clippy -p utexo-bridge-enclave --features vsock,rgb-validation,spv --all-targets -- -D warnings
 
       # SPV path coverage. Cannot use vsock here (Linux runner without
       # vsock support); spv pulls in rgb-validation transitively, which is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "attestation-verify"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "ciborium",
+ "der",
+ "hex",
+ "p384",
+ "serde",
+ "thiserror 2.0.18",
+ "x509-cert",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,17 +2274,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2775,20 +2778,17 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 name = "utexo-bridge-enclave"
 version = "0.1.0"
 dependencies = [
+ "attestation-verify",
  "aws-nitro-enclaves-nsm-api",
- "base64",
  "bip39",
  "bitcoin",
  "chacha20poly1305",
- "ciborium",
- "der",
  "getrandom 0.4.2",
  "hex",
  "hkdf",
  "hmac",
  "k256",
  "nix 0.31.2",
- "p384",
  "prost 0.14.3",
  "prost-build 0.14.3",
  "rand 0.10.0",
@@ -2804,7 +2804,6 @@ dependencies = [
  "tracing-subscriber",
  "vsock",
  "x25519-dalek",
- "x509-cert",
  "zeroize",
 ]
 
@@ -2813,10 +2812,14 @@ name = "utexo-bridge-parent"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "attestation-verify",
+ "bitcoin",
  "clap",
  "hex",
  "prost 0.13.5",
  "prost-build 0.13.5",
+ "rand 0.8.5",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -2824,6 +2827,7 @@ dependencies = [
  "tonic-reflection",
  "tracing",
  "tracing-subscriber",
+ "utexo-bridge-enclave",
  "vsock",
 ]
 
@@ -3222,8 +3226,6 @@ checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
  "const-oid",
  "der",
- "sha1",
- "signature",
  "spki",
  "tls_codec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["enclave", "parent"]
+members = ["attestation-verify", "enclave", "parent"]
 resolver = "2"
 
 [profile.release]

--- a/attestation-verify/Cargo.toml
+++ b/attestation-verify/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "attestation-verify"
+version = "0.1.0"
+edition = "2021"
+description = "AWS Nitro Enclave attestation document verification (COSE_Sign1 + AWS Nitro cert chain)"
+
+[lib]
+name = "attestation_verify"
+path = "src/lib.rs"
+
+[dependencies]
+ciborium = "0.2"
+p384 = { version = "0.13", features = ["ecdsa", "pem"] }
+x509-cert = { version = "0.2", features = ["pem"] }
+der = { version = "0.7", features = ["alloc"] }
+base64 = "0.22"
+serde = { version = "1", features = ["derive"] }
+hex = "0.4"
+thiserror = "2"
+
+[features]
+default = []
+# Enables the mock document path: build raw-CBOR docs without COSE wrapping
+# and verify them without cert-chain checks. PCR/nonce/pubkey binding still
+# enforced. Tests-only.
+mock = []

--- a/attestation-verify/src/lib.rs
+++ b/attestation-verify/src/lib.rs
@@ -1,0 +1,629 @@
+//! AWS Nitro Enclave attestation document verification.
+//!
+//! Pure-Rust verifier extracted from the enclave crate so that:
+//!   - the enclave's cloning peer-verify path,
+//!   - the parent's external `attest-verify` CLI binary,
+//!
+//! all run the *same* verification code. Single source of truth for
+//! "is this attestation document trustworthy?"
+//!
+//! Real path: parses COSE_Sign1, verifies the AWS Nitro certificate chain
+//! down from the hardcoded root CA, checks PCR0/1/2 against expected, and
+//! enforces nonce presence (and equality if a specific value is expected).
+//!
+//! Mock path (`mock` feature): produces and verifies raw CBOR documents
+//! without COSE wrapping or certificate validation. PCR/nonce/pubkey
+//! binding is still enforced. Used by integration tests and dev builds
+//! that cannot reach a real NSM device.
+
+#![forbid(unsafe_code)]
+
+use std::collections::HashMap;
+
+use thiserror::Error;
+
+// ----------------------------------------------------------------------------
+// Public types
+// ----------------------------------------------------------------------------
+
+#[derive(Debug, Error)]
+pub enum VerifyError {
+    #[error("attestation error: {0}")]
+    Attestation(String),
+
+    #[error("certificate error: {0}")]
+    Certificate(String),
+
+    #[error("PCR mismatch: PCR{pcr} expected={expected}, actual={actual}")]
+    PcrMismatch {
+        pcr: u32,
+        expected: String,
+        actual: String,
+    },
+}
+
+pub type Result<T> = std::result::Result<T, VerifyError>;
+
+/// Expected PCR values for an enclave we trust.
+///
+/// Sourced out-of-band — typically pinned in a release artifact, on-chain
+/// config, or operator-supplied flag — and compared bytewise against the
+/// PCRs reported in an attestation document.
+#[derive(Clone, Debug)]
+pub struct ExpectedPcrs {
+    pub pcr0: [u8; 48],
+    pub pcr1: [u8; 48],
+    pub pcr2: [u8; 48],
+}
+
+impl ExpectedPcrs {
+    pub fn new(pcr0: [u8; 48], pcr1: [u8; 48], pcr2: [u8; 48]) -> Self {
+        Self { pcr0, pcr1, pcr2 }
+    }
+
+    pub fn zero() -> Self {
+        Self {
+            pcr0: [0u8; 48],
+            pcr1: [0u8; 48],
+            pcr2: [0u8; 48],
+        }
+    }
+
+    pub fn from_hex(pcr0: &str, pcr1: &str, pcr2: &str) -> Result<Self> {
+        let parse = |s: &str| -> Result<[u8; 48]> {
+            let bytes = hex::decode(s).map_err(|e| VerifyError::Attestation(e.to_string()))?;
+            bytes
+                .try_into()
+                .map_err(|_| VerifyError::Attestation("PCR must be 48 bytes".into()))
+        };
+        Ok(Self {
+            pcr0: parse(pcr0)?,
+            pcr1: parse(pcr1)?,
+            pcr2: parse(pcr2)?,
+        })
+    }
+}
+
+/// The verified contents of an attestation document, minus CBOR/COSE wrapping.
+#[derive(Debug, Clone)]
+pub struct VerifiedAttestation {
+    pub enclave_pubkey: Vec<u8>,
+    pub pcrs: HashMap<u32, Vec<u8>>,
+    pub timestamp: u64,
+    pub user_data: Option<Vec<u8>>,
+    pub nonce: Vec<u8>,
+}
+
+/// Wire-format representation of the NSM attestation payload.
+///
+/// In real mode this is the CBOR payload *inside* a COSE_Sign1 wrapper.
+/// In mock mode it is the entire document (no COSE wrapping).
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct AttestationDocument {
+    #[serde(rename = "module_id", default)]
+    pub module_id: String,
+    pub timestamp: u64,
+    #[serde(default)]
+    pub digest: String,
+    pub pcrs: HashMap<u32, Vec<u8>>,
+    #[serde(default)]
+    pub certificate: Vec<u8>,
+    #[serde(default)]
+    pub cabundle: Vec<Vec<u8>>,
+    #[serde(default)]
+    pub public_key: Option<Vec<u8>>,
+    #[serde(default)]
+    pub user_data: Option<Vec<u8>>,
+    #[serde(default)]
+    pub nonce: Option<Vec<u8>>,
+}
+
+// ----------------------------------------------------------------------------
+// Public API — real path (always available)
+// ----------------------------------------------------------------------------
+
+/// Verify a real (production) Nitro Enclave attestation document.
+///
+/// Checks (in order):
+///   1. Parse COSE_Sign1 envelope and inner CBOR AttestationDocument.
+///   2. Validate the X.509 certificate chain back to the hardcoded
+///      AWS Nitro root CA, checking each certificate's validity window.
+///   3. Verify the COSE_Sign1 signature using the leaf signing certificate.
+///   4. Compare PCR0/1/2 against `expected_pcrs`.
+///   5. Require a nonce. If `expected_nonce` is `Some`, require byte-equality
+///      with it; if `None`, the caller is expected to enforce freshness via
+///      its own replay guard.
+///   6. Require a `public_key` field.
+pub fn verify_attestation(
+    doc: &[u8],
+    expected_pcrs: &ExpectedPcrs,
+    expected_nonce: Option<&[u8; 32]>,
+) -> Result<VerifiedAttestation> {
+    real::verify_real_document(doc, expected_pcrs, expected_nonce)
+}
+
+// ----------------------------------------------------------------------------
+// Public API — mock path (feature-gated)
+// ----------------------------------------------------------------------------
+
+/// Verify a mock attestation document (raw CBOR, no COSE wrapping, no cert chain).
+///
+/// PCR / nonce / pubkey binding are still enforced. Test-only.
+#[cfg(feature = "mock")]
+pub fn verify_mock_attestation(
+    doc: &[u8],
+    expected_pcrs: &ExpectedPcrs,
+    expected_nonce: Option<&[u8; 32]>,
+) -> Result<VerifiedAttestation> {
+    mock::verify_mock_document(doc, expected_pcrs, expected_nonce)
+}
+
+/// Build a mock attestation document for tests.
+///
+/// PCRs are zeroed, no COSE wrapping, no certificate. Pairs with
+/// [`verify_mock_attestation`].
+#[cfg(feature = "mock")]
+pub fn build_mock_document(
+    nonce: &[u8; 32],
+    public_key: Option<&[u8]>,
+    user_data: Option<&[u8]>,
+) -> Result<Vec<u8>> {
+    mock::build_mock_document(nonce, public_key, user_data)
+}
+
+// ----------------------------------------------------------------------------
+// Shared helpers
+// ----------------------------------------------------------------------------
+
+fn verify_pcrs(pcrs: &HashMap<u32, Vec<u8>>, expected: &ExpectedPcrs) -> Result<()> {
+    let check = |idx: u32, expected_bytes: &[u8; 48]| -> Result<()> {
+        let actual = pcrs
+            .get(&idx)
+            .ok_or_else(|| VerifyError::Attestation(format!("Missing PCR{idx}")))?;
+        if actual.as_slice() != expected_bytes {
+            return Err(VerifyError::PcrMismatch {
+                pcr: idx,
+                expected: hex::encode(expected_bytes),
+                actual: hex::encode(actual),
+            });
+        }
+        Ok(())
+    };
+
+    check(0, &expected.pcr0)?;
+    check(1, &expected.pcr1)?;
+    check(2, &expected.pcr2)?;
+    Ok(())
+}
+
+fn check_nonce(doc_nonce: &Option<Vec<u8>>, expected: Option<&[u8; 32]>) -> Result<Vec<u8>> {
+    let nonce = doc_nonce
+        .as_ref()
+        .ok_or_else(|| VerifyError::Attestation("missing nonce in attestation".into()))?;
+    if let Some(exp) = expected {
+        if nonce.as_slice() != exp {
+            return Err(VerifyError::Attestation("nonce mismatch".into()));
+        }
+    }
+    Ok(nonce.clone())
+}
+
+// ----------------------------------------------------------------------------
+// Real path (COSE + cert chain)
+// ----------------------------------------------------------------------------
+
+mod real {
+    use super::*;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use base64::Engine;
+    use p384::ecdsa::{signature::Verifier, Signature, VerifyingKey};
+    use std::sync::OnceLock;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use x509_cert::der::{Decode, Encode};
+    use x509_cert::Certificate;
+
+    // AWS Nitro Enclave root CA. Source:
+    // https://docs.aws.amazon.com/enclaves/latest/user/verify-root.html
+    // Self-signed, P-384, ECDSA-SHA384, valid 2019-10-28 .. 2049-10-28.
+    const AWS_NITRO_ROOT_CERT_PEM: &str = r#"-----BEGIN CERTIFICATE-----
+MIICETCCAZagAwIBAgIRAPkxdWgbkK/hHUbMtOTn+FYwCgYIKoZIzj0EAwMwSTEL
+MAkGA1UEBhMCVVMxDzANBgNVBAoMBkFtYXpvbjEMMAoGA1UECwwDQVdTMRswGQYD
+VQQDDBJhd3Mubml0cm8tZW5jbGF2ZXMwHhcNMTkxMDI4MTMyODA1WhcNNDkxMDI4
+MTQyODA1WjBJMQswCQYDVQQGEwJVUzEPMA0GA1UECgwGQW1hem9uMQwwCgYDVQQL
+DANBV1MxGzAZBgNVBAMMEmF3cy5uaXRyby1lbmNsYXZlczB2MBAGByqGSM49AgEG
+BSuBBAAiA2IABPwCVOumCMHzaHDimtqQvkY4MpJzbolL//Zy2YlES1BR5TSksfbb
+48C8WBoyt7F2Bw7eEtaaP+ohG2bnUs990d0JX28TcPQXCEPZ3BABIeTPYwEoCWZE
+h8l5YoQwTcU/9KNCMEAwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUkCW1DdkF
+R+eWw5b6cp3PmanfS5YwDgYDVR0PAQH/BAQDAgGGMAoGCCqGSM49BAMDA2kAMGYC
+MQCjfy+Rocm9Xue4YnwWmNJVA44fA0P5W2OpYow9OYCVRaEevL8uO1XYru5xtMPW
+rfMCMQCi85sWBbJwKKXdS6BptQFuZbT73o/gBh1qUxl/nNr12UO8Yfwr6wPLb+6N
+IwLz3/Y=
+-----END CERTIFICATE-----"#;
+
+    /// DER bytes of the embedded root cert. Parsed once and compared to
+    /// `cabundle[0]` bytewise on every verify.
+    fn root_cert_der() -> &'static [u8] {
+        static ROOT: OnceLock<Vec<u8>> = OnceLock::new();
+        ROOT.get_or_init(|| {
+            let lines: Vec<&str> = AWS_NITRO_ROOT_CERT_PEM
+                .lines()
+                .filter(|l| !l.starts_with("-----"))
+                .collect();
+            BASE64
+                .decode(lines.join(""))
+                .expect("invalid base64 in embedded root cert")
+        })
+    }
+
+    pub(super) fn verify_real_document(
+        doc: &[u8],
+        expected_pcrs: &ExpectedPcrs,
+        expected_nonce: Option<&[u8; 32]>,
+    ) -> Result<VerifiedAttestation> {
+        let cose = CoseSign1::from_bytes(doc)?;
+        let payload = cose
+            .payload
+            .as_ref()
+            .ok_or_else(|| VerifyError::Attestation("missing COSE payload".into()))?;
+
+        let attestation: AttestationDocument = ciborium::from_reader(payload.as_slice())
+            .map_err(|e| VerifyError::Attestation(format!("failed to parse attestation: {e}")))?;
+
+        verify_certificate_chain(&attestation.certificate, &attestation.cabundle, &cose)?;
+
+        let nonce = check_nonce(&attestation.nonce, expected_nonce)?;
+        verify_pcrs(&attestation.pcrs, expected_pcrs)?;
+
+        let enclave_pubkey = attestation
+            .public_key
+            .ok_or_else(|| VerifyError::Attestation("missing public key".into()))?;
+
+        Ok(VerifiedAttestation {
+            enclave_pubkey,
+            pcrs: attestation.pcrs,
+            timestamp: attestation.timestamp,
+            user_data: attestation.user_data,
+            nonce,
+        })
+    }
+
+    /// Parse and verify the attestation certificate chain.
+    ///
+    /// AWS Nitro cabundle ordering:
+    ///   cabundle[0]      = AWS Nitro root CA (must match embedded root)
+    ///   cabundle[1..N-1] = intermediate CAs
+    ///   cabundle[N-1]    = direct issuer of `signing_cert`
+    ///   signing_cert     = end-entity cert that signed the COSE envelope
+    fn verify_certificate_chain(
+        signing_cert_der: &[u8],
+        cabundle: &[Vec<u8>],
+        cose: &CoseSign1,
+    ) -> Result<()> {
+        if cabundle.is_empty() {
+            return Err(VerifyError::Certificate("empty certificate bundle".into()));
+        }
+
+        if cabundle[0].as_slice() != root_cert_der() {
+            return Err(VerifyError::Certificate(
+                "cabundle[0] is not the AWS Nitro root CA".into(),
+            ));
+        }
+
+        let mut chain = Vec::with_capacity(cabundle.len() + 1);
+        for (i, cert_der) in cabundle.iter().enumerate() {
+            let cert = Certificate::from_der(cert_der).map_err(|e| {
+                VerifyError::Certificate(format!("failed to parse cabundle[{i}]: {e}"))
+            })?;
+            verify_cert_validity(&cert)?;
+            chain.push(cert);
+        }
+        let signing_cert = Certificate::from_der(signing_cert_der)
+            .map_err(|e| VerifyError::Certificate(format!("failed to parse signing cert: {e}")))?;
+        verify_cert_validity(&signing_cert)?;
+        chain.push(signing_cert);
+
+        // chain[0] is the root, anchored above by byte-equality. Walk forward.
+        for i in 0..chain.len() - 1 {
+            verify_issuer_signed_subject(&chain[i], &chain[i + 1])?;
+        }
+
+        let signing_pubkey = extract_p384_pubkey(chain.last().expect("non-empty"))?;
+        let cose_sig = parse_cose_ecdsa_signature(&cose.signature)?;
+        let to_verify = cose.sig_structure()?;
+        signing_pubkey
+            .verify(&to_verify, &cose_sig)
+            .map_err(|_| VerifyError::Attestation("COSE signature verification failed".into()))?;
+
+        Ok(())
+    }
+
+    fn verify_issuer_signed_subject(issuer: &Certificate, subject: &Certificate) -> Result<()> {
+        let issuer_pubkey = extract_p384_pubkey(issuer)?;
+        let tbs_bytes = subject
+            .tbs_certificate
+            .to_der()
+            .map_err(|e| VerifyError::Certificate(format!("TBS DER encode failed: {e}")))?;
+        let sig_bytes = subject
+            .signature
+            .as_bytes()
+            .ok_or_else(|| VerifyError::Certificate("missing signature bytes".into()))?;
+        // X.509 cert signatures are DER-encoded ECDSA (unlike COSE).
+        let signature = Signature::from_der(sig_bytes)
+            .map_err(|e| VerifyError::Certificate(format!("invalid cert signature: {e}")))?;
+        issuer_pubkey
+            .verify(&tbs_bytes, &signature)
+            .map_err(|_| VerifyError::Certificate("certificate signature invalid".into()))
+    }
+
+    /// RFC 8152 §8.1 mandates raw `r || s` (96 bytes for P-384). Accept DER
+    /// defensively in case a doc source deviates.
+    fn parse_cose_ecdsa_signature(sig_bytes: &[u8]) -> Result<Signature> {
+        if sig_bytes.len() == 96 {
+            Signature::try_from(sig_bytes)
+                .map_err(|e| VerifyError::Attestation(format!("invalid COSE raw signature: {e}")))
+        } else {
+            Signature::from_der(sig_bytes).map_err(|e| {
+                VerifyError::Attestation(format!(
+                    "invalid COSE signature ({} bytes, not raw P-384 r||s or DER): {e}",
+                    sig_bytes.len()
+                ))
+            })
+        }
+    }
+
+    fn extract_p384_pubkey(cert: &Certificate) -> Result<VerifyingKey> {
+        let spki = &cert.tbs_certificate.subject_public_key_info;
+        let key_bytes = spki
+            .subject_public_key
+            .as_bytes()
+            .ok_or_else(|| VerifyError::Certificate("missing public key bytes".into()))?;
+
+        VerifyingKey::from_sec1_bytes(key_bytes)
+            .map_err(|e| VerifyError::Certificate(format!("invalid P-384 key: {e}")))
+    }
+
+    fn verify_cert_validity(cert: &Certificate) -> Result<()> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| VerifyError::Certificate("system clock error".into()))?
+            .as_secs();
+
+        let validity = &cert.tbs_certificate.validity;
+        let not_before = validity.not_before.to_unix_duration().as_secs();
+        let not_after = validity.not_after.to_unix_duration().as_secs();
+
+        if now < not_before {
+            return Err(VerifyError::Certificate("certificate not yet valid".into()));
+        }
+        if now > not_after {
+            return Err(VerifyError::Certificate("certificate has expired".into()));
+        }
+        Ok(())
+    }
+
+    pub(super) struct CoseSign1 {
+        protected: Vec<u8>,
+        _unprotected: ciborium::Value,
+        pub payload: Option<Vec<u8>>,
+        pub signature: Vec<u8>,
+    }
+
+    impl CoseSign1 {
+        pub fn from_bytes(data: &[u8]) -> Result<Self> {
+            let value: ciborium::Value = ciborium::from_reader(data)
+                .map_err(|e| VerifyError::Attestation(format!("invalid CBOR: {e}")))?;
+
+            let arr = value
+                .as_array()
+                .ok_or_else(|| VerifyError::Attestation("COSE_Sign1 must be array".into()))?;
+            if arr.len() != 4 {
+                return Err(VerifyError::Attestation(
+                    "COSE_Sign1 must have 4 elements".into(),
+                ));
+            }
+
+            let protected = arr[0]
+                .as_bytes()
+                .ok_or_else(|| VerifyError::Attestation("invalid protected header".into()))?
+                .clone();
+            let unprotected = arr[1].clone();
+            let payload = if arr[2].is_null() {
+                None
+            } else {
+                Some(
+                    arr[2]
+                        .as_bytes()
+                        .ok_or_else(|| VerifyError::Attestation("invalid payload".into()))?
+                        .clone(),
+                )
+            };
+            let signature = arr[3]
+                .as_bytes()
+                .ok_or_else(|| VerifyError::Attestation("invalid signature".into()))?
+                .clone();
+
+            Ok(Self {
+                protected,
+                _unprotected: unprotected,
+                payload,
+                signature,
+            })
+        }
+
+        pub fn sig_structure(&self) -> Result<Vec<u8>> {
+            let structure = ciborium::Value::Array(vec![
+                ciborium::Value::Text("Signature1".into()),
+                ciborium::Value::Bytes(self.protected.clone()),
+                ciborium::Value::Bytes(vec![]),
+                ciborium::Value::Bytes(self.payload.clone().unwrap_or_default()),
+            ]);
+
+            let mut buf = Vec::new();
+            ciborium::into_writer(&structure, &mut buf).map_err(|e| {
+                VerifyError::Attestation(format!("failed to encode sig structure: {e}"))
+            })?;
+            Ok(buf)
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Mock path (raw CBOR, no COSE / cert chain)
+// ----------------------------------------------------------------------------
+
+#[cfg(feature = "mock")]
+mod mock {
+    use super::*;
+
+    pub(super) fn build_mock_document(
+        nonce: &[u8; 32],
+        public_key: Option<&[u8]>,
+        user_data: Option<&[u8]>,
+    ) -> Result<Vec<u8>> {
+        let mut pcrs = HashMap::new();
+        pcrs.insert(0, vec![0u8; 48]);
+        pcrs.insert(1, vec![0u8; 48]);
+        pcrs.insert(2, vec![0u8; 48]);
+
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        let doc = AttestationDocument {
+            module_id: "mock".into(),
+            timestamp,
+            digest: "SHA384".into(),
+            pcrs,
+            certificate: Vec::new(),
+            cabundle: Vec::new(),
+            public_key: public_key.map(|p| p.to_vec()),
+            user_data: user_data.map(|d| d.to_vec()),
+            nonce: Some(nonce.to_vec()),
+        };
+
+        let mut buf = Vec::new();
+        ciborium::into_writer(&doc, &mut buf)
+            .map_err(|e| VerifyError::Attestation(format!("failed to encode mock doc: {e}")))?;
+        Ok(buf)
+    }
+
+    pub(super) fn verify_mock_document(
+        doc: &[u8],
+        expected_pcrs: &ExpectedPcrs,
+        expected_nonce: Option<&[u8; 32]>,
+    ) -> Result<VerifiedAttestation> {
+        let attestation: AttestationDocument = ciborium::from_reader(doc)
+            .map_err(|e| VerifyError::Attestation(format!("failed to parse mock doc: {e}")))?;
+
+        let nonce = check_nonce(&attestation.nonce, expected_nonce)?;
+        verify_pcrs(&attestation.pcrs, expected_pcrs)?;
+
+        let enclave_pubkey = attestation
+            .public_key
+            .ok_or_else(|| VerifyError::Attestation("missing public key".into()))?;
+
+        Ok(VerifiedAttestation {
+            enclave_pubkey,
+            pcrs: attestation.pcrs,
+            timestamp: attestation.timestamp,
+            user_data: attestation.user_data,
+            nonce,
+        })
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expected_pcrs_from_hex_roundtrip() {
+        let pcr0 = "00".repeat(48);
+        let pcr1 = "11".repeat(48);
+        let pcr2 = "22".repeat(48);
+        let pcrs = ExpectedPcrs::from_hex(&pcr0, &pcr1, &pcr2).unwrap();
+        assert_eq!(pcrs.pcr0[0], 0x00);
+        assert_eq!(pcrs.pcr1[0], 0x11);
+        assert_eq!(pcrs.pcr2[47], 0x22);
+    }
+
+    #[test]
+    fn expected_pcrs_from_hex_bad_length() {
+        assert!(ExpectedPcrs::from_hex("ab", "cd", "ef").is_err());
+    }
+
+    #[test]
+    fn expected_pcrs_from_hex_invalid_chars() {
+        let bad = "zz".repeat(48);
+        assert!(ExpectedPcrs::from_hex(&bad, &bad, &bad).is_err());
+    }
+
+    #[cfg(feature = "mock")]
+    mod mock_flow {
+        use super::*;
+
+        #[test]
+        fn mock_roundtrip_happy_path() {
+            let nonce = [7u8; 32];
+            let pubkey = [1u8; 32];
+            let doc = build_mock_document(&nonce, Some(&pubkey), Some(b"user")).unwrap();
+
+            let verified =
+                verify_mock_attestation(&doc, &ExpectedPcrs::zero(), Some(&nonce)).unwrap();
+
+            assert_eq!(verified.enclave_pubkey, pubkey.to_vec());
+            assert_eq!(verified.user_data.as_deref(), Some(b"user".as_ref()));
+            assert_eq!(verified.nonce, nonce.to_vec());
+            assert_eq!(verified.pcrs.get(&0).unwrap().len(), 48);
+        }
+
+        #[test]
+        fn mock_extracts_nonce_when_expected_is_none() {
+            let nonce = [0x5au8; 32];
+            let doc = build_mock_document(&nonce, Some(&[0u8; 32]), None).unwrap();
+            let verified = verify_mock_attestation(&doc, &ExpectedPcrs::zero(), None).unwrap();
+            assert_eq!(verified.nonce, nonce.to_vec());
+        }
+
+        #[test]
+        fn mock_reject_nonce_mismatch() {
+            let nonce = [1u8; 32];
+            let other = [2u8; 32];
+            let doc = build_mock_document(&nonce, Some(&[0u8; 32]), None).unwrap();
+            let err =
+                verify_mock_attestation(&doc, &ExpectedPcrs::zero(), Some(&other)).unwrap_err();
+            assert!(matches!(err, VerifyError::Attestation(_)));
+        }
+
+        #[test]
+        fn mock_reject_pcr_mismatch() {
+            let nonce = [3u8; 32];
+            let doc = build_mock_document(&nonce, Some(&[0u8; 32]), None).unwrap();
+            let expected = ExpectedPcrs::new([1u8; 48], [0u8; 48], [0u8; 48]);
+            let err = verify_mock_attestation(&doc, &expected, Some(&nonce)).unwrap_err();
+            assert!(matches!(err, VerifyError::PcrMismatch { pcr: 0, .. }));
+        }
+
+        #[test]
+        fn mock_reject_missing_pubkey() {
+            let nonce = [4u8; 32];
+            let doc = build_mock_document(&nonce, None, None).unwrap();
+            let err =
+                verify_mock_attestation(&doc, &ExpectedPcrs::zero(), Some(&nonce)).unwrap_err();
+            assert!(matches!(err, VerifyError::Attestation(_)));
+        }
+
+        #[test]
+        fn mock_reject_corrupted_doc() {
+            let err =
+                verify_mock_attestation(&[0xffu8; 16], &ExpectedPcrs::zero(), Some(&[0u8; 32]))
+                    .unwrap_err();
+            assert!(matches!(err, VerifyError::Attestation(_)));
+        }
+    }
+}

--- a/docs/pubkey-attestation.md
+++ b/docs/pubkey-attestation.md
@@ -1,0 +1,194 @@
+# Attested Public Key — Verifying the Bridge Signing Pubkey Belongs to the TEE
+
+External parties (bridge contract operator, auditors, downstream services) can
+prove that the EVM address signing bridge transactions was produced by code
+running inside an AWS Nitro Enclave with a specific measurement (PCR0/1/2),
+without trusting the parent host process.
+
+## Trust statement
+
+After successful verification, the verifier knows:
+
+> "AWS Nitro hardware (which I trust like a TLS root CA) certifies that, at
+> time T (within nonce-freshness), an enclave running code with PCR0=X,
+> PCR1=Y, PCR2=Z produced public key K, and the full key bundle B
+> commits to user_data."
+
+The chain of trust is:
+
+```
+AWS Nitro Root CA  (public, hardcoded)
+       │ signs
+AWS region intermediate(s)
+       │ signs
+This EC2 instance's NSM signing cert
+       │ signs (P-384 ECDSA, COSE_Sign1)
+Attestation document { pcrs, public_key, user_data, nonce, timestamp, ... }
+```
+
+## Protocol
+
+```
+verifier                                 parent gRPC                      enclave (Nitro)
+   │                                          │                                 │
+   │ 1. nonce ← rand(32)                      │                                 │
+   │ 2. AttestedPublicKey(nonce) ────────────▶│                                 │
+   │                                          │ 3. GetAttestedPublicKey(nonce) ▶│
+   │                                          │                                 │ 4. NSM produces COSE_Sign1 doc
+   │                                          │                                 │    binding {nonce,
+   │                                          │                                 │            public_key=evm_uncompressed_pub,
+   │                                          │                                 │            user_data=sha256(bundle)}
+   │                                          │                                 │    to PCR0/1/2
+   │                                          │ ◀── (public_keys, doc) ─────────│
+   │ ◀── AttestedPublicKeyResponse ───────────│                                 │
+   │                                                                            │
+   │ 5. Verify chain → AWS root, COSE sig, validity, PCRs, nonce equal,
+   │    public_key == evm_uncompressed_pub, user_data == sha256(bundle).        │
+```
+
+## Bindings
+
+The NSM attestation document carries two caller-controlled fields. The enclave
+populates them as:
+
+| NSM field    | Bound value                                                                    |
+|--------------|--------------------------------------------------------------------------------|
+| `public_key` | `evm_uncompressed_pub` — the bridge's primary signing key (64 bytes, X\|\|Y) |
+| `user_data`  | `sha256(canonical_bundle)` — 32-byte commitment over the full key bundle      |
+| `nonce`      | the 32-byte nonce supplied by the verifier                                    |
+
+A lightweight verifier can stop at `public_key` (e.g. an EVM contract that
+only cares about the signing address). A thorough verifier rebuilds the
+canonical bundle and checks `user_data` to confirm the BTC keys, xpubs, and
+fingerprint were not swapped by the parent host process.
+
+### Canonical bundle encoding
+
+Length-prefixed (u32 big-endian) concatenation of every field of
+`PublicKeysResponse`, in proto field order. Strings encoded as UTF-8 bytes.
+
+```
+canonical_bundle =
+    u32_be(len(evm_address))           || evm_address
+    u32_be(len(btc_compressed_pub))    || btc_compressed_pub
+    u32_be(len(btc_xpub))              || btc_xpub_utf8
+    u32_be(len(master_fingerprint))    || master_fingerprint
+    u32_be(len(account_xpub_vanilla))  || account_xpub_vanilla_utf8
+    u32_be(len(account_xpub_colored))  || account_xpub_colored_utf8
+    u32_be(len(evm_uncompressed_pub))  || evm_uncompressed_pub
+```
+
+The verifier MUST use the same field set, the same order, and the same
+length-prefix encoding. The reference encoder is `canonical_pubkey_bundle`
+in [`enclave/src/server.rs`](../enclave/src/server.rs) and the reference
+decoder/checker is `canonical_bundle` in
+[`parent/src/bin/attest_verify.rs`](../parent/src/bin/attest_verify.rs).
+
+## Where the expected PCRs come from
+
+PCRs are not self-attested: the verifier needs to know them out of band.
+PCR0 = enclave image hash, PCR1 = kernel + boot, PCR2 = app. Changing one
+byte of the enclave binary changes PCR0 deterministically.
+
+Sourcing options, in increasing order of rigor:
+
+1. **Release artifact / Git tag.** Print PCRs from `nitro-cli build-enclave`
+   into the release notes. Operators paste into `--pcr0/1/2`.
+2. **Config file** loaded by the verifier. Same trust as #1, fewer typos.
+3. **On-chain registry.** Bridge contract stores accepted PCRs;
+   governance/multisig updates them. Verifiers pull from chain. Most
+   rigorous, hardest to upgrade.
+
+This repo currently relies on (1).
+
+## Verification recipe (manual)
+
+Given `(public_keys_bundle, attestation_doc, nonce_sent, expected_pcrs)`:
+
+1. Parse `attestation_doc` as `COSE_Sign1` (CBOR array of length 4).
+2. Parse the inner CBOR payload as `AttestationDocument`.
+3. Verify the certificate chain in `cabundle`:
+    - `cabundle[0]` must equal the AWS Nitro root CA bytewise (DER).
+    - For each `i`, `cabundle[i]` must sign `cabundle[i+1]` (DER ECDSA).
+    - `cabundle[last]` must sign `signing_cert` (the cert in the doc).
+    - Every cert must be inside its validity window.
+4. Verify the COSE signature: P-384 ECDSA over
+   `Sig_structure1 = ["Signature1", protected, h"", payload]`. Per RFC 8152
+   §8.1 the COSE signature is raw `r||s` (96 bytes for P-384), not DER.
+5. PCR check: `doc.pcrs[0/1/2]` must each equal `expected_pcrs.{pcr0,pcr1,pcr2}`
+   bytewise.
+6. Nonce check: `doc.nonce == nonce_sent`.
+7. Pubkey check: `doc.public_key == public_keys_bundle.evm_uncompressed_pub`.
+8. Commitment check: `doc.user_data == sha256(canonical_bundle(public_keys_bundle))`.
+
+If all eight checks pass, the bridge's EVM address (`keccak256(evm_uncompressed_pub)[12..]`)
+is bound to the running TEE measurement.
+
+## Verification recipe (with `attest-verify`)
+
+The `attest-verify` CLI in this repo runs the full recipe.
+
+```bash
+# Production verification (against a real Nitro enclave)
+attest-verify \
+    --endpoint http://parent.example:50051 \
+    --pcr0 <96-hex-chars> \
+    --pcr1 <96-hex-chars> \
+    --pcr2 <96-hex-chars>
+
+# Dev / CI verification (against an enclave built with --features mock-attestation)
+attest-verify --endpoint http://127.0.0.1:50051 --mock
+```
+
+Exit codes:
+
+| Code | Meaning                                                         |
+|------|-----------------------------------------------------------------|
+| 0    | All eight checks passed                                         |
+| 1    | Verification failed (stderr explains why)                       |
+| 2    | Usage / IO / connection error                                   |
+
+## Threat model
+
+Trusted: AWS Nitro root CA private key (off-machine), the running enclave
+image (PCR-pinned), the verifier's own machine.
+
+NOT trusted: the parent host process, the network between parent and
+verifier, any TLS-terminating proxy, any operator with shell on the EC2
+instance. None of them can forge an attestation document because none
+holds the AWS Nitro per-instance signing key.
+
+Defended:
+- **Replay** — the verifier-supplied nonce is signed into the doc and checked
+  for equality on response. An old doc is rejected.
+- **Pubkey swap by parent** — `public_key` is inside the signed payload.
+- **BTC key / xpub swap** — `user_data` commits to the full bundle. A parent
+  cannot change one field of `PublicKeysResponse` without breaking the
+  commitment match.
+- **Fork to a different enclave image** — PCR mismatch on verify.
+- **Stale code (vulnerable image)** — operator publishes accepted PCRs;
+  outdated images won't match.
+
+NOT defended (out of scope for attestation):
+- AWS hardware key compromise (same trust assumption as TLS roots).
+- Bugs in the enclave code _after_ measurement (PCRs only attest the
+  binary; runtime correctness is a separate problem solved by code review,
+  fuzzing, audits).
+
+## Code references
+
+- Enclave-side handler: [`enclave/src/server.rs`](../enclave/src/server.rs)
+  (`handle_get_attested_public_key`).
+- Parent gRPC handler: [`parent/src/grpc_server.rs`](../parent/src/grpc_server.rs)
+  (`attested_public_key`).
+- Verifier crate: [`attestation-verify/src/lib.rs`](../attestation-verify/src/lib.rs).
+- CLI binary: [`parent/src/bin/attest_verify.rs`](../parent/src/bin/attest_verify.rs).
+- Wire definitions:
+  - Enclave wire: [`proto/enclave.proto`](../proto/enclave.proto)
+    (`GetAttestedPublicKeyRequest`/`Response`).
+  - Parent gRPC: [`proto/parentadapter.proto`](../proto/parentadapter.proto)
+    (`AttestedPublicKey` RPC).
+- Tests:
+  - Enclave handler: [`enclave/tests/test_attested_pubkey.rs`](../enclave/tests/test_attested_pubkey.rs).
+  - End-to-end gRPC: [`parent/tests/test_grpc_bridge.rs`](../parent/tests/test_grpc_bridge.rs)
+    (`grpc_attested_public_key_*`).

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -47,12 +47,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # RGB consignment validation (optional, behind rgb-validation feature)
 rgb-ops = { version = "0.11.1-rc.7", features = ["esplora_blocking"], optional = true }
 
-# Attestation verification (NSM COSE_Sign1 + AWS Nitro cert chain)
-ciborium = "0.2"
-p384 = { version = "0.13", features = ["ecdsa", "pem"] }
-x509-cert = { version = "0.2", features = ["pem", "builder"] }
-der = { version = "0.7", features = ["alloc"] }
-base64 = "0.22"
+# Attestation verification (COSE_Sign1 + AWS Nitro cert chain) lives in
+# the workspace `attestation-verify` crate so the parent CLI binary and
+# the enclave share a single verifier.
+attestation-verify = { path = "../attestation-verify" }
 serde = { version = "1", features = ["derive"] }
 
 # Cloning handshake crypto (X25519 DH + HKDF + ChaCha20Poly1305 + HMAC-SHA256)
@@ -89,7 +87,7 @@ rgb-validation = ["rgb-ops"]
 spv = ["rgb-validation"]
 # Mock attestation path: skip NSM / COSE / cert-chain checks and use raw CBOR docs.
 # Testing only — never enable in production builds.
-mock-attestation = []
+mock-attestation = ["attestation-verify/mock"]
 
 [dev-dependencies]
 rand = "0.10.0"

--- a/enclave/src/attestation.rs
+++ b/enclave/src/attestation.rs
@@ -181,11 +181,13 @@ mod nsm {
 // Tests — facade-level only. The verifier itself is tested in attestation-verify.
 // ----------------------------------------------------------------------------
 
-#[cfg(test)]
+// Both tests below need the mock-attestation path; gate the whole module
+// so the `use super::*` doesn't fire `unused_imports` when building without
+// `--features mock-attestation` (CI runs both feature combinations).
+#[cfg(all(test, feature = "mock-attestation"))]
 mod tests {
     use super::*;
 
-    #[cfg(feature = "mock-attestation")]
     #[test]
     fn facade_mock_roundtrip() {
         let nonce = [7u8; 32];
@@ -199,7 +201,6 @@ mod tests {
         assert_eq!(verified.nonce, nonce.to_vec());
     }
 
-    #[cfg(feature = "mock-attestation")]
     #[test]
     fn facade_get_own_pcrs_returns_zero_in_mock() {
         let pcrs = get_own_pcrs().unwrap();

--- a/enclave/src/attestation.rs
+++ b/enclave/src/attestation.rs
@@ -1,111 +1,47 @@
-//! AWS Nitro Enclave attestation.
+//! AWS Nitro Enclave attestation — enclave-side facade.
 //!
-//! Two paths:
-//!   1. Real (default on Linux): requests attestation documents from the
-//!      NSM device (`/dev/nsm`) via `aws-nitro-enclaves-nsm-api`, and
-//!      verifies peer attestations by parsing COSE_Sign1, validating the
-//!      AWS Nitro certificate chain, and comparing PCRs + nonce.
-//!   2. Mock (`mock-attestation` feature or non-Linux): the document is
-//!      a raw CBOR-encoded `AttestationDocument` with no COSE wrapping
-//!      and no certificate chain. Verification skips the crypto checks
-//!      but still enforces PCRs, nonce, and pubkey binding. This lets
-//!      cloning integration tests run on any dev machine.
+//! Production: requests attestation documents from the NSM device
+//! (`/dev/nsm`) via `aws-nitro-enclaves-nsm-api` and reads the enclave's
+//! own PCRs at startup.
 //!
-//! Module is currently not wired into server.rs. PR 4 will plug it in.
+//! Verification (peer attestation, both real and mock): delegated to the
+//! workspace `attestation-verify` crate so the same code path is exercised
+//! by the cloning flow, by tests, and by the external `attest-verify` CLI.
+//!
+//! Mock mode (`mock-attestation` feature): documents are raw CBOR with
+//! all-zero PCRs and no COSE wrapping. Testing only.
 
 #![allow(dead_code)]
 
-use std::collections::HashMap;
-
 use crate::error::{EnclaveError, Result};
 
-/// Expected PCR values for a peer enclave. Constructed once from
-/// a self-attestation at startup (`get_own_pcrs`) and reused for
-/// every peer check.
-#[derive(Clone, Debug)]
-pub struct ExpectedPcrs {
-    pub pcr0: [u8; 48],
-    pub pcr1: [u8; 48],
-    pub pcr2: [u8; 48],
-}
+pub use attestation_verify::{ExpectedPcrs, VerifiedAttestation};
 
-impl ExpectedPcrs {
-    pub fn new(pcr0: [u8; 48], pcr1: [u8; 48], pcr2: [u8; 48]) -> Self {
-        Self { pcr0, pcr1, pcr2 }
-    }
-
-    pub fn zero() -> Self {
-        Self {
-            pcr0: [0u8; 48],
-            pcr1: [0u8; 48],
-            pcr2: [0u8; 48],
+impl From<attestation_verify::VerifyError> for EnclaveError {
+    fn from(e: attestation_verify::VerifyError) -> Self {
+        match e {
+            attestation_verify::VerifyError::Attestation(s) => EnclaveError::Attestation(s),
+            attestation_verify::VerifyError::Certificate(s) => EnclaveError::Certificate(s),
+            attestation_verify::VerifyError::PcrMismatch {
+                pcr,
+                expected,
+                actual,
+            } => EnclaveError::PcrMismatch {
+                pcr,
+                expected,
+                actual,
+            },
         }
     }
-
-    pub fn from_hex(pcr0: &str, pcr1: &str, pcr2: &str) -> Result<Self> {
-        let parse = |s: &str| -> Result<[u8; 48]> {
-            let bytes = hex::decode(s).map_err(|e| EnclaveError::Attestation(e.to_string()))?;
-            bytes
-                .try_into()
-                .map_err(|_| EnclaveError::Attestation("PCR must be 48 bytes".into()))
-        };
-        Ok(Self {
-            pcr0: parse(pcr0)?,
-            pcr1: parse(pcr1)?,
-            pcr2: parse(pcr2)?,
-        })
-    }
 }
-
-/// The verified contents of a peer attestation, minus the CBOR/COSE wrapping.
-#[derive(Debug, Clone)]
-pub struct VerifiedAttestation {
-    pub enclave_pubkey: Vec<u8>,
-    pub pcrs: HashMap<u32, Vec<u8>>,
-    pub timestamp: u64,
-    pub user_data: Option<Vec<u8>>,
-    pub nonce: Vec<u8>,
-}
-
-/// Wire-format representation of the NSM attestation payload.
-///
-/// In real mode this is the CBOR payload *inside* a COSE_Sign1 wrapper.
-/// In mock mode it is the outer document (no COSE wrapping).
-///
-/// Byte fields are encoded as CBOR arrays-of-uint in the mock roundtrip,
-/// which ciborium handles transparently. Real NSM documents use proper
-/// CBOR byte strings — ciborium's deserializer accepts both.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-pub(crate) struct AttestationDocument {
-    #[serde(rename = "module_id", default)]
-    pub module_id: String,
-    pub timestamp: u64,
-    #[serde(default)]
-    pub digest: String,
-    pub pcrs: HashMap<u32, Vec<u8>>,
-    #[serde(default)]
-    pub certificate: Vec<u8>,
-    #[serde(default)]
-    pub cabundle: Vec<Vec<u8>>,
-    #[serde(default)]
-    pub public_key: Option<Vec<u8>>,
-    #[serde(default)]
-    pub user_data: Option<Vec<u8>>,
-    #[serde(default)]
-    pub nonce: Option<Vec<u8>>,
-}
-
-// ----------------------------------------------------------------------------
-// Public API
-// ----------------------------------------------------------------------------
 
 /// Produce an attestation document binding `nonce`, `public_key`, and optional
-/// `user_data`. The returned bytes are what we hand to peers over the wire.
+/// `user_data`. The returned bytes are what we hand to peers (or external
+/// verifiers) over the wire.
 ///
 /// Real path (Linux + no mock): calls the NSM device.
-/// Mock path (`mock-attestation` feature): returns a raw CBOR `AttestationDocument`
-/// with all-zero PCRs and the supplied fields. Non-Linux builds without
-/// `mock-attestation` will fail to compile at the call site.
+/// Mock path (`mock-attestation` feature): returns a raw CBOR document with
+/// all-zero PCRs. Non-Linux builds without `mock-attestation` will fail.
 pub fn get_attestation(
     nonce: &[u8; 32],
     public_key: Option<&[u8]>,
@@ -113,12 +49,12 @@ pub fn get_attestation(
 ) -> Result<Vec<u8>> {
     #[cfg(feature = "mock-attestation")]
     {
-        mock::build_mock_document(nonce, public_key, user_data)
+        attestation_verify::build_mock_document(nonce, public_key, user_data).map_err(Into::into)
     }
 
     #[cfg(all(target_os = "linux", not(feature = "mock-attestation")))]
     {
-        real::request_nsm_attestation(nonce, public_key, user_data)
+        nsm::request_nsm_attestation(nonce, public_key, user_data)
     }
 
     #[cfg(all(not(target_os = "linux"), not(feature = "mock-attestation")))]
@@ -140,7 +76,7 @@ pub fn get_own_pcrs() -> Result<ExpectedPcrs> {
 
     #[cfg(all(target_os = "linux", not(feature = "mock-attestation")))]
     {
-        real::read_own_pcrs()
+        nsm::read_own_pcrs()
     }
 
     #[cfg(all(not(target_os = "linux"), not(feature = "mock-attestation")))]
@@ -151,20 +87,8 @@ pub fn get_own_pcrs() -> Result<ExpectedPcrs> {
     }
 }
 
-/// Verify a peer attestation document and return the extracted fields.
-///
-/// Checks (in order):
-///   1. Parse COSE_Sign1 / AttestationDocument (CBOR).
-///   2. Verify the COSE signature using the embedded leaf certificate.
-///   3. Verify the certificate chain terminates at the AWS Nitro root CA.
-///   4. Check certificate validity windows (not_before / not_after).
-///   5. Compare PCR0/1/2 against `expected_pcrs`.
-///   6. Require a nonce field to be present. If `expected_nonce` is `Some`,
-///      require byte-equality with it. If `None`, caller is expected to
-///      enforce freshness via its own replay guard (see `state::ReplayGuard`).
-///
-/// In `mock-attestation` mode, steps 1–4 are replaced with a raw CBOR parse
-/// and the cert chain is not validated. PCR/nonce/pubkey binding still hold.
+/// Verify a peer attestation document. See [`attestation_verify::verify_attestation`]
+/// for the real path; under `mock-attestation` the mock verifier is used.
 pub fn verify_peer_attestation(
     doc: &[u8],
     expected_pcrs: &ExpectedPcrs,
@@ -172,337 +96,32 @@ pub fn verify_peer_attestation(
 ) -> Result<VerifiedAttestation> {
     #[cfg(feature = "mock-attestation")]
     {
-        mock::verify_mock_document(doc, expected_pcrs, expected_nonce)
+        attestation_verify::verify_mock_attestation(doc, expected_pcrs, expected_nonce)
+            .map_err(Into::into)
     }
 
     #[cfg(not(feature = "mock-attestation"))]
     {
-        real::verify_real_document(doc, expected_pcrs, expected_nonce)
+        attestation_verify::verify_attestation(doc, expected_pcrs, expected_nonce)
+            .map_err(Into::into)
     }
 }
 
 // ----------------------------------------------------------------------------
-// Shared helpers
+// NSM device interaction (Linux only, production path)
 // ----------------------------------------------------------------------------
 
-fn verify_pcrs(pcrs: &HashMap<u32, Vec<u8>>, expected: &ExpectedPcrs) -> Result<()> {
-    let check = |idx: u32, expected_bytes: &[u8; 48]| -> Result<()> {
-        let actual = pcrs
-            .get(&idx)
-            .ok_or_else(|| EnclaveError::Attestation(format!("Missing PCR{idx}")))?;
-        if actual.as_slice() != expected_bytes {
-            return Err(EnclaveError::PcrMismatch {
-                pcr: idx,
-                expected: hex::encode(expected_bytes),
-                actual: hex::encode(actual),
-            });
-        }
-        Ok(())
-    };
-
-    check(0, &expected.pcr0)?;
-    check(1, &expected.pcr1)?;
-    check(2, &expected.pcr2)?;
-    Ok(())
-}
-
-fn check_nonce(doc_nonce: &Option<Vec<u8>>, expected: Option<&[u8; 32]>) -> Result<Vec<u8>> {
-    let nonce = doc_nonce
-        .as_ref()
-        .ok_or_else(|| EnclaveError::Attestation("missing nonce in attestation".into()))?;
-    if let Some(exp) = expected {
-        if nonce.as_slice() != exp {
-            return Err(EnclaveError::Attestation("nonce mismatch".into()));
-        }
-    }
-    Ok(nonce.clone())
-}
-
-// ----------------------------------------------------------------------------
-// Real path (COSE + cert chain)
-// ----------------------------------------------------------------------------
-
-#[cfg(not(feature = "mock-attestation"))]
-mod real {
+#[cfg(all(target_os = "linux", not(feature = "mock-attestation")))]
+mod nsm {
     use super::*;
-    use base64::engine::general_purpose::STANDARD as BASE64;
-    use base64::Engine;
-    use p384::ecdsa::{signature::Verifier, Signature, VerifyingKey};
-    use std::sync::OnceLock;
-    use std::time::{SystemTime, UNIX_EPOCH};
-    use x509_cert::der::{Decode, Encode};
-    use x509_cert::Certificate;
+    use aws_nitro_enclaves_nsm_api::api::{Request, Response};
+    use aws_nitro_enclaves_nsm_api::driver::{nsm_exit, nsm_init, nsm_process_request};
 
-    // AWS Nitro Enclave root CA. Source:
-    // https://docs.aws.amazon.com/enclaves/latest/user/verify-root.html
-    // Self-signed, P-384, ECDSA-SHA384, valid 2019-10-28 .. 2049-10-28.
-    const AWS_NITRO_ROOT_CERT_PEM: &str = r#"-----BEGIN CERTIFICATE-----
-MIICETCCAZagAwIBAgIRAPkxdWgbkK/hHUbMtOTn+FYwCgYIKoZIzj0EAwMwSTEL
-MAkGA1UEBhMCVVMxDzANBgNVBAoMBkFtYXpvbjEMMAoGA1UECwwDQVdTMRswGQYD
-VQQDDBJhd3Mubml0cm8tZW5jbGF2ZXMwHhcNMTkxMDI4MTMyODA1WhcNNDkxMDI4
-MTQyODA1WjBJMQswCQYDVQQGEwJVUzEPMA0GA1UECgwGQW1hem9uMQwwCgYDVQQL
-DANBV1MxGzAZBgNVBAMMEmF3cy5uaXRyby1lbmNsYXZlczB2MBAGByqGSM49AgEG
-BSuBBAAiA2IABPwCVOumCMHzaHDimtqQvkY4MpJzbolL//Zy2YlES1BR5TSksfbb
-48C8WBoyt7F2Bw7eEtaaP+ohG2bnUs990d0JX28TcPQXCEPZ3BABIeTPYwEoCWZE
-h8l5YoQwTcU/9KNCMEAwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUkCW1DdkF
-R+eWw5b6cp3PmanfS5YwDgYDVR0PAQH/BAQDAgGGMAoGCCqGSM49BAMDA2kAMGYC
-MQCjfy+Rocm9Xue4YnwWmNJVA44fA0P5W2OpYow9OYCVRaEevL8uO1XYru5xtMPW
-rfMCMQCi85sWBbJwKKXdS6BptQFuZbT73o/gBh1qUxl/nNr12UO8Yfwr6wPLb+6N
-IwLz3/Y=
------END CERTIFICATE-----"#;
-
-    /// DER bytes of the embedded root cert. Parsed once and compared to
-    /// `cabundle[0]` bytewise on every verify.
-    fn root_cert_der() -> &'static [u8] {
-        static ROOT: OnceLock<Vec<u8>> = OnceLock::new();
-        ROOT.get_or_init(|| {
-            let lines: Vec<&str> = AWS_NITRO_ROOT_CERT_PEM
-                .lines()
-                .filter(|l| !l.starts_with("-----"))
-                .collect();
-            BASE64
-                .decode(lines.join(""))
-                .expect("invalid base64 in embedded root cert")
-        })
-    }
-
-    pub(super) fn verify_real_document(
-        doc: &[u8],
-        expected_pcrs: &ExpectedPcrs,
-        expected_nonce: Option<&[u8; 32]>,
-    ) -> Result<VerifiedAttestation> {
-        let cose = CoseSign1::from_bytes(doc)?;
-        let payload = cose
-            .payload
-            .as_ref()
-            .ok_or_else(|| EnclaveError::Attestation("missing COSE payload".into()))?;
-
-        let attestation: AttestationDocument = ciborium::from_reader(payload.as_slice())
-            .map_err(|e| EnclaveError::Attestation(format!("failed to parse attestation: {e}")))?;
-
-        verify_certificate_chain(&attestation.certificate, &attestation.cabundle, &cose)?;
-
-        let nonce = check_nonce(&attestation.nonce, expected_nonce)?;
-        verify_pcrs(&attestation.pcrs, expected_pcrs)?;
-
-        let enclave_pubkey = attestation
-            .public_key
-            .ok_or_else(|| EnclaveError::Attestation("missing public key".into()))?;
-
-        Ok(VerifiedAttestation {
-            enclave_pubkey,
-            pcrs: attestation.pcrs,
-            timestamp: attestation.timestamp,
-            user_data: attestation.user_data,
-            nonce,
-        })
-    }
-
-    /// Parse and verify the attestation certificate chain.
-    ///
-    /// AWS Nitro cabundle ordering (per the Nitro Enclaves User Guide):
-    ///   cabundle[0]      = AWS Nitro root CA (must match our hardcoded root)
-    ///   cabundle[1..N-1] = intermediate CAs
-    ///   cabundle[N-1]    = direct issuer of `signing_cert`
-    ///   signing_cert     = end-entity cert that signed the COSE envelope
-    ///
-    /// We verify, in order:
-    ///   1. cabundle is non-empty and cabundle[0] bytes == embedded AWS root.
-    ///   2. Each cabundle[i] signs cabundle[i+1].
-    ///   3. cabundle[last] signs signing_cert.
-    ///   4. Every cert is inside its validity window.
-    ///   5. signing_cert's P-384 pubkey verifies the COSE signature over
-    ///      Sig_structure1. Per RFC 8152 §8.1, the COSE signature is a
-    ///      fixed-width raw `r || s` (96 bytes for P-384), *not* DER.
-    fn verify_certificate_chain(
-        signing_cert_der: &[u8],
-        cabundle: &[Vec<u8>],
-        cose: &CoseSign1,
-    ) -> Result<()> {
-        if cabundle.is_empty() {
-            return Err(EnclaveError::Certificate("empty certificate bundle".into()));
-        }
-
-        // 1. Root anchor: bytewise compare to our hardcoded AWS Nitro root.
-        if cabundle[0].as_slice() != root_cert_der() {
-            return Err(EnclaveError::Certificate(
-                "cabundle[0] is not the AWS Nitro root CA".into(),
-            ));
-        }
-
-        // Parse every cabundle cert + signing cert, checking validity windows.
-        let mut chain = Vec::with_capacity(cabundle.len() + 1);
-        for (i, cert_der) in cabundle.iter().enumerate() {
-            let cert = Certificate::from_der(cert_der).map_err(|e| {
-                EnclaveError::Certificate(format!("failed to parse cabundle[{i}]: {e}"))
-            })?;
-            verify_cert_validity(&cert)?;
-            chain.push(cert);
-        }
-        let signing_cert = Certificate::from_der(signing_cert_der)
-            .map_err(|e| EnclaveError::Certificate(format!("failed to parse signing cert: {e}")))?;
-        verify_cert_validity(&signing_cert)?;
-        chain.push(signing_cert);
-
-        // 2-3. Walk: chain[i] issues chain[i+1]. The root is self-signed
-        // and has already been anchored by byte-equality with our hardcoded
-        // copy, so we don't re-verify chain[0].
-        for i in 0..chain.len() - 1 {
-            verify_issuer_signed_subject(&chain[i], &chain[i + 1])?;
-        }
-
-        // 5. COSE signature verification using signing cert's pubkey.
-        let signing_pubkey = extract_p384_pubkey(chain.last().expect("non-empty"))?;
-        let cose_sig = parse_cose_ecdsa_signature(&cose.signature)?;
-        let to_verify = cose.sig_structure()?;
-        signing_pubkey
-            .verify(&to_verify, &cose_sig)
-            .map_err(|_| EnclaveError::Attestation("COSE signature verification failed".into()))?;
-
-        Ok(())
-    }
-
-    fn verify_issuer_signed_subject(issuer: &Certificate, subject: &Certificate) -> Result<()> {
-        let issuer_pubkey = extract_p384_pubkey(issuer)?;
-        let tbs_bytes = subject
-            .tbs_certificate
-            .to_der()
-            .map_err(|e| EnclaveError::Certificate(format!("TBS DER encode failed: {e}")))?;
-        let sig_bytes = subject
-            .signature
-            .as_bytes()
-            .ok_or_else(|| EnclaveError::Certificate("missing signature bytes".into()))?;
-        // X.509 cert signatures are DER-encoded ECDSA (unlike COSE).
-        let signature = Signature::from_der(sig_bytes)
-            .map_err(|e| EnclaveError::Certificate(format!("invalid cert signature: {e}")))?;
-        issuer_pubkey
-            .verify(&tbs_bytes, &signature)
-            .map_err(|_| EnclaveError::Certificate("certificate signature invalid".into()))
-    }
-
-    /// RFC 8152 §8.1 mandates raw `r || s` (96 bytes for P-384). We accept
-    /// a DER fallback defensively in case a document source deviates.
-    fn parse_cose_ecdsa_signature(sig_bytes: &[u8]) -> Result<Signature> {
-        if sig_bytes.len() == 96 {
-            Signature::try_from(sig_bytes)
-                .map_err(|e| EnclaveError::Attestation(format!("invalid COSE raw signature: {e}")))
-        } else {
-            Signature::from_der(sig_bytes).map_err(|e| {
-                EnclaveError::Attestation(format!(
-                    "invalid COSE signature ({} bytes, not raw P-384 r||s or DER): {e}",
-                    sig_bytes.len()
-                ))
-            })
-        }
-    }
-
-    fn extract_p384_pubkey(cert: &Certificate) -> Result<VerifyingKey> {
-        let spki = &cert.tbs_certificate.subject_public_key_info;
-        let key_bytes = spki
-            .subject_public_key
-            .as_bytes()
-            .ok_or_else(|| EnclaveError::Certificate("missing public key bytes".into()))?;
-
-        VerifyingKey::from_sec1_bytes(key_bytes)
-            .map_err(|e| EnclaveError::Certificate(format!("invalid P-384 key: {e}")))
-    }
-
-    fn verify_cert_validity(cert: &Certificate) -> Result<()> {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|_| EnclaveError::Certificate("system clock error".into()))?
-            .as_secs();
-
-        let validity = &cert.tbs_certificate.validity;
-        let not_before = validity.not_before.to_unix_duration().as_secs();
-        let not_after = validity.not_after.to_unix_duration().as_secs();
-
-        if now < not_before {
-            return Err(EnclaveError::Certificate(
-                "certificate not yet valid".into(),
-            ));
-        }
-        if now > not_after {
-            return Err(EnclaveError::Certificate("certificate has expired".into()));
-        }
-        Ok(())
-    }
-
-    pub(super) struct CoseSign1 {
-        protected: Vec<u8>,
-        _unprotected: ciborium::Value,
-        pub payload: Option<Vec<u8>>,
-        pub signature: Vec<u8>,
-    }
-
-    impl CoseSign1 {
-        pub fn from_bytes(data: &[u8]) -> Result<Self> {
-            let value: ciborium::Value = ciborium::from_reader(data)
-                .map_err(|e| EnclaveError::Attestation(format!("invalid CBOR: {e}")))?;
-
-            let arr = value
-                .as_array()
-                .ok_or_else(|| EnclaveError::Attestation("COSE_Sign1 must be array".into()))?;
-            if arr.len() != 4 {
-                return Err(EnclaveError::Attestation(
-                    "COSE_Sign1 must have 4 elements".into(),
-                ));
-            }
-
-            let protected = arr[0]
-                .as_bytes()
-                .ok_or_else(|| EnclaveError::Attestation("invalid protected header".into()))?
-                .clone();
-            let unprotected = arr[1].clone();
-            let payload = if arr[2].is_null() {
-                None
-            } else {
-                Some(
-                    arr[2]
-                        .as_bytes()
-                        .ok_or_else(|| EnclaveError::Attestation("invalid payload".into()))?
-                        .clone(),
-                )
-            };
-            let signature = arr[3]
-                .as_bytes()
-                .ok_or_else(|| EnclaveError::Attestation("invalid signature".into()))?
-                .clone();
-
-            Ok(Self {
-                protected,
-                _unprotected: unprotected,
-                payload,
-                signature,
-            })
-        }
-
-        pub fn sig_structure(&self) -> Result<Vec<u8>> {
-            let structure = ciborium::Value::Array(vec![
-                ciborium::Value::Text("Signature1".into()),
-                ciborium::Value::Bytes(self.protected.clone()),
-                ciborium::Value::Bytes(vec![]),
-                ciborium::Value::Bytes(self.payload.clone().unwrap_or_default()),
-            ]);
-
-            let mut buf = Vec::new();
-            ciborium::into_writer(&structure, &mut buf).map_err(|e| {
-                EnclaveError::Attestation(format!("failed to encode sig structure: {e}"))
-            })?;
-            Ok(buf)
-        }
-    }
-
-    // NSM self-attestation (Linux only).
-    #[cfg(target_os = "linux")]
     pub(super) fn request_nsm_attestation(
         nonce: &[u8; 32],
         public_key: Option<&[u8]>,
         user_data: Option<&[u8]>,
     ) -> Result<Vec<u8>> {
-        use aws_nitro_enclaves_nsm_api::api::{Request, Response};
-        use aws_nitro_enclaves_nsm_api::driver::{nsm_exit, nsm_init, nsm_process_request};
-
         let fd = nsm_init();
         if fd < 0 {
             return Err(EnclaveError::Attestation("failed to initialize NSM".into()));
@@ -527,11 +146,7 @@ IwLz3/Y=
         }
     }
 
-    #[cfg(target_os = "linux")]
     pub(super) fn read_own_pcrs() -> Result<ExpectedPcrs> {
-        use aws_nitro_enclaves_nsm_api::api::{Request, Response};
-        use aws_nitro_enclaves_nsm_api::driver::{nsm_exit, nsm_init, nsm_process_request};
-
         let fd = nsm_init();
         if fd < 0 {
             return Err(EnclaveError::Attestation("failed to initialize NSM".into()));
@@ -560,191 +175,34 @@ IwLz3/Y=
         nsm_exit(fd);
         Ok(ExpectedPcrs::new(pcr0, pcr1, pcr2))
     }
-
-    #[cfg(not(target_os = "linux"))]
-    pub(super) fn request_nsm_attestation(
-        _nonce: &[u8; 32],
-        _public_key: Option<&[u8]>,
-        _user_data: Option<&[u8]>,
-    ) -> Result<Vec<u8>> {
-        Err(EnclaveError::Attestation(
-            "NSM not available on this platform".into(),
-        ))
-    }
-
-    #[cfg(not(target_os = "linux"))]
-    pub(super) fn read_own_pcrs() -> Result<ExpectedPcrs> {
-        Err(EnclaveError::Attestation(
-            "NSM not available on this platform".into(),
-        ))
-    }
 }
 
 // ----------------------------------------------------------------------------
-// Mock path (raw CBOR, no COSE / cert chain)
-// ----------------------------------------------------------------------------
-
-#[cfg(feature = "mock-attestation")]
-mod mock {
-    use super::*;
-
-    pub(super) fn build_mock_document(
-        nonce: &[u8; 32],
-        public_key: Option<&[u8]>,
-        user_data: Option<&[u8]>,
-    ) -> Result<Vec<u8>> {
-        let mut pcrs = HashMap::new();
-        pcrs.insert(0, vec![0u8; 48]);
-        pcrs.insert(1, vec![0u8; 48]);
-        pcrs.insert(2, vec![0u8; 48]);
-
-        let timestamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
-
-        let doc = AttestationDocument {
-            module_id: "mock".into(),
-            timestamp,
-            digest: "SHA384".into(),
-            pcrs,
-            certificate: Vec::new(),
-            cabundle: Vec::new(),
-            public_key: public_key.map(|p| p.to_vec()),
-            user_data: user_data.map(|d| d.to_vec()),
-            nonce: Some(nonce.to_vec()),
-        };
-
-        let mut buf = Vec::new();
-        ciborium::into_writer(&doc, &mut buf)
-            .map_err(|e| EnclaveError::Attestation(format!("failed to encode mock doc: {e}")))?;
-        Ok(buf)
-    }
-
-    pub(super) fn verify_mock_document(
-        doc: &[u8],
-        expected_pcrs: &ExpectedPcrs,
-        expected_nonce: Option<&[u8; 32]>,
-    ) -> Result<VerifiedAttestation> {
-        let attestation: AttestationDocument = ciborium::from_reader(doc)
-            .map_err(|e| EnclaveError::Attestation(format!("failed to parse mock doc: {e}")))?;
-
-        let nonce = check_nonce(&attestation.nonce, expected_nonce)?;
-        verify_pcrs(&attestation.pcrs, expected_pcrs)?;
-
-        let enclave_pubkey = attestation
-            .public_key
-            .ok_or_else(|| EnclaveError::Attestation("missing public key".into()))?;
-
-        Ok(VerifiedAttestation {
-            enclave_pubkey,
-            pcrs: attestation.pcrs,
-            timestamp: attestation.timestamp,
-            user_data: attestation.user_data,
-            nonce,
-        })
-    }
-}
-
-// ----------------------------------------------------------------------------
-// Tests
+// Tests — facade-level only. The verifier itself is tested in attestation-verify.
 // ----------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    #[cfg(feature = "mock-attestation")]
     #[test]
-    fn expected_pcrs_from_hex_roundtrip() {
-        let pcr0 = "00".repeat(48);
-        let pcr1 = "11".repeat(48);
-        let pcr2 = "22".repeat(48);
-        let pcrs = ExpectedPcrs::from_hex(&pcr0, &pcr1, &pcr2).unwrap();
-        assert_eq!(pcrs.pcr0[0], 0x00);
-        assert_eq!(pcrs.pcr1[0], 0x11);
-        assert_eq!(pcrs.pcr2[47], 0x22);
-    }
+    fn facade_mock_roundtrip() {
+        let nonce = [7u8; 32];
+        let pubkey = [1u8; 32];
+        let doc = get_attestation(&nonce, Some(&pubkey), Some(b"user")).unwrap();
 
-    #[test]
-    fn expected_pcrs_from_hex_bad_length() {
-        assert!(ExpectedPcrs::from_hex("ab", "cd", "ef").is_err());
-    }
+        let verified = verify_peer_attestation(&doc, &ExpectedPcrs::zero(), Some(&nonce)).unwrap();
 
-    #[test]
-    fn expected_pcrs_from_hex_invalid_chars() {
-        let bad = "zz".repeat(48);
-        assert!(ExpectedPcrs::from_hex(&bad, &bad, &bad).is_err());
+        assert_eq!(verified.enclave_pubkey, pubkey.to_vec());
+        assert_eq!(verified.user_data.as_deref(), Some(b"user".as_ref()));
+        assert_eq!(verified.nonce, nonce.to_vec());
     }
 
     #[cfg(feature = "mock-attestation")]
-    mod mock_flow {
-        use super::*;
-
-        #[test]
-        fn mock_roundtrip_happy_path() {
-            let nonce = [7u8; 32];
-            let pubkey = [1u8; 32];
-            let doc = get_attestation(&nonce, Some(&pubkey), Some(b"user")).unwrap();
-
-            let verified =
-                verify_peer_attestation(&doc, &ExpectedPcrs::zero(), Some(&nonce)).unwrap();
-
-            assert_eq!(verified.enclave_pubkey, pubkey.to_vec());
-            assert_eq!(verified.user_data.as_deref(), Some(b"user".as_ref()));
-            assert_eq!(verified.nonce, nonce.to_vec());
-            assert_eq!(verified.pcrs.get(&0).unwrap().len(), 48);
-        }
-
-        #[test]
-        fn mock_extracts_nonce_when_expected_is_none() {
-            let nonce = [0x5au8; 32];
-            let doc = get_attestation(&nonce, Some(&[0u8; 32]), None).unwrap();
-            let verified = verify_peer_attestation(&doc, &ExpectedPcrs::zero(), None).unwrap();
-            assert_eq!(verified.nonce, nonce.to_vec());
-        }
-
-        #[test]
-        fn mock_reject_nonce_mismatch() {
-            let nonce = [1u8; 32];
-            let other = [2u8; 32];
-            let doc = get_attestation(&nonce, Some(&[0u8; 32]), None).unwrap();
-            let err =
-                verify_peer_attestation(&doc, &ExpectedPcrs::zero(), Some(&other)).unwrap_err();
-            assert!(matches!(err, EnclaveError::Attestation(_)));
-        }
-
-        #[test]
-        fn mock_reject_pcr_mismatch() {
-            let nonce = [3u8; 32];
-            let doc = get_attestation(&nonce, Some(&[0u8; 32]), None).unwrap();
-            let expected = ExpectedPcrs::new([1u8; 48], [0u8; 48], [0u8; 48]);
-            let err = verify_peer_attestation(&doc, &expected, Some(&nonce)).unwrap_err();
-            assert!(matches!(err, EnclaveError::PcrMismatch { pcr: 0, .. }));
-        }
-
-        #[test]
-        fn mock_reject_missing_pubkey() {
-            let nonce = [4u8; 32];
-            let doc = get_attestation(&nonce, None, None).unwrap();
-            let err =
-                verify_peer_attestation(&doc, &ExpectedPcrs::zero(), Some(&nonce)).unwrap_err();
-            assert!(matches!(err, EnclaveError::Attestation(_)));
-        }
-
-        #[test]
-        fn mock_reject_corrupted_doc() {
-            let err =
-                verify_peer_attestation(&[0xffu8; 16], &ExpectedPcrs::zero(), Some(&[0u8; 32]))
-                    .unwrap_err();
-            assert!(matches!(err, EnclaveError::Attestation(_)));
-        }
-
-        #[test]
-        fn get_own_pcrs_mock_returns_zero() {
-            let pcrs = get_own_pcrs().unwrap();
-            assert_eq!(pcrs.pcr0, [0u8; 48]);
-            assert_eq!(pcrs.pcr1, [0u8; 48]);
-            assert_eq!(pcrs.pcr2, [0u8; 48]);
-        }
+    #[test]
+    fn facade_get_own_pcrs_returns_zero_in_mock() {
+        let pcrs = get_own_pcrs().unwrap();
+        assert_eq!(pcrs.pcr0, [0u8; 48]);
     }
 }

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -24,6 +24,23 @@ pub struct ServerContext {
     pub header_chain: std::sync::Mutex<crate::spv::HeaderChain>,
 }
 
+impl ServerContext {
+    /// Construct a `ServerContext` from the always-present fields, hiding
+    /// feature-gated fields like `rgb_validator` so external callers
+    /// (e.g. the parent's E2E tests) don't need to mirror our cfg flags.
+    pub fn new(
+        state: EnclaveState,
+        header_chain: std::sync::Mutex<crate::spv::HeaderChain>,
+    ) -> Self {
+        Self {
+            state,
+            #[cfg(feature = "rgb-validation")]
+            rgb_validator: None,
+            header_chain,
+        }
+    }
+}
+
 /// Handle a single connection: read one request, dispatch, write one response, close.
 pub fn handle_connection(stream: impl Read + Write, ctx: &ServerContext) {
     if let Err(e) = process_connection(stream, ctx) {
@@ -98,6 +115,10 @@ fn dispatch(request: EnclaveRequest, ctx: &ServerContext) -> EnclaveResponse {
         Some(Request::GetLastSavedBlock(req)) => {
             tracing::info!("request: GetLastSavedBlock");
             handle_get_last_saved_block(ctx, req)
+        }
+        Some(Request::GetAttestedPublicKey(req)) => {
+            tracing::info!("request: GetAttestedPublicKey");
+            handle_get_attested_public_key(&ctx.state, req)
         }
         None => {
             tracing::warn!("received empty request (no oneof variant set)");
@@ -206,6 +227,78 @@ fn handle_get_public_key(
             account_xpub_colored: keys.account_xpub_colored,
             evm_uncompressed_pub: keys.evm_uncompressed_pub.to_vec(),
         })),
+    })
+}
+
+/// Build the canonical bundle that the verifier hashes to check `user_data`.
+///
+/// Length-prefixed (u32 BE) concatenation of every byte field in
+/// PublicKeysResponse, in the same field order as the proto. Strings are
+/// encoded as their UTF-8 bytes. Order and field set MUST match the
+/// verifier — see `docs/pubkey-attestation.md`.
+fn canonical_pubkey_bundle(keys: &PublicKeysResponse) -> Vec<u8> {
+    let parts: [&[u8]; 7] = [
+        &keys.evm_address,
+        &keys.btc_compressed_pub,
+        keys.btc_xpub.as_bytes(),
+        &keys.master_fingerprint,
+        keys.account_xpub_vanilla.as_bytes(),
+        keys.account_xpub_colored.as_bytes(),
+        &keys.evm_uncompressed_pub,
+    ];
+    let total: usize = parts.iter().map(|p| 4 + p.len()).sum();
+    let mut out = Vec::with_capacity(total);
+    for p in parts {
+        out.extend_from_slice(&(p.len() as u32).to_be_bytes());
+        out.extend_from_slice(p);
+    }
+    out
+}
+
+fn handle_get_attested_public_key(
+    state: &EnclaveState,
+    req: GetAttestedPublicKeyRequest,
+) -> Result<EnclaveResponse> {
+    use sha2::{Digest, Sha256};
+
+    let nonce: [u8; 32] = req.nonce.as_slice().try_into().map_err(|_| {
+        EnclaveError::InvalidRequest(format!("nonce must be 32 bytes, got {}", req.nonce.len()))
+    })?;
+
+    let keys = state.get_keys()?;
+    let public_keys = PublicKeysResponse {
+        evm_address: keys.evm_address.to_vec(),
+        btc_compressed_pub: keys.btc_compressed_pubkey.to_vec(),
+        btc_xpub: keys.btc_xpub,
+        master_fingerprint: keys.master_fingerprint.to_vec(),
+        account_xpub_vanilla: keys.account_xpub_vanilla,
+        account_xpub_colored: keys.account_xpub_colored,
+        evm_uncompressed_pub: keys.evm_uncompressed_pub.to_vec(),
+    };
+
+    let bundle = canonical_pubkey_bundle(&public_keys);
+    let commitment: [u8; 32] = Sha256::digest(&bundle).into();
+
+    let attestation_doc = crate::attestation::get_attestation(
+        &nonce,
+        Some(&public_keys.evm_uncompressed_pub),
+        Some(&commitment),
+    )?;
+
+    tracing::info!(
+        evm_address = %hex::encode(&public_keys.evm_address),
+        commitment = %hex::encode(commitment),
+        attestation_bytes = attestation_doc.len(),
+        "returning attested public keys"
+    );
+
+    Ok(EnclaveResponse {
+        response: Some(Response::GetAttestedPublicKey(
+            GetAttestedPublicKeyResponse {
+                public_keys: Some(public_keys),
+                attestation_doc,
+            },
+        )),
     })
 }
 

--- a/enclave/tests/test_attested_pubkey.rs
+++ b/enclave/tests/test_attested_pubkey.rs
@@ -1,0 +1,177 @@
+//! Integration tests for `GetAttestedPublicKey`.
+//!
+//! Runs with `--features mock-attestation,allow-seed-import`. Mock mode
+//! skips COSE / cert-chain validation but still enforces nonce, PCRs, and
+//! the embedded `public_key` / `user_data` bindings — which is exactly
+//! what we want to exercise here, since those are the bits the new RPC
+//! produces.
+
+#![cfg(all(feature = "mock-attestation", feature = "allow-seed-import"))]
+
+mod common;
+
+use common::{send_request, start_test_server};
+use sha2::{Digest, Sha256};
+use utexo_bridge_enclave::proto::enclave_request::Request as Req;
+use utexo_bridge_enclave::proto::enclave_response::Response as Resp;
+use utexo_bridge_enclave::proto::*;
+
+const TEST_MNEMONIC: &str =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+fn initialize(port: u16) {
+    let resp = send_request(
+        port,
+        &EnclaveRequest {
+            request: Some(Req::InitializeKey(InitializeKeyRequest {
+                seed: vec![],
+                mnemonic: TEST_MNEMONIC.into(),
+            })),
+        },
+    );
+    assert!(matches!(resp.response, Some(Resp::InitializeKey(_))));
+}
+
+fn canonical_bundle(keys: &PublicKeysResponse) -> Vec<u8> {
+    let parts: [&[u8]; 7] = [
+        &keys.evm_address,
+        &keys.btc_compressed_pub,
+        keys.btc_xpub.as_bytes(),
+        &keys.master_fingerprint,
+        keys.account_xpub_vanilla.as_bytes(),
+        keys.account_xpub_colored.as_bytes(),
+        &keys.evm_uncompressed_pub,
+    ];
+    let mut out = Vec::new();
+    for p in parts {
+        out.extend_from_slice(&(p.len() as u32).to_be_bytes());
+        out.extend_from_slice(p);
+    }
+    out
+}
+
+fn request_attested(port: u16, nonce: &[u8]) -> GetAttestedPublicKeyResponse {
+    let resp = send_request(
+        port,
+        &EnclaveRequest {
+            request: Some(Req::GetAttestedPublicKey(GetAttestedPublicKeyRequest {
+                nonce: nonce.to_vec(),
+            })),
+        },
+    );
+    match resp.response {
+        Some(Resp::GetAttestedPublicKey(r)) => r,
+        other => panic!("expected GetAttestedPublicKey, got {:?}", other),
+    }
+}
+
+#[test]
+fn attested_pubkey_happy_path_binds_evm_pubkey_and_commitment() {
+    let port = start_test_server();
+    initialize(port);
+
+    let nonce = [0xa5u8; 32];
+    let resp = request_attested(port, &nonce);
+
+    let public_keys = resp.public_keys.expect("public_keys present");
+
+    // Verifier path: parse the attestation doc, confirm the bindings.
+    let verified = attestation_verify::verify_mock_attestation(
+        &resp.attestation_doc,
+        &attestation_verify::ExpectedPcrs::zero(),
+        Some(&nonce),
+    )
+    .expect("attestation verifies");
+
+    // The NSM `public_key` field MUST be the bridge's EVM uncompressed pubkey.
+    assert_eq!(verified.enclave_pubkey, public_keys.evm_uncompressed_pub);
+
+    // The NSM `user_data` field MUST be sha256 of the canonical bundle.
+    let expected_commitment: [u8; 32] = Sha256::digest(canonical_bundle(&public_keys)).into();
+    assert_eq!(
+        verified.user_data.as_deref(),
+        Some(expected_commitment.as_slice()),
+        "user_data must be sha256(canonical_bundle)"
+    );
+
+    // Nonce echoed.
+    assert_eq!(verified.nonce, nonce.to_vec());
+}
+
+#[test]
+fn attested_pubkey_rejects_wrong_nonce_size() {
+    let port = start_test_server();
+    initialize(port);
+
+    let resp = send_request(
+        port,
+        &EnclaveRequest {
+            request: Some(Req::GetAttestedPublicKey(GetAttestedPublicKeyRequest {
+                nonce: vec![0u8; 16], // wrong length
+            })),
+        },
+    );
+
+    match resp.response {
+        Some(Resp::Error(e)) => {
+            assert!(
+                e.message.contains("32 bytes"),
+                "expected nonce-size error, got {:?}",
+                e
+            );
+        }
+        other => panic!("expected Error, got {:?}", other),
+    }
+}
+
+#[test]
+fn attested_pubkey_rejects_before_init() {
+    let port = start_test_server();
+
+    let resp = send_request(
+        port,
+        &EnclaveRequest {
+            request: Some(Req::GetAttestedPublicKey(GetAttestedPublicKeyRequest {
+                nonce: vec![0u8; 32],
+            })),
+        },
+    );
+
+    assert!(matches!(resp.response, Some(Resp::Error(_))));
+}
+
+#[test]
+fn attested_pubkey_different_nonces_yield_different_docs() {
+    let port = start_test_server();
+    initialize(port);
+
+    let resp_a = request_attested(port, &[1u8; 32]);
+    let resp_b = request_attested(port, &[2u8; 32]);
+
+    assert_ne!(resp_a.attestation_doc, resp_b.attestation_doc);
+
+    // But the public-key bundle is identical (same enclave, same keys).
+    assert_eq!(resp_a.public_keys, resp_b.public_keys);
+}
+
+#[test]
+fn attested_pubkey_wrong_expected_nonce_fails_verify() {
+    let port = start_test_server();
+    initialize(port);
+
+    let nonce = [0x11u8; 32];
+    let other_nonce = [0x22u8; 32];
+    let resp = request_attested(port, &nonce);
+
+    let err = attestation_verify::verify_mock_attestation(
+        &resp.attestation_doc,
+        &attestation_verify::ExpectedPcrs::zero(),
+        Some(&other_nonce),
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        attestation_verify::VerifyError::Attestation(_)
+    ));
+}

--- a/enclave/tests/test_clone.rs
+++ b/enclave/tests/test_clone.rs
@@ -42,6 +42,7 @@ fn initialize_key_from_mnemonic(port: u16, mnemonic: &str) -> PublicKeysResponse
             master_fingerprint: r.master_fingerprint,
             account_xpub_vanilla: r.account_xpub_vanilla,
             account_xpub_colored: r.account_xpub_colored,
+            evm_uncompressed_pub: r.evm_uncompressed_pub,
         },
         other => panic!("expected InitializeKey response, got {:?}", other),
     }

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -71,7 +71,7 @@ fn build_test_multisig_psbt(our_pubkey: &bitcoin::PublicKey) -> Vec<u8> {
     let sk3 = SecretKey::from_slice(&[0x03; 32]).unwrap();
     let pk3 = bitcoin::PublicKey::new(sk3.public_key(&secp));
 
-    let mut pubkeys = vec![*our_pubkey, pk2, pk3];
+    let mut pubkeys = [*our_pubkey, pk2, pk3];
     pubkeys.sort_by_key(|k| k.to_bytes());
 
     let witness_script = ScriptBuilder::new()

--- a/parent/Cargo.toml
+++ b/parent/Cargo.toml
@@ -11,6 +11,10 @@ path = "src/main.rs"
 name = "utexo-bridge-parent-cli"
 path = "src/bin/cli.rs"
 
+[[bin]]
+name = "attest-verify"
+path = "src/bin/attest_verify.rs"
+
 [dependencies]
 prost = "0.13"
 tonic = "0.12"
@@ -27,6 +31,13 @@ hex = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+# attest-verify CLI dependencies. `mock` feature is enabled so the CLI can
+# verify documents from an enclave built with `mock-attestation` for dev/CI;
+# production verification (no --mock flag) goes through the real path.
+attestation-verify = { path = "../attestation-verify", features = ["mock"] }
+sha2 = "0.10"
+rand = "0.8"
+
 [target.'cfg(target_os = "linux")'.dependencies]
 vsock = "0.5"
 
@@ -37,3 +48,9 @@ tonic-build = "0.12"
 [features]
 default = []
 vsock = []
+
+[dev-dependencies]
+# Real enclave (with mock-attestation + seed-import) for end-to-end tests
+# that drive the full CLI verifier against a live enclave + gRPC stack.
+utexo-bridge-enclave = { path = "../enclave", features = ["mock-attestation", "allow-seed-import"] }
+bitcoin = "0.32"

--- a/parent/src/attest_verify.rs
+++ b/parent/src/attest_verify.rs
@@ -1,0 +1,129 @@
+//! Library half of the `attest-verify` CLI.
+//!
+//! Calls the parent's `AttestedPublicKey` gRPC, verifies the returned
+//! attestation document end-to-end, and returns the verified bundle. The
+//! binary in `bin/attest_verify.rs` is a thin wrapper that parses CLI
+//! flags, calls [`verify_attested_pubkey`], and formats output.
+//!
+//! Exposed here so integration tests can drive the same code paths used
+//! by the binary against an in-process parent + enclave stack.
+
+use anyhow::{bail, Context, Result};
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+
+use crate::grpc_proto::enclave_service_client::EnclaveServiceClient;
+use crate::grpc_proto::{AttestedPublicKeyRequest, AttestedPublicKeyResponse};
+
+/// Whether to verify the document via the COSE/cert-chain real path or
+/// the raw-CBOR mock path. Real production use MUST always pass `Real`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VerifyMode {
+    Real,
+    Mock,
+}
+
+/// Successful verification result. The presence of this value is the
+/// proof that the bridge's signing pubkey was produced inside a TEE
+/// matching the supplied PCRs.
+#[derive(Debug, Clone)]
+pub struct AttestedPubkeyResult {
+    pub response: AttestedPublicKeyResponse,
+    pub verified: attestation_verify::VerifiedAttestation,
+    pub bundle_commitment: [u8; 32],
+    pub nonce_sent: [u8; 32],
+}
+
+/// Build the canonical key bundle that the verifier hashes to check
+/// `user_data`. Field order and encoding MUST match the enclave's
+/// `canonical_pubkey_bundle` in `enclave/src/server.rs`.
+pub fn canonical_bundle(resp: &AttestedPublicKeyResponse) -> Vec<u8> {
+    let parts: [&[u8]; 7] = [
+        &resp.evm_address,
+        &resp.btc_compressed_pub,
+        resp.btc_xpub.as_bytes(),
+        &resp.master_fingerprint,
+        resp.account_xpub_vanilla.as_bytes(),
+        resp.account_xpub_colored.as_bytes(),
+        &resp.evm_uncompressed_pub,
+    ];
+    let mut out = Vec::new();
+    for p in parts {
+        out.extend_from_slice(&(p.len() as u32).to_be_bytes());
+        out.extend_from_slice(p);
+    }
+    out
+}
+
+/// Run the full attestation flow: connect to `endpoint`, send a fresh
+/// nonce, verify the returned doc against `expected_pcrs`, and re-check
+/// the embedded pubkey + commitment against the wire bundle.
+///
+/// Returns `Ok(_)` only if every check passes. Errors describe the
+/// specific failure (gRPC connect, RPC error, parse error, signature
+/// failure, PCR mismatch, nonce mismatch, pubkey mismatch, commitment
+/// mismatch).
+pub async fn verify_attested_pubkey(
+    endpoint: &str,
+    expected_pcrs: attestation_verify::ExpectedPcrs,
+    mode: VerifyMode,
+) -> Result<AttestedPubkeyResult> {
+    let mut nonce = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut nonce);
+
+    let mut client = EnclaveServiceClient::connect(endpoint.to_string())
+        .await
+        .with_context(|| format!("connecting to {endpoint}"))?;
+
+    let response = client
+        .attested_public_key(AttestedPublicKeyRequest {
+            nonce: nonce.to_vec(),
+        })
+        .await
+        .context("AttestedPublicKey RPC failed")?
+        .into_inner();
+
+    let verified = match mode {
+        VerifyMode::Real => attestation_verify::verify_attestation(
+            &response.attestation_doc,
+            &expected_pcrs,
+            Some(&nonce),
+        )
+        .context("attestation verify failed")?,
+        VerifyMode::Mock => attestation_verify::verify_mock_attestation(
+            &response.attestation_doc,
+            &expected_pcrs,
+            Some(&nonce),
+        )
+        .context("mock attestation verify failed")?,
+    };
+
+    if verified.enclave_pubkey != response.evm_uncompressed_pub {
+        bail!(
+            "attestation `public_key` ({} bytes) does not match wire evm_uncompressed_pub ({} bytes)",
+            verified.enclave_pubkey.len(),
+            response.evm_uncompressed_pub.len()
+        );
+    }
+
+    let bundle = canonical_bundle(&response);
+    let bundle_commitment: [u8; 32] = Sha256::digest(&bundle).into();
+    let user_data = verified
+        .user_data
+        .as_deref()
+        .context("attestation has no user_data field")?;
+    if user_data != bundle_commitment {
+        bail!(
+            "attestation `user_data` ({}) does not match sha256(canonical_bundle) ({})",
+            hex::encode(user_data),
+            hex::encode(bundle_commitment),
+        );
+    }
+
+    Ok(AttestedPubkeyResult {
+        response,
+        verified,
+        bundle_commitment,
+        nonce_sent: nonce,
+    })
+}

--- a/parent/src/bin/attest_verify.rs
+++ b/parent/src/bin/attest_verify.rs
@@ -1,0 +1,134 @@
+//! `attest-verify` — externally verify that the bridge signing pubkey
+//! belongs to the running TEE.
+//!
+//! Issues a fresh nonce, calls the parent's `AttestedPublicKey` gRPC,
+//! and runs the AWS Nitro attestation verifier (cert chain + COSE
+//! signature + PCR check + nonce equality + bundle commitment).
+//!
+//! Usage:
+//!     attest-verify --endpoint http://127.0.0.1:50051 \
+//!         --pcr0 <hex> --pcr1 <hex> --pcr2 <hex>
+//!
+//! Use `--mock` against an enclave built with `mock-attestation` (PCRs are
+//! all zeros and the COSE wrapper is skipped).
+//!
+//! Exit codes:
+//!     0 — verification succeeded
+//!     1 — verification failed (output explains why)
+//!     2 — usage / IO / connection error
+
+use std::process::ExitCode;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+
+use utexo_bridge_parent::attest_verify::{
+    verify_attested_pubkey, AttestedPubkeyResult, VerifyMode,
+};
+
+#[derive(Parser)]
+#[command(
+    name = "attest-verify",
+    about = "Verify a UTEXO bridge signing pubkey against its TEE attestation"
+)]
+struct Cli {
+    /// Parent gRPC endpoint
+    #[arg(long, default_value = "http://127.0.0.1:50051")]
+    endpoint: String,
+
+    /// Expected PCR0 (96 hex chars = 48 bytes). Required unless --mock.
+    #[arg(long)]
+    pcr0: Option<String>,
+
+    /// Expected PCR1 (96 hex chars = 48 bytes). Required unless --mock.
+    #[arg(long)]
+    pcr1: Option<String>,
+
+    /// Expected PCR2 (96 hex chars = 48 bytes). Required unless --mock.
+    #[arg(long)]
+    pcr2: Option<String>,
+
+    /// Verify a mock-attestation document (zero PCRs, no COSE wrapping).
+    /// For dev/CI only. Real production verification MUST NOT use this flag.
+    #[arg(long)]
+    mock: bool,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    match run(cli).await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("FAIL: {e:#}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+async fn run(cli: Cli) -> Result<()> {
+    let (expected_pcrs, mode) = if cli.mock {
+        eprintln!(
+            "warning: --mock skips COSE/cert-chain checks; do NOT use against production enclaves"
+        );
+        (attestation_verify::ExpectedPcrs::zero(), VerifyMode::Mock)
+    } else {
+        let pcr0 = cli.pcr0.context("--pcr0 required (or pass --mock)")?;
+        let pcr1 = cli.pcr1.context("--pcr1 required (or pass --mock)")?;
+        let pcr2 = cli.pcr2.context("--pcr2 required (or pass --mock)")?;
+        let pcrs = attestation_verify::ExpectedPcrs::from_hex(&pcr0, &pcr1, &pcr2)
+            .context("invalid PCR hex")?;
+        (pcrs, VerifyMode::Real)
+    };
+
+    let result = verify_attested_pubkey(&cli.endpoint, expected_pcrs, mode).await?;
+    print_ok(&result);
+    Ok(())
+}
+
+fn print_ok(result: &AttestedPubkeyResult) {
+    let r = &result.response;
+    let v = &result.verified;
+    println!("OK");
+    println!(
+        "  EVM address           : 0x{}",
+        hex::encode(&r.evm_address)
+    );
+    println!(
+        "  EVM uncompressed pub  : 0x{}",
+        hex::encode(&r.evm_uncompressed_pub)
+    );
+    println!(
+        "  BTC compressed pub    : 0x{}",
+        hex::encode(&r.btc_compressed_pub)
+    );
+    println!("  BTC xpub              : {}", r.btc_xpub);
+    println!(
+        "  Master fingerprint    : 0x{}",
+        hex::encode(&r.master_fingerprint)
+    );
+    println!("  Account xpub (vanilla): {}", r.account_xpub_vanilla);
+    println!("  Account xpub (colored): {}", r.account_xpub_colored);
+    println!(
+        "  Bundle commitment     : 0x{}",
+        hex::encode(result.bundle_commitment)
+    );
+    println!(
+        "  PCR0                  : 0x{}",
+        hex::encode(v.pcrs.get(&0).map(|v| v.as_slice()).unwrap_or(&[]))
+    );
+    println!(
+        "  PCR1                  : 0x{}",
+        hex::encode(v.pcrs.get(&1).map(|v| v.as_slice()).unwrap_or(&[]))
+    );
+    println!(
+        "  PCR2                  : 0x{}",
+        hex::encode(v.pcrs.get(&2).map(|v| v.as_slice()).unwrap_or(&[]))
+    );
+    println!("  Attestation timestamp : {}", v.timestamp);
+    println!(
+        "  Nonce echoed          : 0x{}",
+        hex::encode(v.nonce.clone())
+    );
+}

--- a/parent/src/grpc_server.rs
+++ b/parent/src/grpc_server.rs
@@ -11,9 +11,10 @@ use crate::enriched;
 const ENCLAVE_TIMEOUT: Duration = Duration::from_secs(30);
 use crate::grpc_proto::enclave_service_server::EnclaveService;
 use crate::grpc_proto::{
-    CloneRequest, CloneResponse, DataType, GetLastSavedBlockRequest, GetLastSavedBlockResponse,
-    InitializeRequest, InitializeResponse, PublicKeyRequest, PublicKeyResponse, SignRequest,
-    Signature, SubmitHeadersRequest, SubmitHeadersResponse,
+    AttestedPublicKeyRequest, AttestedPublicKeyResponse, CloneRequest, CloneResponse, DataType,
+    GetLastSavedBlockRequest, GetLastSavedBlockResponse, InitializeRequest, InitializeResponse,
+    PublicKeyRequest, PublicKeyResponse, SignRequest, Signature, SubmitHeadersRequest,
+    SubmitHeadersResponse,
 };
 
 /// Enclave connection target — either TCP address or vsock CID+port.
@@ -376,6 +377,57 @@ impl EnclaveService for ParentAdapterService {
             Some(enclave_response::Response::Error(e)) => Err(Self::enclave_error_to_status(&e)),
             other => Err(Status::internal(format!(
                 "unexpected enclave response for SubmitHeaders: {:?}",
+                other
+            ))),
+        }
+    }
+
+    /// AttestedPublicKey — proves the bridge's signing pubkey was produced
+    /// inside this TEE. Forwards a 32-byte caller nonce to the enclave,
+    /// returns the public-key bundle plus an NSM attestation document that
+    /// binds the EVM pubkey + a sha256 commitment over the full bundle to
+    /// the enclave's PCRs. See docs/pubkey-attestation.md for the
+    /// verification recipe.
+    async fn attested_public_key(
+        &self,
+        request: Request<AttestedPublicKeyRequest>,
+    ) -> Result<Response<AttestedPublicKeyResponse>, Status> {
+        let inner = request.into_inner();
+        if inner.nonce.len() != 32 {
+            return Err(Status::invalid_argument(format!(
+                "nonce must be 32 bytes, got {}",
+                inner.nonce.len()
+            )));
+        }
+        tracing::info!("gRPC AttestedPublicKey called");
+
+        let enclave_req = EnclaveRequest {
+            request: Some(enclave_request::Request::GetAttestedPublicKey(
+                enclave_proto::GetAttestedPublicKeyRequest { nonce: inner.nonce },
+            )),
+        };
+
+        let resp = self.send_to_enclave(enclave_req).await?;
+
+        match resp.response {
+            Some(enclave_response::Response::GetAttestedPublicKey(r)) => {
+                let pk = r.public_keys.ok_or_else(|| {
+                    Status::internal("enclave returned attestation without public_keys")
+                })?;
+                Ok(Response::new(AttestedPublicKeyResponse {
+                    evm_address: pk.evm_address,
+                    evm_uncompressed_pub: pk.evm_uncompressed_pub,
+                    btc_compressed_pub: pk.btc_compressed_pub,
+                    btc_xpub: pk.btc_xpub,
+                    master_fingerprint: pk.master_fingerprint,
+                    account_xpub_vanilla: pk.account_xpub_vanilla,
+                    account_xpub_colored: pk.account_xpub_colored,
+                    attestation_doc: r.attestation_doc,
+                }))
+            }
+            Some(enclave_response::Response::Error(e)) => Err(Self::enclave_error_to_status(&e)),
+            other => Err(Status::internal(format!(
+                "unexpected enclave response for AttestedPublicKey: {:?}",
                 other
             ))),
         }

--- a/parent/src/lib.rs
+++ b/parent/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod attest_verify;
 pub mod client;
 pub mod config;
 pub mod error;

--- a/parent/tests/test_attest_verify_e2e.rs
+++ b/parent/tests/test_attest_verify_e2e.rs
@@ -1,0 +1,182 @@
+//! True end-to-end test for the `attest-verify` flow.
+//!
+//! Spins up the **real** enclave server (in-process, via the public API
+//! exposed from the enclave crate), the **real** parent gRPC server
+//! pointing at it, and drives the **real** `attest-verify` library
+//! function against the full stack. No hand-built mock attestations,
+//! no inline-duplicated check logic — this exercises everything the
+//! deployed CLI binary does, except for argument parsing and stdout
+//! formatting.
+
+use std::net::TcpListener;
+use std::sync::Arc;
+
+use tonic::transport::Server;
+
+use utexo_bridge_enclave::server::{self as enclave_server, ServerContext};
+use utexo_bridge_enclave::spv::{checkpoint_for, HeaderChain, Network};
+use utexo_bridge_enclave::state::EnclaveState;
+use utexo_bridge_parent::attest_verify::{verify_attested_pubkey, VerifyMode};
+use utexo_bridge_parent::grpc_proto::enclave_service_server::EnclaveServiceServer;
+use utexo_bridge_parent::grpc_server::{EnclaveTarget, ParentAdapterService};
+
+const TEST_MNEMONIC: &str =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+/// Start a real enclave TCP server on a random port. Initializes keys
+/// from the canonical BIP-39 test mnemonic so the EVM address is
+/// deterministic across test runs. Returns the port.
+fn start_real_enclave() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    let state = EnclaveState::new(bitcoin::Network::Bitcoin);
+    state
+        .initialize_from_mnemonic(TEST_MNEMONIC)
+        .expect("seed import");
+
+    let header_chain = std::sync::Mutex::new(HeaderChain::new(
+        Network::Regtest,
+        checkpoint_for(Network::Regtest),
+    ));
+    let ctx = Arc::new(ServerContext::new(state, header_chain));
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            match stream {
+                Ok(s) => enclave_server::handle_connection(s, &ctx),
+                Err(_) => continue,
+            }
+        }
+    });
+
+    port
+}
+
+async fn start_real_parent_grpc(enclave_port: u16) -> u16 {
+    let grpc_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let grpc_addr = grpc_listener.local_addr().unwrap();
+    let grpc_port = grpc_addr.port();
+    drop(grpc_listener);
+
+    let service =
+        ParentAdapterService::new(EnclaveTarget::Tcp(format!("127.0.0.1:{enclave_port}")));
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(EnclaveServiceServer::new(service))
+            .serve(grpc_addr)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+    grpc_port
+}
+
+#[tokio::test]
+async fn e2e_attest_verify_succeeds_against_live_stack() {
+    let enclave_port = start_real_enclave();
+    let grpc_port = start_real_parent_grpc(enclave_port).await;
+
+    let result = verify_attested_pubkey(
+        &format!("http://127.0.0.1:{grpc_port}"),
+        attestation_verify::ExpectedPcrs::zero(),
+        VerifyMode::Mock,
+    )
+    .await
+    .expect("end-to-end verification succeeds");
+
+    // EVM address from BIP-39 test vector "abandon abandon ... about" with
+    // the project's BIP-44 derivation. We don't hardcode the bytes —
+    // we just assert the structure is correct.
+    assert_eq!(result.response.evm_address.len(), 20);
+    assert_eq!(result.response.evm_uncompressed_pub.len(), 64);
+    assert_eq!(result.response.btc_compressed_pub.len(), 33);
+    assert_eq!(result.response.master_fingerprint.len(), 4);
+    assert!(result.response.btc_xpub.starts_with("xpub"));
+    assert!(!result.response.account_xpub_vanilla.is_empty());
+    assert!(!result.response.account_xpub_colored.is_empty());
+
+    // The verified `public_key` (NSM-bound) MUST equal the wire EVM pubkey.
+    assert_eq!(
+        result.verified.enclave_pubkey,
+        result.response.evm_uncompressed_pub
+    );
+
+    // The bundle commitment is non-zero and matches what verify_attested_pubkey
+    // checked against the NSM-bound `user_data`.
+    assert_ne!(result.bundle_commitment, [0u8; 32]);
+
+    // Nonce was a fresh 32 bytes and was echoed back in the doc.
+    assert_eq!(result.verified.nonce.len(), 32);
+}
+
+#[tokio::test]
+async fn e2e_attest_verify_fails_on_pcr_mismatch() {
+    let enclave_port = start_real_enclave();
+    let grpc_port = start_real_parent_grpc(enclave_port).await;
+
+    // Mock enclaves report all-zero PCRs; pass non-zero expected PCRs to
+    // simulate "operator passed wrong/stale PCRs to the verifier".
+    let wrong_pcrs = attestation_verify::ExpectedPcrs::new([0xAA; 48], [0u8; 48], [0u8; 48]);
+
+    let err = verify_attested_pubkey(
+        &format!("http://127.0.0.1:{grpc_port}"),
+        wrong_pcrs,
+        VerifyMode::Mock,
+    )
+    .await
+    .expect_err("PCR0 mismatch must fail verification");
+
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("PCR0") || msg.contains("PCR mismatch"),
+        "expected PCR mismatch error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn e2e_attest_verify_fails_on_real_path_against_mock_enclave() {
+    // Mock enclave produces a raw-CBOR doc, not a COSE_Sign1. The real
+    // verify path expects COSE_Sign1, so it must reject the doc — proving
+    // that --mock and the real path are not interchangeable, which is the
+    // entire safety property of the mode flag.
+    let enclave_port = start_real_enclave();
+    let grpc_port = start_real_parent_grpc(enclave_port).await;
+
+    let err = verify_attested_pubkey(
+        &format!("http://127.0.0.1:{grpc_port}"),
+        attestation_verify::ExpectedPcrs::zero(),
+        VerifyMode::Real, // <- real path against mock doc
+    )
+    .await
+    .expect_err("real verifier must reject a mock document");
+
+    let msg = format!("{err:#}");
+    // The mock doc is not a 4-element COSE array, so parsing fails first.
+    assert!(
+        msg.contains("COSE") || msg.contains("CBOR") || msg.contains("attestation verify failed"),
+        "expected COSE/CBOR parse failure, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn e2e_attest_verify_fails_on_unreachable_endpoint() {
+    let err = verify_attested_pubkey(
+        "http://127.0.0.1:1", // nothing listening here
+        attestation_verify::ExpectedPcrs::zero(),
+        VerifyMode::Mock,
+    )
+    .await
+    .expect_err("connection to dead port must fail");
+
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("connecting")
+            || msg.contains("connect")
+            || msg.contains("Connection")
+            || msg.contains("transport"),
+        "expected connection error, got: {msg}"
+    );
+}

--- a/parent/tests/test_grpc_bridge.rs
+++ b/parent/tests/test_grpc_bridge.rs
@@ -16,7 +16,9 @@ use utexo_bridge_parent::enriched;
 use utexo_bridge_parent::framing;
 use utexo_bridge_parent::grpc_proto::enclave_service_client::EnclaveServiceClient;
 use utexo_bridge_parent::grpc_proto::enclave_service_server::EnclaveServiceServer;
-use utexo_bridge_parent::grpc_proto::{DataType, PublicKeyRequest, SignRequest};
+use utexo_bridge_parent::grpc_proto::{
+    AttestedPublicKeyRequest, DataType, PublicKeyRequest, SignRequest,
+};
 use utexo_bridge_parent::grpc_server::{EnclaveTarget, ParentAdapterService};
 
 /// Start a mock enclave TCP server that responds to specific request types.
@@ -95,6 +97,53 @@ fn start_mock_enclave() -> u16 {
                         },
                     )),
                 },
+                Some(enclave_request::Request::GetAttestedPublicKey(req)) => {
+                    // Build a fresh mock attestation doc binding the mock pubkey.
+                    use sha2::Digest;
+                    let public_keys = enclave_proto::PublicKeysResponse {
+                        evm_address: vec![0xAA; 20],
+                        btc_compressed_pub: vec![0xBB; 33],
+                        btc_xpub: "xpub-test".into(),
+                        master_fingerprint: vec![0xDD; 4],
+                        account_xpub_vanilla: "tpub-vanilla-test".into(),
+                        account_xpub_colored: "tpub-colored-test".into(),
+                        evm_uncompressed_pub: vec![0xEE; 64],
+                    };
+                    let mut bundle: Vec<u8> = Vec::new();
+                    let parts: [&[u8]; 7] = [
+                        &public_keys.evm_address,
+                        &public_keys.btc_compressed_pub,
+                        public_keys.btc_xpub.as_bytes(),
+                        &public_keys.master_fingerprint,
+                        public_keys.account_xpub_vanilla.as_bytes(),
+                        public_keys.account_xpub_colored.as_bytes(),
+                        &public_keys.evm_uncompressed_pub,
+                    ];
+                    for p in parts {
+                        bundle.extend_from_slice(&(p.len() as u32).to_be_bytes());
+                        bundle.extend_from_slice(p);
+                    }
+                    let commitment: [u8; 32] = sha2::Sha256::digest(&bundle).into();
+                    let nonce: [u8; 32] = req
+                        .nonce
+                        .as_slice()
+                        .try_into()
+                        .expect("test must send 32-byte nonce");
+                    let doc = attestation_verify::build_mock_document(
+                        &nonce,
+                        Some(&public_keys.evm_uncompressed_pub),
+                        Some(&commitment),
+                    )
+                    .expect("build mock doc");
+                    EnclaveResponse {
+                        response: Some(enclave_response::Response::GetAttestedPublicKey(
+                            enclave_proto::GetAttestedPublicKeyResponse {
+                                public_keys: Some(public_keys),
+                                attestation_doc: doc,
+                            },
+                        )),
+                    }
+                }
                 _ => EnclaveResponse {
                     response: Some(enclave_response::Response::Error(
                         enclave_proto::ErrorResponse {
@@ -519,4 +568,76 @@ async fn grpc_submit_headers_roundtrip() {
     assert_eq!(resp.last_block_height, 215_003);
     assert_eq!(resp.last_block_hash, vec![0x22; 32]);
     assert_eq!(resp.headers_accepted, 3);
+}
+
+#[tokio::test]
+async fn grpc_attested_public_key_roundtrip_and_verify() {
+    let enclave_port = start_mock_enclave();
+    let grpc_port = start_grpc_server(enclave_port).await;
+
+    let mut client = EnclaveServiceClient::connect(format!("http://127.0.0.1:{grpc_port}"))
+        .await
+        .unwrap();
+
+    let nonce = [0x37u8; 32];
+    let resp = client
+        .attested_public_key(AttestedPublicKeyRequest {
+            nonce: nonce.to_vec(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    // Wire-level public-key bundle is intact.
+    assert_eq!(resp.evm_address, vec![0xAA; 20]);
+    assert_eq!(resp.evm_uncompressed_pub, vec![0xEE; 64]);
+    assert!(!resp.attestation_doc.is_empty());
+
+    // The attestation document verifies, binds the EVM pubkey, and the
+    // commitment over the canonical bundle matches.
+    let verified = attestation_verify::verify_mock_attestation(
+        &resp.attestation_doc,
+        &attestation_verify::ExpectedPcrs::zero(),
+        Some(&nonce),
+    )
+    .expect("verify mock doc");
+    assert_eq!(verified.enclave_pubkey, resp.evm_uncompressed_pub);
+
+    use sha2::Digest;
+    let mut bundle: Vec<u8> = Vec::new();
+    let parts: [&[u8]; 7] = [
+        &resp.evm_address,
+        &resp.btc_compressed_pub,
+        resp.btc_xpub.as_bytes(),
+        &resp.master_fingerprint,
+        resp.account_xpub_vanilla.as_bytes(),
+        resp.account_xpub_colored.as_bytes(),
+        &resp.evm_uncompressed_pub,
+    ];
+    for p in parts {
+        bundle.extend_from_slice(&(p.len() as u32).to_be_bytes());
+        bundle.extend_from_slice(p);
+    }
+    let expected: [u8; 32] = sha2::Sha256::digest(&bundle).into();
+    assert_eq!(verified.user_data.as_deref(), Some(expected.as_slice()));
+    assert_eq!(verified.nonce, nonce.to_vec());
+}
+
+#[tokio::test]
+async fn grpc_attested_public_key_rejects_wrong_nonce_size() {
+    let enclave_port = start_mock_enclave();
+    let grpc_port = start_grpc_server(enclave_port).await;
+
+    let mut client = EnclaveServiceClient::connect(format!("http://127.0.0.1:{grpc_port}"))
+        .await
+        .unwrap();
+
+    let err = client
+        .attested_public_key(AttestedPublicKeyRequest {
+            nonce: vec![0u8; 16],
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
 }

--- a/proto/enclave.proto
+++ b/proto/enclave.proto
@@ -17,6 +17,7 @@ message EnclaveRequest {
     SetCloneRequest        set_clone         = 9;
     SubmitHeadersRequest      submit_headers        = 11;
     GetLastSavedBlockRequest  get_last_saved_block  = 12;
+    GetAttestedPublicKeyRequest get_attested_public_key = 13;
     // Reserved for future:
     // HealthCheckRequest  health_check     = 10;
   }
@@ -35,6 +36,7 @@ message EnclaveResponse {
     SetCloneResponse        set_clone        = 9;
     SubmitHeadersResponse      submit_headers       = 11;
     GetLastSavedBlockResponse  get_last_saved_block = 12;
+    GetAttestedPublicKeyResponse get_attested_public_key = 13;
     // Reserved for future:
     // HealthCheckResponse  health_check     = 10;
     ErrorResponse           error            = 15;
@@ -75,6 +77,29 @@ message PublicKeysResponse {
   string account_xpub_vanilla   = 5;
   string account_xpub_colored   = 6;
   bytes evm_uncompressed_pub    = 7;  // 64 bytes — secp256k1 X||Y (no 04 prefix)
+}
+
+// Returns the public-key bundle along with an NSM attestation document
+// that cryptographically binds the keys to this enclave's PCRs at the time
+// of the call. Lets external verifiers (bridge contract operator, auditors)
+// confirm "the EVM address signing my bridge txs was produced by code with
+// PCR0=X" without any trust in the parent process.
+//
+// `nonce` MUST be a fresh 32 bytes from the verifier — the enclave embeds
+// it in the NSM doc, and the verifier checks equality on response to defeat
+// replay. The NSM doc binds:
+//     public_key field -> evm_uncompressed_pub (64 bytes, primary signing key)
+//     user_data  field -> sha256(canonical_bundle)
+// where canonical_bundle is the length-prefixed concatenation of every key
+// in PublicKeysResponse. A lightweight verifier may stop at the public_key
+// field; a thorough one rebuilds the bundle and checks user_data.
+message GetAttestedPublicKeyRequest {
+  bytes nonce = 1;  // MUST be 32 bytes
+}
+
+message GetAttestedPublicKeyResponse {
+  PublicKeysResponse public_keys     = 1;
+  bytes              attestation_doc = 2;  // COSE_Sign1 NSM attestation (real) or raw CBOR (mock)
 }
 
 // === EVM Signing (RGB→EVM direction) ===

--- a/proto/parentadapter.proto
+++ b/proto/parentadapter.proto
@@ -30,6 +30,13 @@ service EnclaveService {
   // Pushes a batch of Bitcoin block headers into the enclave's cache.
   // Listener fetches from Esplora and feeds them in ascending-height batches.
   rpc SubmitHeaders(SubmitHeadersRequest) returns (SubmitHeadersResponse);
+
+  // Returns the bridge's public-key bundle along with an NSM attestation
+  // document binding the EVM signing pubkey (in `public_key` field) and a
+  // sha256 commitment over the full bundle (in `user_data` field) to the
+  // running enclave's PCRs. The caller-supplied 32-byte `nonce` is echoed
+  // in the doc and MUST be checked for equality on verify (replay defence).
+  rpc AttestedPublicKey(AttestedPublicKeyRequest) returns (AttestedPublicKeyResponse);
 }
 
 message InitializeRequest {
@@ -70,4 +77,21 @@ message SubmitHeadersResponse {
   uint32 last_block_height = 1;      // enclave's latest block after processing
   bytes  last_block_hash   = 2;      // 32 bytes
   uint32 headers_accepted  = 3;      // how many from the batch were valid
+}
+
+// --- Attested public key ---
+
+message AttestedPublicKeyRequest {
+  bytes nonce = 1;                   // MUST be 32 bytes; embedded in NSM doc
+}
+
+message AttestedPublicKeyResponse {
+  bytes  evm_address           = 1;  // 20 bytes
+  bytes  evm_uncompressed_pub  = 2;  // 64 bytes (X||Y) — ALSO present in attestation_doc.public_key
+  bytes  btc_compressed_pub    = 3;  // 33 bytes
+  string btc_xpub              = 4;
+  bytes  master_fingerprint    = 5;  // 4 bytes
+  string account_xpub_vanilla  = 6;
+  string account_xpub_colored  = 7;
+  bytes  attestation_doc       = 8;  // COSE_Sign1 NSM doc (real) or raw CBOR (mock)
 }


### PR DESCRIPTION
## Summary

Adds an externally verifiable proof that the bridge's signing pubkey was produced inside an enclave with a specific PCR measurement. External verifiers (bridge contract operator, auditors, downstream services) can now confirm the EVM address signing bridge txs comes from a known TEE image, **without trusting the parent host process**.

> ⚠️ **Base branch:** this PR is targeted at `feat/spv-staleness` because the e2e test wires up a real `ServerContext` which needs the SPV `header_chain` field. When #32 merges, the base will auto-rebase onto `dev`.

## What it does

A caller sends a fresh 32-byte nonce; the enclave returns the public-key bundle plus an NSM attestation document binding:

| NSM field    | Bound value |
|--------------|-------------|
| `public_key` | `evm_uncompressed_pub` (the bridge's primary signing key) |
| `user_data`  | `sha256(canonical_bundle)` (commitment over all keys) |
| `nonce`      | the verifier's 32-byte challenge (replay defence) |

Lightweight verifiers (an EVM contract that only cares about the signing address) can stop at `public_key`. Thorough verifiers rebuild the canonical bundle and check `user_data` to confirm BTC keys / xpubs were not swapped by the parent.

## Architecture

The verifier itself is extracted into a new workspace crate `attestation-verify/` so the enclave's existing **cloning peer-verify path** and the new **external CLI** run the **same** verification code. Single source of truth — any bug found by either caller is fixed for both. Mock support is feature-gated.

```
┌──────────────────────┐    AttestedPublicKey (gRPC)    ┌─────────────┐  vsock   ┌────────────────────────┐
│ external verifier    │ ─────────────────────────────▶ │ parent      │ ───────▶ │ enclave (Nitro)        │
│ attest-verify CLI    │                                │ adapter     │          │ NSM produces COSE_Sign1│
└──────────────────────┘ ◀───────────────────────────── └─────────────┘ ◀─────── │ binding pubkey + PCRs  │
                              (bundle + attestation_doc)                          └────────────────────────┘
```

See `docs/pubkey-attestation.md` for the verification recipe and threat model.

## Test coverage

| Layer | Tests | What's real / what's stubbed |
|-------|-------|------------------------------|
| `attestation-verify` unit | 9 | verifier + mock builder; everything else stubbed |
| Enclave handler integration | 5 | real enclave, real wire protocol, real verifier; no parent gRPC |
| Parent gRPC integration | 2 | real parent gRPC, real verifier; mock TCP enclave |
| **End-to-end** | **4** | **real enclave + real parent gRPC + real CLI library function** |

The real NSM path (`verify_attestation` without `--mock`) requires actual Nitro hardware and is **not exercised in CI**. The cert-chain code is unchanged from the cloning flow which has been exercising the verify machinery via mock attestation. First production deployment should confirm CBOR byte-string handling and the cert-chain walk against a live NSM document — see `docs/pubkey-attestation.md` for the failure decoder ring.

## Files of note

- New crate: `attestation-verify/` — pure-Rust verifier (COSE_Sign1 + AWS Nitro cert chain + PCR + nonce + pubkey check)
- Refactor: `enclave/src/attestation.rs` slimmed to a thin facade over the new crate
- New RPC: `proto/enclave.proto` + `proto/parentadapter.proto` define `GetAttestedPublicKey` / `AttestedPublicKey`
- Enclave handler: `handle_get_attested_public_key` in `enclave/src/server.rs`
- Parent handler: `attested_public_key` in `parent/src/grpc_server.rs`
- CLI: `parent/src/bin/attest_verify.rs` (thin wrapper) + `parent/src/attest_verify.rs` (library, testable)
- Docs: `docs/pubkey-attestation.md` (protocol, recipe, threat model)

## Tag-along

`enclave/tests/test_clone.rs` gains a missing `evm_uncompressed_pub` field — pre-existing compile bug masked on this branch, surfaced when running tests after the verifier-crate refactor.

## Test plan

- [x] `cargo test --workspace --features utexo-bridge-enclave/mock-attestation,utexo-bridge-enclave/allow-seed-import` — 197 tests pass
- [x] `cargo build -p utexo-bridge-enclave --features rgb-validation` — feature-gated `ServerContext` field still builds
- [x] `cargo fmt --all`
- [ ] Production smoke test on Nitro EC2 (planned, see docs)