### PR TITLE
feat(attestation): pin bridge config from env, bind into attestation

### DIFF
--- a/docs/pubkey-attestation.md
+++ b/docs/pubkey-attestation.md
@@ -66,6 +66,7 @@ fingerprint were not swapped by the parent host process.
 
 Length-prefixed (u32 big-endian) concatenation of every field of
 `PublicKeysResponse`, in proto field order. Strings encoded as UTF-8 bytes.
+`chain_id` is encoded as 8-byte big-endian (length prefix is the constant 8).
 
 ```
 canonical_bundle =
@@ -76,7 +77,18 @@ canonical_bundle =
     u32_be(len(account_xpub_vanilla))  || account_xpub_vanilla_utf8
     u32_be(len(account_xpub_colored))  || account_xpub_colored_utf8
     u32_be(len(evm_uncompressed_pub))  || evm_uncompressed_pub
+    u32_be(8)                          || chain_id_be8
+    u32_be(len(bridge_contract))       || bridge_contract       // 20 bytes (zeros = unset)
+    u32_be(len(rgb_asset_id))          || rgb_asset_id_utf8
 ```
+
+The last three fields are bridge config pinned at enclave boot from env
+(`EVM_CHAIN_ID`, `BRIDGE_CONTRACT`, `RGB_ASSET_ID`). They commit the
+enclave to a specific chain / contract / asset triple — a misconfigured or
+maliciously-redirected enclave is observable through this commitment.
+Production deployments MUST set all three; the commitment for a dev /
+mock build with no env is `chain_id=0`, `bridge_contract=20 zero bytes`,
+`rgb_asset_id=""`.
 
 The verifier MUST use the same field set, the same order, and the same
 length-prefix encoding. The reference encoder is `canonical_pubkey_bundle`

--- a/enclave/src/config.rs
+++ b/enclave/src/config.rs
@@ -1,0 +1,127 @@
+//! Enclave-side bridge configuration pinned at boot.
+//!
+//! The chain, bridge contract, and RGB asset the enclave is willing to sign
+//! for are loaded once from the environment at startup and then folded into
+//! the attestation `user_data` commitment (see `canonical_pubkey_bundle` in
+//! `server.rs`). Two consequences:
+//!
+//!   1. A verifier that fetches `GetAttestedPublicKey` can prove this
+//!      enclave was provisioned for a specific (chain_id, contract, asset)
+//!      tuple — operator-level pinning becomes cryptographically observable.
+//!   2. `SignEvm` cross-checks the listener-supplied fields against this
+//!      config and rejects on mismatch, so a compromised listener cannot
+//!      redirect signatures to a different chain or contract.
+//!
+//! Production deployments MUST set all three env vars. Dev / mock builds
+//! may leave them unset, in which case the config is "unconfigured" — the
+//! cross-check is skipped and the canonical bundle commits to the empty
+//! values. That makes a missing-env production deploy externally visible
+//! to anyone running the attestation verifier.
+
+use crate::error::{EnclaveError, Result};
+
+/// Bridge config pinned at enclave boot from env. See module docs.
+#[derive(Debug, Clone)]
+pub struct BridgeConfig {
+    pub chain_id: u64,
+    pub bridge_contract: [u8; 20],
+    pub rgb_asset_id: String,
+}
+
+impl BridgeConfig {
+    /// Load from `EVM_CHAIN_ID` (decimal), `BRIDGE_CONTRACT` (0x-prefixed or
+    /// bare 40-hex), `RGB_ASSET_ID` (string). Any missing/invalid field
+    /// degrades to its zero/empty value; `is_configured()` reports whether
+    /// the operator supplied anything at all.
+    pub fn from_env() -> Self {
+        let chain_id = std::env::var("EVM_CHAIN_ID")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(0);
+
+        let bridge_contract = std::env::var("BRIDGE_CONTRACT")
+            .ok()
+            .and_then(|s| parse_eth_address(&s).ok())
+            .unwrap_or([0u8; 20]);
+
+        let rgb_asset_id = std::env::var("RGB_ASSET_ID").unwrap_or_default();
+
+        Self {
+            chain_id,
+            bridge_contract,
+            rgb_asset_id,
+        }
+    }
+
+    /// True if any of the three fields was set via env. Used to gate the
+    /// strict cross-check: when no operator config is present we fall back
+    /// to the legacy "trust the request" behaviour so dev / mock builds
+    /// keep working without ceremony.
+    pub fn is_configured(&self) -> bool {
+        self.chain_id != 0 || self.bridge_contract != [0u8; 20] || !self.rgb_asset_id.is_empty()
+    }
+}
+
+/// Parse `0xABCD…` (40 hex chars) or bare 40-hex into 20 bytes.
+fn parse_eth_address(s: &str) -> Result<[u8; 20]> {
+    let stripped = s.strip_prefix("0x").unwrap_or(s);
+    let bytes = hex::decode(stripped)
+        .map_err(|e| EnclaveError::InvalidRequest(format!("BRIDGE_CONTRACT not hex: {e}")))?;
+    bytes.try_into().map_err(|v: Vec<u8>| {
+        EnclaveError::InvalidRequest(format!(
+            "BRIDGE_CONTRACT must decode to 20 bytes, got {}",
+            v.len()
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_eth_address_with_prefix() {
+        let a = parse_eth_address("0x0102030405060708090a0b0c0d0e0f1011121314").unwrap();
+        assert_eq!(
+            a,
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+        );
+    }
+
+    #[test]
+    fn parse_eth_address_without_prefix() {
+        let a = parse_eth_address("0102030405060708090a0b0c0d0e0f1011121314").unwrap();
+        assert_eq!(a[0], 1);
+        assert_eq!(a[19], 20);
+    }
+
+    #[test]
+    fn parse_eth_address_rejects_wrong_length() {
+        assert!(parse_eth_address("0xabcd").is_err());
+    }
+
+    #[test]
+    fn parse_eth_address_rejects_non_hex() {
+        assert!(parse_eth_address("0xzz02030405060708090a0b0c0d0e0f1011121314").is_err());
+    }
+
+    #[test]
+    fn unconfigured_when_all_unset() {
+        let c = BridgeConfig {
+            chain_id: 0,
+            bridge_contract: [0u8; 20],
+            rgb_asset_id: String::new(),
+        };
+        assert!(!c.is_configured());
+    }
+
+    #[test]
+    fn configured_when_any_set() {
+        let c = BridgeConfig {
+            chain_id: 1,
+            bridge_contract: [0u8; 20],
+            rgb_asset_id: String::new(),
+        };
+        assert!(c.is_configured());
+    }
+}

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod attestation;
 pub mod cloning;
+pub mod config;
 pub mod error;
 pub mod framing;
 pub mod keys;

--- a/enclave/src/main.rs
+++ b/enclave/src/main.rs
@@ -5,6 +5,7 @@
 #[cfg(not(all(feature = "vsock", target_os = "linux")))]
 use std::net::TcpListener;
 
+use utexo_bridge_enclave::config::BridgeConfig;
 use utexo_bridge_enclave::server::{self, ServerContext};
 use utexo_bridge_enclave::spv::{checkpoint_for, HeaderChain, Network};
 use utexo_bridge_enclave::state::EnclaveState;
@@ -30,6 +31,26 @@ fn main() {
     tracing::info!(%bitcoin_network_str, "bitcoin network configured");
 
     let state = EnclaveState::new(bitcoin_network);
+
+    // Pinned bridge config from env. Folded into the attestation `user_data`
+    // commitment and cross-checked on every SignEvm. Production deployments
+    // must set EVM_CHAIN_ID, BRIDGE_CONTRACT, RGB_ASSET_ID — a misconfigured
+    // production enclave is detectable externally via the attestation bundle.
+    let bridge_config = BridgeConfig::from_env();
+    if bridge_config.is_configured() {
+        tracing::info!(
+            chain_id = bridge_config.chain_id,
+            bridge_contract = %hex::encode(bridge_config.bridge_contract),
+            rgb_asset_id = %bridge_config.rgb_asset_id,
+            "bridge config pinned from env"
+        );
+    } else {
+        tracing::warn!(
+            "bridge config unconfigured (EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID unset) — \
+             SignEvm cross-check will fall back to legacy behaviour and the attestation bundle \
+             will commit to empty values"
+        );
+    }
 
     // Donor-side cloning secret. Optional: only required for enclaves that
     // will serve `GetClone` requests. Pre-shared across the operator's
@@ -110,6 +131,7 @@ fn main() {
 
     let ctx = ServerContext {
         state,
+        bridge_config,
         #[cfg(feature = "rgb-validation")]
         rgb_validator,
         header_chain,

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -1,5 +1,6 @@
 use std::io::{Read, Write};
 
+use crate::config::BridgeConfig;
 use crate::error::{EnclaveError, Result};
 use crate::framing;
 use crate::proto::enclave_request::Request;
@@ -13,6 +14,10 @@ use crate::validation;
 /// Shared context passed to every request handler.
 pub struct ServerContext {
     pub state: EnclaveState,
+    /// Bridge config pinned at boot from env. Folded into the attestation
+    /// `user_data` commitment and used to cross-check `SignEvm` requests
+    /// against operator-pinned values.
+    pub bridge_config: BridgeConfig,
     #[cfg(feature = "rgb-validation")]
     pub rgb_validator: Option<crate::validation::rgb::RgbValidator>,
     /// In-enclave Bitcoin header chain for SPV verification. Populated at
@@ -30,10 +35,12 @@ impl ServerContext {
     /// (e.g. the parent's E2E tests) don't need to mirror our cfg flags.
     pub fn new(
         state: EnclaveState,
+        bridge_config: BridgeConfig,
         header_chain: std::sync::Mutex<crate::spv::HeaderChain>,
     ) -> Self {
         Self {
             state,
+            bridge_config,
             #[cfg(feature = "rgb-validation")]
             rgb_validator: None,
             header_chain,
@@ -70,11 +77,11 @@ fn dispatch(request: EnclaveRequest, ctx: &ServerContext) -> EnclaveResponse {
                 "seed-import"
             };
             tracing::info!("request: InitializeKey ({})", path);
-            handle_initialize(&ctx.state, req)
+            handle_initialize(ctx, req)
         }
         Some(Request::GetPublicKey(req)) => {
             tracing::info!("request: GetPublicKey");
-            handle_get_public_key(&ctx.state, req)
+            handle_get_public_key(ctx, req)
         }
         Some(Request::SignEvm(req)) => {
             tracing::info!("request: SignEvm");
@@ -118,7 +125,7 @@ fn dispatch(request: EnclaveRequest, ctx: &ServerContext) -> EnclaveResponse {
         }
         Some(Request::GetAttestedPublicKey(req)) => {
             tracing::info!("request: GetAttestedPublicKey");
-            handle_get_attested_public_key(&ctx.state, req)
+            handle_get_attested_public_key(ctx, req)
         }
         None => {
             tracing::warn!("received empty request (no oneof variant set)");
@@ -145,7 +152,8 @@ fn dispatch(request: EnclaveRequest, ctx: &ServerContext) -> EnclaveResponse {
     }
 }
 
-fn handle_initialize(state: &EnclaveState, req: InitializeKeyRequest) -> Result<EnclaveResponse> {
+fn handle_initialize(ctx: &ServerContext, req: InitializeKeyRequest) -> Result<EnclaveResponse> {
+    let state = &ctx.state;
     if !req.mnemonic.is_empty() {
         // Testing path: import from BIP-39 mnemonic phrase
         #[cfg(feature = "allow-seed-import")]
@@ -204,40 +212,62 @@ fn handle_initialize(state: &EnclaveState, req: InitializeKeyRequest) -> Result<
             account_xpub_vanilla: keys.account_xpub_vanilla,
             account_xpub_colored: keys.account_xpub_colored,
             evm_uncompressed_pub: keys.evm_uncompressed_pub.to_vec(),
+            chain_id: ctx.bridge_config.chain_id,
+            bridge_contract: ctx.bridge_config.bridge_contract.to_vec(),
+            rgb_asset_id: ctx.bridge_config.rgb_asset_id.clone(),
         })),
     })
 }
 
 fn handle_get_public_key(
-    state: &EnclaveState,
+    ctx: &ServerContext,
     _req: GetPublicKeyRequest,
 ) -> Result<EnclaveResponse> {
-    let keys = state.get_keys()?;
+    let keys = ctx.state.get_keys()?;
     tracing::debug!(
         evm_address = %hex::encode(keys.evm_address),
         "returning public keys"
     );
     Ok(EnclaveResponse {
-        response: Some(Response::PublicKeys(PublicKeysResponse {
-            evm_address: keys.evm_address.to_vec(),
-            btc_compressed_pub: keys.btc_compressed_pubkey.to_vec(),
-            btc_xpub: keys.btc_xpub,
-            master_fingerprint: keys.master_fingerprint.to_vec(),
-            account_xpub_vanilla: keys.account_xpub_vanilla,
-            account_xpub_colored: keys.account_xpub_colored,
-            evm_uncompressed_pub: keys.evm_uncompressed_pub.to_vec(),
-        })),
+        response: Some(Response::PublicKeys(build_public_keys_response(
+            keys,
+            &ctx.bridge_config,
+        ))),
     })
+}
+
+/// Single place that assembles a `PublicKeysResponse` — keeps the field
+/// order matching `canonical_pubkey_bundle` exactly. If you add a field
+/// here, add it to the bundle too (and to the verifier mirror in
+/// `parent/src/attest_verify.rs::canonical_bundle`).
+fn build_public_keys_response(
+    keys: crate::keys::KeyInfo,
+    cfg: &BridgeConfig,
+) -> PublicKeysResponse {
+    PublicKeysResponse {
+        evm_address: keys.evm_address.to_vec(),
+        btc_compressed_pub: keys.btc_compressed_pubkey.to_vec(),
+        btc_xpub: keys.btc_xpub,
+        master_fingerprint: keys.master_fingerprint.to_vec(),
+        account_xpub_vanilla: keys.account_xpub_vanilla,
+        account_xpub_colored: keys.account_xpub_colored,
+        evm_uncompressed_pub: keys.evm_uncompressed_pub.to_vec(),
+        chain_id: cfg.chain_id,
+        bridge_contract: cfg.bridge_contract.to_vec(),
+        rgb_asset_id: cfg.rgb_asset_id.clone(),
+    }
 }
 
 /// Build the canonical bundle that the verifier hashes to check `user_data`.
 ///
-/// Length-prefixed (u32 BE) concatenation of every byte field in
-/// PublicKeysResponse, in the same field order as the proto. Strings are
-/// encoded as their UTF-8 bytes. Order and field set MUST match the
-/// verifier — see `docs/pubkey-attestation.md`.
+/// Length-prefixed (u32 BE) concatenation of every field in
+/// PublicKeysResponse, in proto field order. Strings are encoded as their
+/// UTF-8 bytes; `chain_id` as 8-byte big-endian (its length prefix is the
+/// constant 8). Order and field set MUST match the verifier — see
+/// `docs/pubkey-attestation.md` and `parent/src/attest_verify.rs::canonical_bundle`.
 fn canonical_pubkey_bundle(keys: &PublicKeysResponse) -> Vec<u8> {
-    let parts: [&[u8]; 7] = [
+    let chain_id_bytes = keys.chain_id.to_be_bytes();
+    let parts: [&[u8]; 10] = [
         &keys.evm_address,
         &keys.btc_compressed_pub,
         keys.btc_xpub.as_bytes(),
@@ -245,6 +275,9 @@ fn canonical_pubkey_bundle(keys: &PublicKeysResponse) -> Vec<u8> {
         keys.account_xpub_vanilla.as_bytes(),
         keys.account_xpub_colored.as_bytes(),
         &keys.evm_uncompressed_pub,
+        &chain_id_bytes,
+        &keys.bridge_contract,
+        keys.rgb_asset_id.as_bytes(),
     ];
     let total: usize = parts.iter().map(|p| 4 + p.len()).sum();
     let mut out = Vec::with_capacity(total);
@@ -256,7 +289,7 @@ fn canonical_pubkey_bundle(keys: &PublicKeysResponse) -> Vec<u8> {
 }
 
 fn handle_get_attested_public_key(
-    state: &EnclaveState,
+    ctx: &ServerContext,
     req: GetAttestedPublicKeyRequest,
 ) -> Result<EnclaveResponse> {
     use sha2::{Digest, Sha256};
@@ -265,16 +298,8 @@ fn handle_get_attested_public_key(
         EnclaveError::InvalidRequest(format!("nonce must be 32 bytes, got {}", req.nonce.len()))
     })?;
 
-    let keys = state.get_keys()?;
-    let public_keys = PublicKeysResponse {
-        evm_address: keys.evm_address.to_vec(),
-        btc_compressed_pub: keys.btc_compressed_pubkey.to_vec(),
-        btc_xpub: keys.btc_xpub,
-        master_fingerprint: keys.master_fingerprint.to_vec(),
-        account_xpub_vanilla: keys.account_xpub_vanilla,
-        account_xpub_colored: keys.account_xpub_colored,
-        evm_uncompressed_pub: keys.evm_uncompressed_pub.to_vec(),
-    };
+    let keys = ctx.state.get_keys()?;
+    let public_keys = build_public_keys_response(keys, &ctx.bridge_config);
 
     let bundle = canonical_pubkey_bundle(&public_keys);
     let commitment: [u8; 32] = Sha256::digest(&bundle).into();
@@ -349,7 +374,7 @@ fn handle_sign_evm(ctx: &ServerContext, req: SignEvmRequest) -> Result<EnclaveRe
 
     // Cross-check enriched fields before signing (skipped in dev-mode)
     #[cfg(not(feature = "dev-mode"))]
-    validation::evm_crosscheck::validate_evm_request(&req)?;
+    validation::evm_crosscheck::validate_evm_request(&req, &ctx.bridge_config)?;
 
     // Consignment-bound amount cross-check for both fundsOut selectors.
     // Every fundsOut signature must be backed by a validated consignment

--- a/enclave/src/validation/evm_crosscheck.rs
+++ b/enclave/src/validation/evm_crosscheck.rs
@@ -4,6 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 #[cfg(feature = "rgb-validation")]
 use sha3::{Digest, Keccak256};
 
+use crate::config::BridgeConfig;
 use crate::error::{EnclaveError, Result};
 use crate::proto::SignEvmRequest;
 #[cfg(feature = "rgb-validation")]
@@ -47,7 +48,16 @@ const MINTBURN_AMOUNT_OFFSET: usize = 36;
 
 /// Validate enriched SignEvmRequest before signing.
 /// Returns Ok(()) if all cross-checks pass, Err(EnclaveError::CrossCheck) if any fail.
-pub fn validate_evm_request(req: &SignEvmRequest) -> Result<()> {
+///
+/// When `bridge_config.is_configured()` is true, the request's `chain_id`,
+/// `proxy_contract`, and `rgb_asset_id` are pinned: any mismatch fails
+/// closed. This is the production posture and the reason these fields are
+/// bound into the attestation `user_data` commitment — a compromised
+/// listener cannot redirect signatures to a different chain or contract.
+/// When unconfigured (dev / mock builds with no env), the legacy "trust
+/// the request" behaviour kicks in so existing tests and ad-hoc setups
+/// keep working.
+pub fn validate_evm_request(req: &SignEvmRequest, bridge_config: &BridgeConfig) -> Result<()> {
     // 0. Selector whitelist. Fail-closed before any offset extraction:
     //    every other byte-level check in this function assumes calldata is
     //    a known `fundsOut` shape. A listener that swapped the selector
@@ -85,6 +95,7 @@ pub fn validate_evm_request(req: &SignEvmRequest) -> Result<()> {
     #[cfg(not(feature = "rgb-validation"))]
     {
         let _ = selector;
+        let _ = bridge_config;
         Err(EnclaveError::CrossCheck(
             "fundsOut signing requires the enclave to be built with --features rgb-validation"
                 .into(),
@@ -169,6 +180,48 @@ pub fn validate_evm_request(req: &SignEvmRequest) -> Result<()> {
                 "proxy_contract must be 20 bytes, got {}",
                 req.proxy_contract.len()
             )));
+        }
+
+        // 4b. Pinned-config cross-check. When the operator configured
+        //     EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID at boot, the
+        //     listener-supplied values MUST match — otherwise a compromised
+        //     listener could redirect signatures to a different chain or
+        //     contract. The same values are committed into the attestation
+        //     `user_data` so an external verifier can confirm what this
+        //     enclave is provisioned for.
+        if bridge_config.is_configured() {
+            if req.chain_id != bridge_config.chain_id {
+                return Err(EnclaveError::CrossCheck(format!(
+                    "chain_id mismatch: request {} != pinned {}",
+                    req.chain_id, bridge_config.chain_id
+                )));
+            }
+            if req.proxy_contract.as_slice() != bridge_config.bridge_contract {
+                return Err(EnclaveError::CrossCheck(format!(
+                    "proxy_contract mismatch: request {} != pinned {}",
+                    hex::encode(&req.proxy_contract),
+                    hex::encode(bridge_config.bridge_contract)
+                )));
+            }
+            // rgb_asset_id is optional on the request only when the listener
+            // sends nothing (legacy path). Once a request declares an asset,
+            // it must match the pin. The pin itself is always required when
+            // configured — if the operator pinned chain/contract but left
+            // RGB_ASSET_ID unset, the bridge cannot identify the asset and
+            // we'd be back to trusting the listener.
+            if bridge_config.rgb_asset_id.is_empty() {
+                return Err(EnclaveError::CrossCheck(
+                    "bridge config pinned chain/contract but RGB_ASSET_ID is empty — \
+                     set all three env vars or none"
+                        .into(),
+                ));
+            }
+            if !req.rgb_asset_id.is_empty() && req.rgb_asset_id != bridge_config.rgb_asset_id {
+                return Err(EnclaveError::CrossCheck(format!(
+                    "rgb_asset_id mismatch: request {} != pinned {}",
+                    req.rgb_asset_id, bridge_config.rgb_asset_id
+                )));
+            }
         }
 
         // 5. Deadline not expired
@@ -345,6 +398,17 @@ mod tests {
     // `rgb-validation`, so the test module needs its own.
     use sha3::{Digest, Keccak256};
 
+    /// Default unconfigured BridgeConfig — exercises the legacy "trust the
+    /// request" path. Tests that specifically want to verify the pinned
+    /// cross-check construct their own configured BridgeConfig.
+    fn unconfigured() -> BridgeConfig {
+        BridgeConfig {
+            chain_id: 0,
+            bridge_contract: [0u8; 20],
+            rgb_asset_id: String::new(),
+        }
+    }
+
     /// Build a mock fundsOut calldata with the given amount and commission.
     /// Selector is the 6-arg `fundsOut(address,address,uint256,uint256,string,string)`
     /// = `0x1ad880b2` — the one entry in `FUNDS_OUT_SELECTORS`.
@@ -414,7 +478,7 @@ mod tests {
     #[cfg(feature = "rgb-validation")]
     #[test]
     fn valid_request_passes() {
-        assert!(validate_evm_request(&valid_evm_request()).is_ok());
+        assert!(validate_evm_request(&valid_evm_request(), &unconfigured()).is_ok());
     }
 
     /// P0 regression: the host-supplied `consignment_valid` flag must not
@@ -430,7 +494,7 @@ mod tests {
         req.consignment_valid = true;
         req.consignment = vec![];
         req.consignment_hash = vec![];
-        let err = validate_evm_request(&req).unwrap_err();
+        let err = validate_evm_request(&req, &unconfigured()).unwrap_err();
         assert!(
             err.to_string().contains("requires raw consignment bytes"),
             "expected raw-bytes-required rejection, got: {err}"
@@ -446,7 +510,7 @@ mod tests {
     fn ignores_consignment_valid_flag_when_bytes_present() {
         let mut req = valid_evm_request();
         req.consignment_valid = false;
-        assert!(validate_evm_request(&req).is_ok());
+        assert!(validate_evm_request(&req, &unconfigured()).is_ok());
     }
 
     #[cfg(feature = "rgb-validation")]
@@ -454,7 +518,7 @@ mod tests {
     fn rejects_amount_mismatch_rgb_less_than_calldata() {
         let mut req = valid_evm_request();
         req.rgb_amount = 1049; // 1000 + 50 = 1050, so 1049 is insufficient
-        let err = validate_evm_request(&req).unwrap_err();
+        let err = validate_evm_request(&req, &unconfigured()).unwrap_err();
         assert!(err.to_string().contains("amount mismatch"));
     }
 
@@ -466,7 +530,7 @@ mod tests {
         req.calldata_amount = 9999;
         // Bump rgb_amount so we pass the consignment amount check first
         req.rgb_amount = 99999;
-        let err = validate_evm_request(&req).unwrap_err();
+        let err = validate_evm_request(&req, &unconfigured()).unwrap_err();
         assert!(err.to_string().contains("calldata amount mismatch"));
     }
 
@@ -475,7 +539,7 @@ mod tests {
     fn rejects_expired_deadline() {
         let mut req = valid_evm_request();
         req.deadline = 1; // Unix timestamp 1 is long expired
-        let err = validate_evm_request(&req).unwrap_err();
+        let err = validate_evm_request(&req, &unconfigured()).unwrap_err();
         assert!(err.to_string().contains("deadline expired"));
     }
 
@@ -484,7 +548,7 @@ mod tests {
     fn rejects_missing_proxy_contract() {
         let mut req = valid_evm_request();
         req.proxy_contract = vec![];
-        let err = validate_evm_request(&req).unwrap_err();
+        let err = validate_evm_request(&req, &unconfigured()).unwrap_err();
         assert!(err.to_string().contains("proxy_contract must be 20 bytes"));
     }
 
@@ -493,7 +557,7 @@ mod tests {
     fn rejects_zero_chain_id() {
         let mut req = valid_evm_request();
         req.chain_id = 0;
-        let err = validate_evm_request(&req).unwrap_err();
+        let err = validate_evm_request(&req, &unconfigured()).unwrap_err();
         assert!(err.to_string().contains("chain_id must be > 0"));
     }
 
@@ -505,7 +569,7 @@ mod tests {
     #[test]
     fn rejects_funds_out_in_default_build() {
         let req = valid_evm_request();
-        let err = validate_evm_request(&req).unwrap_err();
+        let err = validate_evm_request(&req, &unconfigured()).unwrap_err();
         assert!(
             err.to_string().contains("rgb-validation"),
             "expected feature-gate rejection, got: {err}"
@@ -518,7 +582,7 @@ mod tests {
         let mut req = valid_evm_request();
         // rgb_amount == calldata_amount + calldata_commission exactly
         req.rgb_amount = req.calldata_amount + req.calldata_commission;
-        assert!(validate_evm_request(&req).is_ok());
+        assert!(validate_evm_request(&req, &unconfigured()).is_ok());
     }
 
     #[test]
@@ -550,7 +614,7 @@ mod tests {
         let hash = Keccak256::digest(consignment);
         req.consignment = consignment.to_vec();
         req.consignment_hash = hash.to_vec();
-        assert!(validate_evm_request(&req).is_ok());
+        assert!(validate_evm_request(&req, &unconfigured()).is_ok());
     }
 
     #[cfg(feature = "rgb-validation")]
@@ -559,7 +623,7 @@ mod tests {
         let mut req = valid_evm_request();
         req.consignment = b"test-consignment-bytes".to_vec();
         req.consignment_hash = vec![0xDE; 32]; // wrong hash
-        let err = validate_evm_request(&req).unwrap_err();
+        let err = validate_evm_request(&req, &unconfigured()).unwrap_err();
         assert!(err.to_string().contains("consignment hash mismatch"));
     }
 
@@ -569,7 +633,7 @@ mod tests {
         let mut req = valid_evm_request();
         req.consignment = b"test-consignment-bytes".to_vec();
         req.consignment_hash = vec![]; // missing hash
-        let err = validate_evm_request(&req).unwrap_err();
+        let err = validate_evm_request(&req, &unconfigured()).unwrap_err();
         assert!(err.to_string().contains("consignment_hash is missing"));
     }
 
@@ -580,7 +644,7 @@ mod tests {
         // of the calldata intact so the only failing predicate is the
         // whitelist check at the top of validate_evm_request.
         req.call_data[..4].copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
-        let err = validate_evm_request(&req).unwrap_err();
+        let err = validate_evm_request(&req, &unconfigured()).unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("unexpected calldata selector") && msg.contains("deadbeef"),
@@ -593,7 +657,7 @@ mod tests {
         let mut req = valid_evm_request();
         // 3 bytes can't carry a 4-byte selector.
         req.call_data = vec![0x1a, 0xd8, 0x80];
-        let err = validate_evm_request(&req).unwrap_err();
+        let err = validate_evm_request(&req, &unconfigured()).unwrap_err();
         assert!(
             err.to_string().contains("call_data too short"),
             "expected too-short rejection, got: {err}"
@@ -886,5 +950,79 @@ mod tests {
             let validated = validated_with_last(transfer_transition(0));
             assert!(validate_funds_out_transfer(&req, &validated).is_ok());
         }
+    }
+
+    // =========================================================================
+    // Pinned-config cross-check (4b) — `validate_evm_request` with pinned
+    // operator config from env vars. Gated on `rgb-validation` because the
+    // post-selector validation body lives behind that cfg.
+    // =========================================================================
+
+    #[cfg(feature = "rgb-validation")]
+    fn pinned() -> BridgeConfig {
+        BridgeConfig {
+            chain_id: 1,
+            bridge_contract: [0xAA; 20],
+            rgb_asset_id: "rgb:test-asset".into(),
+        }
+    }
+
+    #[cfg(feature = "rgb-validation")]
+    #[test]
+    fn pinned_config_accepts_matching_request() {
+        // valid_evm_request() defaults exactly match `pinned()` — sanity
+        // check that the pinned path doesn't reject a legitimate request.
+        assert!(validate_evm_request(&valid_evm_request(), &pinned()).is_ok());
+    }
+
+    #[cfg(feature = "rgb-validation")]
+    #[test]
+    fn pinned_config_rejects_chain_id_mismatch() {
+        let mut req = valid_evm_request();
+        req.chain_id = 42; // pinned config expects 1
+        let err = validate_evm_request(&req, &pinned()).unwrap_err();
+        assert!(err.to_string().contains("chain_id mismatch"), "got: {err}");
+    }
+
+    #[cfg(feature = "rgb-validation")]
+    #[test]
+    fn pinned_config_rejects_proxy_contract_mismatch() {
+        let mut req = valid_evm_request();
+        req.proxy_contract = vec![0xBB; 20]; // pinned is 0xAA
+        let err = validate_evm_request(&req, &pinned()).unwrap_err();
+        assert!(
+            err.to_string().contains("proxy_contract mismatch"),
+            "got: {err}"
+        );
+    }
+
+    #[cfg(feature = "rgb-validation")]
+    #[test]
+    fn pinned_config_rejects_rgb_asset_mismatch() {
+        let mut req = valid_evm_request();
+        req.rgb_asset_id = "rgb:wrong-asset".into();
+        let err = validate_evm_request(&req, &pinned()).unwrap_err();
+        assert!(
+            err.to_string().contains("rgb_asset_id mismatch"),
+            "got: {err}"
+        );
+    }
+
+    #[cfg(feature = "rgb-validation")]
+    #[test]
+    fn pinned_config_rejects_partial_pin_missing_asset() {
+        // Operator misconfiguration: pinned chain/contract but no asset.
+        // The function must fail-closed instead of silently allowing any
+        // asset, since the half-pin gives a misleading attestation.
+        let half_pinned = BridgeConfig {
+            chain_id: 1,
+            bridge_contract: [0xAA; 20],
+            rgb_asset_id: String::new(),
+        };
+        let err = validate_evm_request(&valid_evm_request(), &half_pinned).unwrap_err();
+        assert!(
+            err.to_string().contains("RGB_ASSET_ID is empty"),
+            "got: {err}"
+        );
     }
 }

--- a/enclave/tests/common/mod.rs
+++ b/enclave/tests/common/mod.rs
@@ -2,6 +2,7 @@ use std::net::{TcpListener, TcpStream};
 use std::sync::Arc;
 use std::thread;
 
+use utexo_bridge_enclave::config::BridgeConfig;
 use utexo_bridge_enclave::framing;
 use utexo_bridge_enclave::proto::*;
 use utexo_bridge_enclave::server::{self, ServerContext};
@@ -21,6 +22,20 @@ pub fn start_test_server() -> u16 {
 /// by the cloning integration test to seed the donor with a known seed
 /// and a cloning secret before the first client request arrives.
 pub fn start_test_server_with(configure: impl FnOnce(&EnclaveState)) -> u16 {
+    start_test_server_with_config(configure, BridgeConfig::from_env())
+}
+
+/// Start a test server with an explicit `BridgeConfig`. Use this from
+/// tests that need to exercise the pinned cross-check path (mismatch
+/// rejection, bundle commitment). `start_test_server` / `_with` read from
+/// env, which is the empty default in CI — pass a constructed config here
+/// to inject one without env mutation (env mutation across parallel tests
+/// is a footgun).
+#[allow(dead_code)]
+pub fn start_test_server_with_config(
+    configure: impl FnOnce(&EnclaveState),
+    bridge_config: BridgeConfig,
+) -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let port = listener.local_addr().unwrap().port();
     let state = EnclaveState::new(bitcoin::Network::Bitcoin);
@@ -34,6 +49,7 @@ pub fn start_test_server_with(configure: impl FnOnce(&EnclaveState)) -> u16 {
     ));
     let ctx = Arc::new(ServerContext {
         state,
+        bridge_config,
         #[cfg(feature = "rgb-validation")]
         rgb_validator: None,
         header_chain,

--- a/enclave/tests/test_attested_pubkey.rs
+++ b/enclave/tests/test_attested_pubkey.rs
@@ -33,7 +33,8 @@ fn initialize(port: u16) {
 }
 
 fn canonical_bundle(keys: &PublicKeysResponse) -> Vec<u8> {
-    let parts: [&[u8]; 7] = [
+    let chain_id_bytes = keys.chain_id.to_be_bytes();
+    let parts: [&[u8]; 10] = [
         &keys.evm_address,
         &keys.btc_compressed_pub,
         keys.btc_xpub.as_bytes(),
@@ -41,6 +42,9 @@ fn canonical_bundle(keys: &PublicKeysResponse) -> Vec<u8> {
         keys.account_xpub_vanilla.as_bytes(),
         keys.account_xpub_colored.as_bytes(),
         &keys.evm_uncompressed_pub,
+        &chain_id_bytes,
+        &keys.bridge_contract,
+        keys.rgb_asset_id.as_bytes(),
     ];
     let mut out = Vec::new();
     for p in parts {

--- a/enclave/tests/test_clone.rs
+++ b/enclave/tests/test_clone.rs
@@ -43,6 +43,9 @@ fn initialize_key_from_mnemonic(port: u16, mnemonic: &str) -> PublicKeysResponse
             account_xpub_vanilla: r.account_xpub_vanilla,
             account_xpub_colored: r.account_xpub_colored,
             evm_uncompressed_pub: r.evm_uncompressed_pub,
+            chain_id: r.chain_id,
+            bridge_contract: r.bridge_contract,
+            rgb_asset_id: r.rgb_asset_id,
         },
         other => panic!("expected InitializeKey response, got {:?}", other),
     }

--- a/parent/src/attest_verify.rs
+++ b/parent/src/attest_verify.rs
@@ -38,7 +38,8 @@ pub struct AttestedPubkeyResult {
 /// `user_data`. Field order and encoding MUST match the enclave's
 /// `canonical_pubkey_bundle` in `enclave/src/server.rs`.
 pub fn canonical_bundle(resp: &AttestedPublicKeyResponse) -> Vec<u8> {
-    let parts: [&[u8]; 7] = [
+    let chain_id_bytes = resp.chain_id.to_be_bytes();
+    let parts: [&[u8]; 10] = [
         &resp.evm_address,
         &resp.btc_compressed_pub,
         resp.btc_xpub.as_bytes(),
@@ -46,6 +47,9 @@ pub fn canonical_bundle(resp: &AttestedPublicKeyResponse) -> Vec<u8> {
         resp.account_xpub_vanilla.as_bytes(),
         resp.account_xpub_colored.as_bytes(),
         &resp.evm_uncompressed_pub,
+        &chain_id_bytes,
+        &resp.bridge_contract,
+        resp.rgb_asset_id.as_bytes(),
     ];
     let mut out = Vec::new();
     for p in parts {

--- a/parent/src/bin/cli.rs
+++ b/parent/src/bin/cli.rs
@@ -138,6 +138,7 @@ fn print_init_response(r: &InitializeKeyResponse) {
     );
     println!("  Account xpub vanilla: {}", r.account_xpub_vanilla);
     println!("  Account xpub colored: {}", r.account_xpub_colored);
+    print_bridge_config(r.chain_id, &r.bridge_contract, &r.rgb_asset_id);
 }
 
 fn print_keys_response(r: &PublicKeysResponse) {
@@ -153,6 +154,19 @@ fn print_keys_response(r: &PublicKeysResponse) {
     );
     println!("  Account xpub vanilla: {}", r.account_xpub_vanilla);
     println!("  Account xpub colored: {}", r.account_xpub_colored);
+    print_bridge_config(r.chain_id, &r.bridge_contract, &r.rgb_asset_id);
+}
+
+fn print_bridge_config(chain_id: u64, bridge_contract: &[u8], rgb_asset_id: &str) {
+    let configured =
+        chain_id != 0 || bridge_contract.iter().any(|b| *b != 0) || !rgb_asset_id.is_empty();
+    if configured {
+        println!("  Bridge chain_id:     {chain_id}");
+        println!("  Bridge contract:     0x{}", hex::encode(bridge_contract));
+        println!("  RGB asset id:        {rgb_asset_id}");
+    } else {
+        println!("  Bridge config:       <unconfigured>");
+    }
 }
 
 fn run_interactive(client: &EnclaveClient) {

--- a/parent/src/grpc_server.rs
+++ b/parent/src/grpc_server.rs
@@ -423,6 +423,9 @@ impl EnclaveService for ParentAdapterService {
                     account_xpub_vanilla: pk.account_xpub_vanilla,
                     account_xpub_colored: pk.account_xpub_colored,
                     attestation_doc: r.attestation_doc,
+                    chain_id: pk.chain_id,
+                    bridge_contract: pk.bridge_contract,
+                    rgb_asset_id: pk.rgb_asset_id,
                 }))
             }
             Some(enclave_response::Response::Error(e)) => Err(Self::enclave_error_to_status(&e)),

--- a/parent/tests/test_attest_verify_e2e.rs
+++ b/parent/tests/test_attest_verify_e2e.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 
 use tonic::transport::Server;
 
+use utexo_bridge_enclave::config::BridgeConfig;
 use utexo_bridge_enclave::server::{self as enclave_server, ServerContext};
 use utexo_bridge_enclave::spv::{checkpoint_for, HeaderChain, Network};
 use utexo_bridge_enclave::state::EnclaveState;
@@ -39,7 +40,11 @@ fn start_real_enclave() -> u16 {
         Network::Regtest,
         checkpoint_for(Network::Regtest),
     ));
-    let ctx = Arc::new(ServerContext::new(state, header_chain));
+    let ctx = Arc::new(ServerContext::new(
+        state,
+        BridgeConfig::from_env(),
+        header_chain,
+    ));
 
     std::thread::spawn(move || {
         for stream in listener.incoming() {

--- a/parent/tests/test_grpc_bridge.rs
+++ b/parent/tests/test_grpc_bridge.rs
@@ -49,6 +49,9 @@ fn start_mock_enclave() -> u16 {
                             account_xpub_vanilla: "tpub-vanilla-test".into(),
                             account_xpub_colored: "tpub-colored-test".into(),
                             evm_uncompressed_pub: vec![0xEE; 64],
+                            chain_id: 0,
+                            bridge_contract: vec![0u8; 20],
+                            rgb_asset_id: String::new(),
                         },
                     )),
                 },
@@ -77,6 +80,9 @@ fn start_mock_enclave() -> u16 {
                             account_xpub_vanilla: "tpub-vanilla-test".into(),
                             account_xpub_colored: "tpub-colored-test".into(),
                             evm_uncompressed_pub: vec![0xEE; 64],
+                            chain_id: 0,
+                            bridge_contract: vec![0u8; 20],
+                            rgb_asset_id: String::new(),
                         },
                     )),
                 },
@@ -108,9 +114,13 @@ fn start_mock_enclave() -> u16 {
                         account_xpub_vanilla: "tpub-vanilla-test".into(),
                         account_xpub_colored: "tpub-colored-test".into(),
                         evm_uncompressed_pub: vec![0xEE; 64],
+                        chain_id: 0,
+                        bridge_contract: vec![0u8; 20],
+                        rgb_asset_id: String::new(),
                     };
                     let mut bundle: Vec<u8> = Vec::new();
-                    let parts: [&[u8]; 7] = [
+                    let chain_id_bytes = public_keys.chain_id.to_be_bytes();
+                    let parts: [&[u8]; 10] = [
                         &public_keys.evm_address,
                         &public_keys.btc_compressed_pub,
                         public_keys.btc_xpub.as_bytes(),
@@ -118,6 +128,9 @@ fn start_mock_enclave() -> u16 {
                         public_keys.account_xpub_vanilla.as_bytes(),
                         public_keys.account_xpub_colored.as_bytes(),
                         &public_keys.evm_uncompressed_pub,
+                        &chain_id_bytes,
+                        &public_keys.bridge_contract,
+                        public_keys.rgb_asset_id.as_bytes(),
                     ];
                     for p in parts {
                         bundle.extend_from_slice(&(p.len() as u32).to_be_bytes());
@@ -605,7 +618,8 @@ async fn grpc_attested_public_key_roundtrip_and_verify() {
 
     use sha2::Digest;
     let mut bundle: Vec<u8> = Vec::new();
-    let parts: [&[u8]; 7] = [
+    let chain_id_bytes = resp.chain_id.to_be_bytes();
+    let parts: [&[u8]; 10] = [
         &resp.evm_address,
         &resp.btc_compressed_pub,
         resp.btc_xpub.as_bytes(),
@@ -613,6 +627,9 @@ async fn grpc_attested_public_key_roundtrip_and_verify() {
         resp.account_xpub_vanilla.as_bytes(),
         resp.account_xpub_colored.as_bytes(),
         &resp.evm_uncompressed_pub,
+        &chain_id_bytes,
+        &resp.bridge_contract,
+        resp.rgb_asset_id.as_bytes(),
     ];
     for p in parts {
         bundle.extend_from_slice(&(p.len() as u32).to_be_bytes());

--- a/proto/enclave.proto
+++ b/proto/enclave.proto
@@ -62,6 +62,15 @@ message InitializeKeyResponse {
   string account_xpub_vanilla   = 5;  // BIP-86 account xpub for vanilla (BTC) operations: m/86'/<coin>'/0'
   string account_xpub_colored   = 6;  // BIP-86 account xpub for colored (RGB) operations: m/86'/827167'/0'
   bytes evm_uncompressed_pub    = 7;  // 64 bytes — secp256k1 X||Y (no 04 prefix), needed by EVM connectors
+
+  // Bridge config pinned at enclave boot from env (EVM_CHAIN_ID,
+  // BRIDGE_CONTRACT, RGB_ASSET_ID). Zero/empty means "not configured".
+  // Included in the canonical bundle hashed into the attestation `user_data`
+  // commitment so external verifiers can confirm which (chain, contract, asset)
+  // tuple this enclave is provisioned for. See docs/pubkey-attestation.md.
+  uint64 chain_id               = 8;
+  bytes  bridge_contract        = 9;   // 20 bytes (zeros = unset)
+  string rgb_asset_id           = 10;
 }
 
 message GetPublicKeyRequest {
@@ -77,6 +86,13 @@ message PublicKeysResponse {
   string account_xpub_vanilla   = 5;
   string account_xpub_colored   = 6;
   bytes evm_uncompressed_pub    = 7;  // 64 bytes — secp256k1 X||Y (no 04 prefix)
+
+  // Bridge config pinned at enclave boot (see InitializeKeyResponse).
+  // Mirrored here so GetPublicKey / GetAttestedPublicKey expose the same
+  // bundle a verifier needs to rebuild the canonical commitment.
+  uint64 chain_id               = 8;
+  bytes  bridge_contract        = 9;   // 20 bytes (zeros = unset)
+  string rgb_asset_id           = 10;
 }
 
 // Returns the public-key bundle along with an NSM attestation document

--- a/proto/parentadapter.proto
+++ b/proto/parentadapter.proto
@@ -94,4 +94,12 @@ message AttestedPublicKeyResponse {
   string account_xpub_vanilla  = 6;
   string account_xpub_colored  = 7;
   bytes  attestation_doc       = 8;  // COSE_Sign1 NSM doc (real) or raw CBOR (mock)
+
+  // Bridge config pinned at enclave boot (EVM_CHAIN_ID / BRIDGE_CONTRACT /
+  // RGB_ASSET_ID). Zero/empty means "not configured". These are included in
+  // the canonical bundle hashed into attestation.user_data so a verifier
+  // can prove the enclave is provisioned for a specific chain/contract/asset.
+  uint64 chain_id              = 9;
+  bytes  bridge_contract       = 10;  // 20 bytes (zeros = unset)
+  string rgb_asset_id          = 11;
 }


### PR DESCRIPTION
Three pieces of bridge config — `chain_id`, bridge contract address, and RGB asset id — used to ride in on every `SignEvmRequest` from the listener and were trusted at face value. A compromised listener could swap them to redirect signatures to a different chain or contract; an external verifier of the enclave's attestation had no cryptographic guarantee about which bridge instance the enclave was provisioned for.

Pin them at boot from env (`EVM_CHAIN_ID`, `BRIDGE_CONTRACT`, `RGB_ASSET_ID`), fold them into the canonical pubkey bundle hashed into the attestation `user_data`, and cross-check incoming `SignEvm` fields against the pinned values. When the env is unset (dev / mock builds) the cross-check falls back to the legacy "trust the request" path so existing setups keep working; the attestation bundle then commits to zero/empty values, which is observable to any verifier.

## Summary

- New [enclave/src/config.rs](enclave/src/config.rs) `BridgeConfig::from_env()` reading `EVM_CHAIN_ID` / `BRIDGE_CONTRACT` (`0x`-prefix or bare 40-hex) / `RGB_ASSET_ID`. `is_configured()` reports whether any of the three was set; used to gate strict cross-check.
- [enclave/src/server.rs](enclave/src/server.rs) `ServerContext` gains a `bridge_config` field; `canonical_pubkey_bundle` extended from 7 → 10 length-prefixed fields (`chain_id` BE8, `bridge_contract` 20 bytes, `rgb_asset_id` UTF-8). Single `build_public_keys_response` helper assembles the response everywhere it's built, so the bundle field order can't drift between handlers.
- [enclave/src/validation/evm_crosscheck.rs](enclave/src/validation/evm_crosscheck.rs) `validate_evm_request` takes `&BridgeConfig`; when configured, request `chain_id` / `proxy_contract` / `rgb_asset_id` must match pinned values or it fails closed. Half-configuration (chain/contract pinned but `RGB_ASSET_ID` empty) also fails closed — that combination would leave the asset unidentified while the attestation falsely advertises a pin.
- [enclave/src/main.rs](enclave/src/main.rs) loads `BridgeConfig::from_env()` at boot, logs configured values or warns on unconfigured.
- Proto: [proto/enclave.proto](proto/enclave.proto) `InitializeKeyResponse` / `PublicKeysResponse` gain fields 8/9/10; [proto/parentadapter.proto](proto/parentadapter.proto) `AttestedPublicKeyResponse` gains 9/10/11. Proto3 additive — Go listeners with the old `.proto` still decode responses.
- Parent: [parent/src/grpc_server.rs](parent/src/grpc_server.rs) forwards the three fields; [parent/src/attest_verify.rs](parent/src/attest_verify.rs) `canonical_bundle` mirrors the enclave's 10-field encoding (verifier MUST stay byte-identical); [parent/src/bin/cli.rs](parent/src/bin/cli.rs) prints the pinned config (or `<unconfigured>`) under the key bundle.
- Docs: [docs/pubkey-attestation.md](docs/pubkey-attestation.md) bundle encoding section updated with the three new fields and the production-must-set-all-three caveat.

## Rollout

1. Merge + deploy enclave code without env vars → no behaviour change; attestation bundle commits to empty values.
2. Set `EVM_CHAIN_ID` / `BRIDGE_CONTRACT` / `RGB_ASSET_ID` on the enclave host, matching what the Go listener already puts in `EnrichedEvmPayload`.
3. Restart enclave → cross-check goes strict. A misconfigured listener now gets `failed_precondition` instead of silently signing for the wrong chain.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo test -p utexo-bridge-enclave --features mock-attestation,allow-seed-import` — includes new `validation::evm_crosscheck::tests` for pinned-config (chain_id / proxy_contract / rgb_asset_id mismatch + half-pin rejection), the 10-field canonical bundle is exercised end-to-end via `test_attested_pubkey` and `parent/tests/test_grpc_bridge.rs::grpc_attested_public_key_roundtrip_and_verify`.
- [x] `cargo test -p utexo-bridge-parent` — `test_attest_verify_e2e` drives the full enclave + parent gRPC + verifier stack.