### PR TITLE
fix(signing): apply EIP-191 prefix to signRawMessage

### DIFF
--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -436,15 +436,23 @@ fn handle_sign_raw_message(
         return Err(EnclaveError::InvalidRequest("message is empty".into()));
     }
 
-    // Hash the raw message with keccak256 to produce a 32-byte digest
+    // EIP-191 personal_sign envelope: keccak256("\x19Ethereum Signed Message:\n" || len || msg).
+    // The 0x19 prefix byte is not a valid first byte for any Ethereum transaction
+    // envelope (legacy RLP starts at 0xc0+, typed txs use 0x01..=0x7f), so a
+    // signature produced here can never be replayed as a transaction signature
+    // — which is the whole point of EIP-191 and why this RPC must use it.
     use sha3::{Digest, Keccak256};
-    let hash: [u8; 32] = Keccak256::digest(&req.message).into();
+    let mut hasher = Keccak256::new();
+    hasher.update(b"\x19Ethereum Signed Message:\n");
+    hasher.update(req.message.len().to_string().as_bytes());
+    hasher.update(&req.message);
+    let hash: [u8; 32] = hasher.finalize().into();
     let signature = state.sign_evm(&hash)?;
 
     tracing::info!(
         sig_hex = %hex::encode(signature),
         msg_len = req.message.len(),
-        "raw message signature produced"
+        "raw message signature produced (EIP-191)"
     );
 
     Ok(EnclaveResponse {

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -826,7 +826,16 @@ fn test_sign_raw_message_recoverable() {
         other => panic!("expected RawSignatureResponse, got {:?}", other),
     };
 
-    let msg_hash: [u8; 32] = Keccak256::digest(&message).into();
+    // EIP-191 personal_sign envelope: the enclave hashes
+    // `"\x19Ethereum Signed Message:\n" || len(msg) || msg`, NOT raw keccak(msg).
+    // The verifier MUST rebuild the same preimage, otherwise pubkey recovery
+    // returns a different address.
+    let mut hasher = Keccak256::new();
+    hasher.update(b"\x19Ethereum Signed Message:\n");
+    hasher.update(message.len().to_string().as_bytes());
+    hasher.update(&message);
+    let msg_hash: [u8; 32] = hasher.finalize().into();
+
     let signature = K256Signature::from_slice(&sig_bytes[..64]).unwrap();
     let recovery_id = RecoveryId::from_byte(sig_bytes[64]).unwrap();
     let recovered_key =
@@ -838,7 +847,22 @@ fn test_sign_raw_message_recoverable() {
 
     assert_eq!(
         recovered_address, evm_address,
-        "recovered address must match the enclave's EVM address"
+        "recovered address must match the enclave's EVM address — verifier must use the EIP-191 preimage"
+    );
+
+    // Sanity: raw-keccak preimage must NOT recover to the same address. If this
+    // ever passes, the enclave dropped the EIP-191 prefix and is back to
+    // signing arbitrary digests — i.e. the eth_sign tx-forgery hole is open.
+    let raw_hash: [u8; 32] = Keccak256::digest(&message).into();
+    let raw_recovered = VerifyingKey::recover_from_prehash(&raw_hash, &signature, recovery_id).ok();
+    let raw_address = raw_recovered.map(|k| {
+        let pk_bytes = k.to_encoded_point(false);
+        Keccak256::digest(&pk_bytes.as_bytes()[1..])[12..].to_vec()
+    });
+    assert_ne!(
+        raw_address.as_deref(),
+        Some(evm_address.as_slice()),
+        "raw-keccak recovery must NOT match enclave address — EIP-191 prefix is missing"
     );
 }
 


### PR DESCRIPTION
The handler previously hashed the raw message with keccak256 and signed the result. That digest lives in the same preimage space as an RLP-encoded Ethereum transaction, so any caller of this RPC could submit `rlp(tx)` as the message and receive a valid transaction signature — bypassing every cross-check on signEvm.

Prefix the message with `"\x19Ethereum Signed Message:\n" || len(msg)` before hashing (EIP-191 personal_sign envelope). The 0x19 byte is not a valid first byte for any Ethereum transaction envelope (legacy RLP starts at 0xc0+, typed txs at 0x01..=0x7f), so the signature space is disjoint from tx signatures.

## Summary

- [enclave/src/server.rs](enclave/src/server.rs) `handle_sign_raw_message` — prefix EIP-191 envelope before keccak256, then sign the resulting 32-byte digest. Empty-message rejection unchanged.
- [enclave/tests/test_signing.rs](enclave/tests/test_signing.rs) `test_sign_raw_message_recoverable` — verifier now reconstructs the EIP-191 preimage (`"\x19Ethereum Signed Message:\n" || len || msg`) before pubkey recovery, plus a guardrail assert that raw-keccak recovery does NOT match — a regression alarm if the prefix is ever dropped.

## Contract-side dependency

On-chain verifiers of this signature must hash with the same EIP-191 preimage (OpenZeppelin: `ECDSA.toEthSignedMessageHash`) (@sh3ifu). Currently no listener / contract path consumes this signature, so there is no in-flight breakage; the change closes the hole before that path lands.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo test -p utexo-bridge-enclave --features mock-attestation,allow-seed-import` — includes the updated `test_sign_raw_message_recoverable` (gated on `allow-seed-import` since recovery needs a known seed).