### PR TITLE
fix(docker): unblock CD Docker builds after F1 regression

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -30,6 +30,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Load the read-only deploy key for `rgb-consignment-parser` into an
+      # ssh-agent on the runner. `docker/build-push-action` with
+      # `ssh: default` forwards $SSH_AUTH_SOCK into the build so the
+      # `RUN --mount=type=ssh` lines in the enclave Dockerfiles can pull
+      # the private dep. The parent Dockerfile doesn't strictly need this
+      # (public patches via libgit2 work without an agent), but loading
+      # it unconditionally keeps the matrix steps uniform.
+      - name: Set up SSH for private RGB deps
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.RGB_CONSIGNMENT_PARSER_DEPLOY_KEY }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -48,6 +60,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
+          ssh: default
           tags: |
             ${{ env.REGISTRY }}/${{ matrix.image }}${{ env.ENVIRONMENT }}:${{ github.sha }}
             ${{ env.REGISTRY }}/${{ matrix.image }}${{ env.ENVIRONMENT }}:latest
@@ -61,6 +74,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
+          ssh: default
           tags: |
             ${{ env.REGISTRY }}/${{ matrix.image }}${{ env.ENVIRONMENT }}:${{ github.sha }}
             ${{ env.REGISTRY }}/${{ matrix.image }}${{ env.ENVIRONMENT }}:latest

--- a/build/Dockerfile.enclave
+++ b/build/Dockerfile.enclave
@@ -1,8 +1,29 @@
-FROM rust:1.85-slim AS builder
+# syntax=docker/dockerfile:1.4
+# Production enclave image (vsock + rgb-validation + spv).
+# Usage:
+#   DOCKER_BUILDKIT=1 docker build --ssh default \
+#     -f build/Dockerfile.enclave -t utexo-bridge-enclave .
+#
+# `--ssh default` forwards the host's SSH agent into the build so cargo
+# can fetch the private `rgb-consignment` git dep that the
+# `rgb-validation`/`spv` features pull in.
 
+FROM rust:1.89-slim AS builder
+
+# `git` + `openssh-client`: the workspace `[patch.crates-io]` uses public
+# git URLs for rgb-consensus / rgb-ops / rgb-invoicing / rgb-strict-encoding,
+# and `enclave/Cargo.toml` pulls `rgb-consignment` over SSH. `.cargo/config.toml`
+# sets `net.git-fetch-with-cli = true` so cargo shells out to system `git`
+# rather than bundled libgit2. `openssh-client` provides the ssh binary +
+# known_hosts machinery `git` needs for the SSH transport.
 RUN apt-get update && apt-get install -y \
-    pkg-config libssl-dev protobuf-compiler \
+    pkg-config libssl-dev protobuf-compiler git ca-certificates openssh-client \
     && rm -rf /var/lib/apt/lists/*
+
+# Trust github.com's SSH host key so the build doesn't prompt or fail
+# on host-key verification when fetching the private parser dep.
+RUN mkdir -p /root/.ssh && \
+    ssh-keyscan -t ed25519,ecdsa github.com >> /root/.ssh/known_hosts
 
 WORKDIR /build
 COPY . /build/
@@ -10,7 +31,11 @@ COPY . /build/
 WORKDIR /build/enclave
 # `spv` implies `rgb-validation`; listing both explicitly so the feature
 # set is visible at a glance.
-RUN cargo build --release --features vsock,rgb-validation,spv
+#
+# `--mount=type=ssh` exposes the SSH_AUTH_SOCK forwarded by `--ssh default`
+# only for the duration of this RUN, so no credentials end up in the
+# image layers.
+RUN --mount=type=ssh cargo build --release --features vsock,rgb-validation,spv
 
 # --- Runtime ---
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal AS runtime

--- a/build/Dockerfile.enclave-dev
+++ b/build/Dockerfile.enclave-dev
@@ -1,13 +1,32 @@
+# syntax=docker/dockerfile:1.4
 # Enclave (dev mode, TCP, no vsock)
 # Usage:
-#   docker build -f build/Dockerfile.enclave-dev -t utexo-bridge-enclave-dev .
+#   DOCKER_BUILDKIT=1 docker build --ssh default \
+#     -f build/Dockerfile.enclave-dev -t utexo-bridge-enclave-dev .
+#
+# `--ssh default` forwards the host's SSH agent into the build so cargo
+# can fetch the private `rgb-consignment` git dep (under
+# `rgb-validation`/`spv`). In CI this is wired via `docker/build-push-action`
+# with `ssh: default` after `webfactory/ssh-agent` loads
+# `secrets.RGB_CONSIGNMENT_PARSER_DEPLOY_KEY`.
 
 # ===== Builder Stage =====
-FROM rust:1.85-slim AS builder
+FROM rust:1.89-slim AS builder
 
+# `git` + `openssh-client`: the workspace `[patch.crates-io]` uses public
+# git URLs for rgb-consensus / rgb-ops / rgb-invoicing / rgb-strict-encoding,
+# and `enclave/Cargo.toml` pulls `rgb-consignment` over SSH. `.cargo/config.toml`
+# sets `net.git-fetch-with-cli = true` so cargo shells out to system `git`
+# rather than bundled libgit2. `openssh-client` provides the ssh binary +
+# known_hosts machinery `git` needs for the SSH transport.
 RUN apt-get update && apt-get install -y \
-    pkg-config libssl-dev protobuf-compiler \
+    pkg-config libssl-dev protobuf-compiler git ca-certificates openssh-client \
     && rm -rf /var/lib/apt/lists/*
+
+# Trust github.com's SSH host key so the build doesn't prompt or fail
+# on host-key verification when fetching the private parser dep.
+RUN mkdir -p /root/.ssh && \
+    ssh-keyscan -t ed25519,ecdsa github.com >> /root/.ssh/known_hosts
 
 WORKDIR /build
 COPY . /build/
@@ -17,7 +36,11 @@ WORKDIR /build/enclave
 # without the production-only `vsock,rgb-validation` combo. Without spv,
 # the enclave fails-closed on any request that carries merkle_proofs,
 # which is what we want — build mismatch should always fail loudly.
-RUN cargo build --release --features allow-seed-import,spv
+#
+# `--mount=type=ssh` exposes the SSH_AUTH_SOCK forwarded by `--ssh default`
+# only for the duration of this RUN, so no credentials end up in the
+# image layers.
+RUN --mount=type=ssh cargo build --release --features allow-seed-import,spv
 
 # ===== Runtime Stage =====
 FROM debian:bookworm-slim

--- a/build/Dockerfile.parent
+++ b/build/Dockerfile.parent
@@ -11,10 +11,16 @@
 #     utexo-bridge-parent
 
 # ===== Builder Stage =====
-FROM rust:1.85-slim AS builder
+FROM rust:1.89-slim AS builder
 
+# `git` + `ca-certificates`: the workspace `[patch.crates-io]` rewrites
+# rgb-consensus / rgb-ops / rgb-invoicing / rgb-strict-encoding to public
+# git URLs, and `.cargo/config.toml` sets `net.git-fetch-with-cli = true`
+# so cargo shells out to system `git` instead of bundled libgit2. Without
+# `git` installed, cargo fails with "No such file or directory" before
+# the build even starts.
 RUN apt-get update && apt-get install -y \
-    pkg-config libssl-dev protobuf-compiler \
+    pkg-config libssl-dev protobuf-compiler git ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build


### PR DESCRIPTION
## What broke

The F1 merge wired `.cargo/config.toml` with `net.git-fetch-with-cli = true` (cargo shells out to system `git` for git deps instead of bundled libgit2) and the workspace pulled in `rgb-consignment` which needs Rust 1.88+ for let-chains. The in-repo CI workflow was updated at the same time, but the three Dockerfiles weren't, so `CD Develop Environment` started failing the moment F1 hit `dev`:

```
error: failed to load source for dependency `rgb-consensus`
  No such file or directory (os error 2)
```

That's ENOENT spawning `git`, not a network failure — `rust:1.85-slim` carries cargo but no `git` binary, and `git-fetch-with-cli = true` makes cargo refuse to fall back to libgit2.

## What this PR changes

### All three Dockerfiles
- Bump `rust:1.85-slim` → `rust:1.89-slim` (let-chains in `rgb-consignment`).
- apt-install `git` + `ca-certificates` so the public `[patch.crates-io]` URLs (rgb-consensus / rgb-ops / rgb-invoicing / rgb-strict-encoding) clone successfully.

### `Dockerfile.enclave` + `Dockerfile.enclave-dev`
- Additionally install `openssh-client`, prime `/root/.ssh/known_hosts` with github.com's host keys via `ssh-keyscan`.
- Add the `# syntax=docker/dockerfile:1.4` directive.
- Switch the `cargo build` line to `RUN --mount=type=ssh ...` so `$SSH_AUTH_SOCK` is exposed only for that step (no credentials baked into image layers).

### `cd-dev.yml`
- Load `secrets.RGB_CONSIGNMENT_PARSER_DEPLOY_KEY` into the runner's ssh-agent before the Docker build (mirrors the existing setup in `ci.yml`).
- Add `ssh: default` to both `docker/build-push-action` invocations so Buildx forwards `$SSH_AUTH_SOCK` into the build sandbox.

## Test plan

- [ ] CD `build (parent, ...)` matrix job goes green.
- [ ] CD `build (enclave-light, ...)` matrix job goes green.
- [ ] `deploy` job runs (was previously skipped because the `build` matrix failed).

Local Docker daemon wasn't available so I couldn't dry-run the images here — relying on CI for verification. The changes are mechanical and isolated to the Docker / CD layer; nothing in the Rust workspace moves.