### PR TITLE
fix(docker): wire SSH agent into parent Dockerfile

### DIFF
--- a/build/Dockerfile.parent
+++ b/build/Dockerfile.parent
@@ -1,6 +1,15 @@
+# syntax=docker/dockerfile:1.4
 # Parent Adapter (gRPC proxy to Enclave)
 # Usage:
-#   docker build -f build/Dockerfile.parent -t utexo-bridge-parent .
+#   DOCKER_BUILDKIT=1 docker build --ssh default \
+#     -f build/Dockerfile.parent -t utexo-bridge-parent .
+#
+# `--ssh default` is required even though parent doesn't link against
+# `rgb-consignment`: cargo's resolver fetches every git source declared
+# anywhere in the workspace before it knows which crates a `-p` build
+# actually compiles. The optional `rgb-consignment` dep lives in
+# `enclave/Cargo.toml` and is hosted on a private repo over SSH, so the
+# agent socket has to be exposed.
 #
 # Dev (TCP to enclave container):
 #   docker run -e ENCLAVE_ADDR=enclave:5000 utexo-bridge-parent
@@ -16,17 +25,27 @@ FROM rust:1.89-slim AS builder
 # `git` + `ca-certificates`: the workspace `[patch.crates-io]` rewrites
 # rgb-consensus / rgb-ops / rgb-invoicing / rgb-strict-encoding to public
 # git URLs, and `.cargo/config.toml` sets `net.git-fetch-with-cli = true`
-# so cargo shells out to system `git` instead of bundled libgit2. Without
-# `git` installed, cargo fails with "No such file or directory" before
-# the build even starts.
+# so cargo shells out to system `git` instead of bundled libgit2.
+# `openssh-client` is required because cargo's workspace resolver also
+# fetches the private `rgb-consignment` git source (declared optional in
+# `enclave/Cargo.toml`) even when building `-p utexo-bridge-parent` —
+# the resolution is workspace-wide, not target-scoped.
 RUN apt-get update && apt-get install -y \
-    pkg-config libssl-dev protobuf-compiler git ca-certificates \
+    pkg-config libssl-dev protobuf-compiler git ca-certificates openssh-client \
     && rm -rf /var/lib/apt/lists/*
+
+# Trust github.com's SSH host key so the build doesn't prompt or fail
+# on host-key verification when fetching the private parser dep.
+RUN mkdir -p /root/.ssh && \
+    ssh-keyscan -t ed25519,ecdsa github.com >> /root/.ssh/known_hosts
 
 WORKDIR /build
 COPY . /build/
 
-RUN cargo build --release -p utexo-bridge-parent
+# `--mount=type=ssh` exposes the SSH_AUTH_SOCK forwarded by `--ssh default`
+# only for the duration of this RUN, so no credentials end up in the
+# image layers.
+RUN --mount=type=ssh cargo build --release -p utexo-bridge-parent
 
 # ===== Runtime Stage =====
 FROM debian:bookworm-slim


### PR DESCRIPTION
Follow-up to #36. The first CD run on `dev` after that merge showed enclave-light built green ✅ but parent failed ❌. Root cause: I assumed `cargo build -p utexo-bridge-parent` wouldn't need the private `rgb-consignment` git source because parent doesn't link against it. That's wrong — cargo's resolver is workspace-scoped:

> fatal: Could not read from remote repository.
> error: failed to get \`rgb-consignment\` as a dependency of package \`utexo-bridge-enclave v0.1.0 (/build/enclave)\`

The optional dep lives in `enclave/Cargo.toml` and the workspace-level resolution fetches every git source before deciding which crates actually compile under `-p`.

This PR mirrors the SSH treatment already applied to the enclave Dockerfiles: `# syntax=docker/dockerfile:1.4` directive, install `openssh-client`, prime known_hosts via `ssh-keyscan`, switch the cargo step to `RUN --mount=type=ssh`. The CD workflow's `ssh: default` from #36 already forwards the agent socket, so no workflow change is needed.

## Test plan

- [ ] CD `build (parent, ...)` matrix job goes green this time.