### PR TITLE
feat(crosscheck): whitelist PSBT shape on signPsbt

### DIFF
--- a/enclave/src/validation/psbt_crosscheck.rs
+++ b/enclave/src/validation/psbt_crosscheck.rs
@@ -1,3 +1,5 @@
+use bitcoin::psbt::Psbt;
+
 use crate::error::{EnclaveError, Result};
 use crate::proto::SignPsbtRequest;
 
@@ -11,9 +13,29 @@ use crate::proto::SignPsbtRequest;
 ///   present. Used for `create_utxo` and other plain BTC operations that don't
 ///   involve RGB state or EVM events.
 pub fn validate_psbt_request(req: &SignPsbtRequest) -> Result<()> {
-    // PSBT must always be present regardless of mode.
+    // 0. Shape whitelist. Mirrors the EVM-side selector whitelist: refuse
+    //    payloads that aren't even a legitimate PSBT before any other
+    //    predicate runs. Catches three classes of garbage up-front:
+    //
+    //      (a) empty bytes (handler tried to sign nothing),
+    //      (b) bytes that don't conform to BIP-174 (random/truncated/
+    //          tampered),
+    //      (c) PSBTs with no inputs — there's literally nothing to sign,
+    //          and the unsigned-tx-must-be-non-empty rule is implicit in
+    //          BIP-174's signing semantics.
+    //
+    //    The existing PSBT signer would have failed later on these too,
+    //    but with a much noisier downstream error. Failing here gives the
+    //    caller a single clear reason.
     if req.psbt_bytes.is_empty() {
         return Err(EnclaveError::CrossCheck("psbt_bytes is empty".into()));
+    }
+    let psbt = Psbt::deserialize(&req.psbt_bytes)
+        .map_err(|e| EnclaveError::CrossCheck(format!("psbt_bytes is not a valid PSBT: {e}")))?;
+    if psbt.unsigned_tx.input.is_empty() {
+        return Err(EnclaveError::CrossCheck(
+            "psbt has no inputs — nothing to sign".into(),
+        ));
     }
 
     // Vanilla mode: no EVM enrichment → skip bridge cross-checks.
@@ -67,6 +89,37 @@ pub fn validate_psbt_request(req: &SignPsbtRequest) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bitcoin::hashes::Hash;
+    use bitcoin::{Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness};
+
+    /// Minimal but BIP-174-valid PSBT: one dummy input, one dummy output, no
+    /// signatures. Used as the "shape passes the whitelist" stand-in across
+    /// the validation tests — the request fields under test are everything
+    /// *around* the PSBT, not the PSBT contents themselves.
+    fn minimal_valid_psbt_bytes() -> Vec<u8> {
+        let unsigned_tx = Transaction {
+            version: bitcoin::transaction::Version(2),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_raw_hash(bitcoin::hashes::sha256d::Hash::from_byte_array(
+                        [0u8; 32],
+                    )),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(1_000),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        };
+        Psbt::from_unsigned_tx(unsigned_tx)
+            .expect("from_unsigned_tx")
+            .serialize()
+    }
 
     fn valid_bridge_psbt_request() -> SignPsbtRequest {
         SignPsbtRequest {
@@ -78,7 +131,7 @@ mod tests {
             evm_amount: 1000,
             evm_recipient: vec![0x22; 20],
             evm_commission: 50,
-            psbt_bytes: vec![0xFF; 100],
+            psbt_bytes: minimal_valid_psbt_bytes(),
             psbt_output_amount: 900,
             rgb_asset_id: "rgb:test-asset".into(),
         }
@@ -94,7 +147,7 @@ mod tests {
             evm_amount: 0,
             evm_recipient: vec![],
             evm_commission: 0,
-            psbt_bytes: vec![0xFF; 100],
+            psbt_bytes: minimal_valid_psbt_bytes(),
             psbt_output_amount: 0,
             rgb_asset_id: String::new(),
         }
@@ -182,5 +235,57 @@ mod tests {
         let mut req = valid_bridge_psbt_request();
         req.evm_amount = req.psbt_output_amount + req.evm_commission;
         assert!(validate_psbt_request(&req).is_ok());
+    }
+
+    // =========================================================================
+    // PSBT shape whitelist tests — apply to both bridge and vanilla modes
+    // =========================================================================
+
+    #[test]
+    fn rejects_garbage_psbt_bytes() {
+        // Long enough to clear the empty-bytes guard but not a BIP-174 PSBT.
+        let mut req = vanilla_psbt_request();
+        req.psbt_bytes = vec![0xFF; 100];
+        let err = validate_psbt_request(&req).unwrap_err();
+        assert!(
+            err.to_string().contains("not a valid PSBT"),
+            "expected PSBT parse rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_truncated_psbt_below_magic() {
+        // Shorter than the 5-byte BIP-174 magic prefix.
+        let mut req = vanilla_psbt_request();
+        req.psbt_bytes = vec![0x70, 0x73];
+        let err = validate_psbt_request(&req).unwrap_err();
+        assert!(
+            err.to_string().contains("not a valid PSBT"),
+            "expected PSBT parse rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_psbt_with_no_inputs() {
+        // Build a PSBT whose unsigned tx has zero inputs. BIP-174 lets us
+        // serialise it; the validation layer is what enforces the
+        // "something to sign" invariant.
+        let unsigned_tx = Transaction {
+            version: bitcoin::transaction::Version(2),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![],
+            output: vec![TxOut {
+                value: Amount::from_sat(1_000),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        };
+        let psbt = Psbt::from_unsigned_tx(unsigned_tx).expect("from_unsigned_tx");
+        let mut req = vanilla_psbt_request();
+        req.psbt_bytes = psbt.serialize();
+        let err = validate_psbt_request(&req).unwrap_err();
+        assert!(
+            err.to_string().contains("no inputs"),
+            "expected no-inputs rejection, got: {err}"
+        );
     }
 }

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -58,6 +58,39 @@ fn valid_sign_evm_request(amount: u64, commission: u64) -> SignEvmRequest {
     }
 }
 
+/// Build a minimal BIP-174-valid PSBT for tests that only care about
+/// `validate_psbt_request` shape-checking accepting the bytes — the actual
+/// signing path won't sign this (no witness data, no matchable keys), so
+/// only use it for tests that expect rejection BEFORE the signer runs.
+fn minimal_valid_psbt_bytes() -> Vec<u8> {
+    use bitcoin::hashes::Hash;
+    use bitcoin::psbt::Psbt;
+    use bitcoin::{Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness};
+
+    let unsigned_tx = Transaction {
+        version: bitcoin::transaction::Version(2),
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: Txid::from_raw_hash(bitcoin::hashes::sha256d::Hash::from_byte_array(
+                    [0u8; 32],
+                )),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(1_000),
+            script_pubkey: ScriptBuf::new(),
+        }],
+    };
+    Psbt::from_unsigned_tx(unsigned_tx)
+        .expect("from_unsigned_tx")
+        .serialize()
+}
+
 /// Build a minimal 2-of-3 multisig PSBT for testing with a known pubkey.
 #[cfg(feature = "allow-seed-import")]
 fn build_test_multisig_psbt(our_pubkey: &bitcoin::PublicKey) -> Vec<u8> {
@@ -374,7 +407,7 @@ fn test_sign_psbt_before_init() {
             evm_amount: 1000,
             evm_recipient: vec![],
             evm_commission: 0,
-            psbt_bytes: vec![0xFF; 10],
+            psbt_bytes: minimal_valid_psbt_bytes(),
             psbt_output_amount: 500,
             rgb_asset_id: String::new(),
         })),
@@ -413,7 +446,7 @@ fn test_sign_psbt_rejects_unfinalized() {
             evm_amount: 1000,
             evm_recipient: vec![],
             evm_commission: 0,
-            psbt_bytes: vec![0xFF; 10],
+            psbt_bytes: minimal_valid_psbt_bytes(),
             psbt_output_amount: 500,
             rgb_asset_id: String::new(),
         })),
@@ -451,7 +484,7 @@ fn test_sign_psbt_rejects_amount_mismatch() {
             evm_amount: 100,
             evm_recipient: vec![],
             evm_commission: 20,
-            psbt_bytes: vec![0xFF; 10],
+            psbt_bytes: minimal_valid_psbt_bytes(),
             psbt_output_amount: 90, // 90 + 20 = 110 > 100
             rgb_asset_id: String::new(),
         })),
@@ -496,19 +529,21 @@ fn test_sign_vanilla_psbt_skips_evm_checks() {
             evm_amount: 0,
             evm_recipient: vec![],
             evm_commission: 0,
-            psbt_bytes: vec![0xFF; 10], // not a real PSBT — will fail at signing, not validation
+            psbt_bytes: minimal_valid_psbt_bytes(),
             psbt_output_amount: 0,
             rgb_asset_id: String::new(),
         })),
     };
     let resp = common::send_request(port, &sign_req);
 
-    // The request passes cross-checks (vanilla mode) but fails at actual PSBT
-    // parsing since 0xFF bytes aren't a valid PSBT. That's fine — we're testing
-    // that validation didn't reject it.
+    // Vanilla mode skips the EVM cross-checks even though `evm_event_valid`
+    // is false. The PSBT shape check now passes (real BIP-174 bytes), and
+    // the signer returns 0 matchable inputs successfully — no key material
+    // in this PSBT lines up with the test seed.
     match &resp.response {
         Some(Response::Error(e)) => {
-            // Should NOT be a cross-check error (code 3) — should be a signing error
+            // Should NOT be a cross-check error (code 3) — vanilla mode
+            // is the whole point of this test.
             assert_ne!(
                 e.code, 3,
                 "vanilla PSBT should not fail cross-checks, but got: {}",
@@ -516,7 +551,7 @@ fn test_sign_vanilla_psbt_skips_evm_checks() {
             );
         }
         Some(Response::SignedPsbt(_)) => {
-            // Would only happen with a real valid PSBT — fine too
+            // Expected with the new minimal-valid PSBT shape.
         }
         other => panic!("unexpected response: {:?}", other),
     }


### PR DESCRIPTION
Completes the PSBT half of the up-front shape whitelist from item #7 of the post-SPV checklist. Symmetric to the EVM-side \`fundsOut\` selector whitelist already on \`dev\` ([#35](https://github.com/UTEXO-Protocol/enclave-signer/pull/35)): refuse payloads that aren't even a legitimate BIP-174 PSBT before any downstream predicate runs.

## What changes

Three rejection classes added at the top of \`validate_psbt_request\`:

1. **Empty \`psbt_bytes\`** — already enforced, kept.
2. **Bytes that don't deserialise** via \`bitcoin::psbt::Psbt::deserialize\` (random / truncated / tampered).
3. **PSBTs whose unsigned tx has zero inputs** — there's literally nothing to sign.

The downstream signer would have failed later on each of these, but with much noisier errors. Failing here gives the caller one clear reason and shrinks the surface downstream code has to defend against.

## Test changes

Unit + integration tests adjusted to use a real minimal BIP-174-valid PSBT (one dummy input, one dummy output, no signatures) wherever the request fields under test are everything *around* the PSBT content. New rejection tests cover all three classes explicitly.

## Test plan

- [x] cargo fmt + clippy --all-targets -D warnings (default + production combo)
- [x] cargo test --workspace
- [x] cargo test -p utexo-bridge-enclave --features spv — 175 tests OK
- [x] 13 unit tests under validation::psbt_crosscheck::tests (3 new)
- [x] 18 integration tests in tests/test_signing.rs