### PR TITLE
chore(crosscheck): drop stale 'rgb-lib follow-up' comment

### DIFF
--- a/enclave/src/validation/evm_crosscheck.rs
+++ b/enclave/src/validation/evm_crosscheck.rs
@@ -74,8 +74,11 @@ pub fn validate_evm_request(req: &SignEvmRequest) -> Result<()> {
     }
 
     // 1b. If raw consignment bytes are present, verify hash integrity.
-    //     This catches tampering between Listener and Enclave.
-    //     Full RGB validation (rgb-lib) will be added in a follow-up PR.
+    //     This catches tampering between Listener and Enclave. Full RGB
+    //     validation (deserialize + `rgbstd::Transfer::validate` against
+    //     an Esplora resolver) runs earlier in `handle_sign_evm` when
+    //     built with `--features rgb-validation`; this hash check is the
+    //     defence-in-depth that always runs.
     if !req.consignment.is_empty() {
         if req.consignment_hash.is_empty() {
             return Err(EnclaveError::CrossCheck(


### PR DESCRIPTION
## Summary
- The comment at `enclave/src/validation/evm_crosscheck.rs` claimed full RGB validation would be added in a follow-up PR. That work already shipped — `RgbValidator::validate_consignment` runs `rgbstd::Transfer::validate` against an Esplora resolver from inside `handle_sign_evm` when built with `--features rgb-validation`.
- Rewrite the comment to describe what the surrounding hash check actually does (defence-in-depth tamper detection between Listener and Enclave) and point at where the real validation happens.

Follow-ups that delivered the validation this comment was waiting on:
- #10 — original in-enclave `RgbValidator` + `handle_sign_evm` wiring.
- #31 — SPV plumbed `witness_txids` / `chain_net` through `ValidatedConsignment`.
- #34 — F1 op_id + last-transition extraction.
- #41 — IFA `MS_BURNED_ASSET` burn-amount extraction (feeds `validate_funds_out_burn`).

## Test plan
- [ ] No behavioural change — comment-only edit; existing tests should pass unchanged.