### PR TITLE
evm msig fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 .claude/
+.idea/

--- a/enclave/src/keys.rs
+++ b/enclave/src/keys.rs
@@ -21,6 +21,8 @@ const RGB_COIN_TYPE: u32 = 827167;
 pub struct KeyInfo {
     pub evm_address: [u8; 20],
     pub evm_uncompressed_pub: [u8; 64],
+    pub evm_gas_tx_address: [u8; 20],
+    pub evm_gas_tx_uncompressed_pub: [u8; 64],
     pub btc_compressed_pubkey: [u8; 33],
     pub btc_xpub: String,
     pub master_fingerprint: [u8; 4],
@@ -40,9 +42,12 @@ pub enum AccountType {
 pub struct KeyManager {
     seed: SecretBox<[u8; 64]>,
     evm_secret: SecretBox<[u8; 32]>,
+    evm_gas_tx_secret: SecretBox<[u8; 32]>,
     btc_secret: SecretBox<[u8; 32]>,
     evm_address: [u8; 20],
     evm_uncompressed_pub: [u8; 64],
+    evm_gas_tx_address: [u8; 20],
+    evm_gas_tx_uncompressed_pub: [u8; 64],
     btc_compressed_pubkey: [u8; 33],
     btc_xpub: Xpub,
     // BIP-86 taproot account keys
@@ -117,6 +122,25 @@ impl KeyManager {
         let mut evm_address = [0u8; 20];
         evm_address.copy_from_slice(&hash[12..32]);
 
+        // === EVM Gas TX: m/44'/60'/0'/0/1 (separate key for gas transaction signing) ===
+        let evm_gas_tx_path = DerivationPath::from_str("m/44'/60'/0'/0/1")
+            .map_err(|e| EnclaveError::InvalidKey(format!("invalid EVM gas TX path: {}", e)))?;
+        let evm_gas_tx_xpriv = master.derive_priv(&secp, &evm_gas_tx_path).map_err(|e| {
+            EnclaveError::InvalidKey(format!("EVM gas TX derivation failed: {}", e))
+        })?;
+        let evm_gas_tx_secret_key = evm_gas_tx_xpriv.private_key;
+        let mut evm_gas_tx_secret_bytes = evm_gas_tx_secret_key.secret_bytes();
+        let evm_gas_tx_secret = SecretBox::new(Box::new(evm_gas_tx_secret_bytes));
+        evm_gas_tx_secret_bytes.zeroize();
+
+        let evm_gas_tx_pubkey = PublicKey::from_secret_key(&secp, &evm_gas_tx_secret_key);
+        let evm_gas_tx_uncompressed = evm_gas_tx_pubkey.serialize_uncompressed();
+        let mut evm_gas_tx_uncompressed_pub = [0u8; 64];
+        evm_gas_tx_uncompressed_pub.copy_from_slice(&evm_gas_tx_uncompressed[1..]);
+        let gas_tx_hash = Keccak256::digest(evm_gas_tx_uncompressed_pub);
+        let mut evm_gas_tx_address = [0u8; 20];
+        evm_gas_tx_address.copy_from_slice(&gas_tx_hash[12..32]);
+
         // === BTC Legacy: m/84'/0'/0'/0/0 (kept for backward compatibility) ===
         let btc_path = DerivationPath::from_str("m/84'/0'/0'/0/0")
             .map_err(|e| EnclaveError::InvalidKey(format!("invalid BTC path: {}", e)))?;
@@ -166,9 +190,12 @@ impl KeyManager {
         Ok(Self {
             seed: seed_box,
             evm_secret,
+            evm_gas_tx_secret,
             btc_secret,
             evm_address,
             evm_uncompressed_pub,
+            evm_gas_tx_address,
+            evm_gas_tx_uncompressed_pub,
             btc_compressed_pubkey,
             btc_xpub,
             master_fingerprint,
@@ -206,6 +233,14 @@ impl KeyManager {
 
     pub fn account_xpub_colored(&self) -> &Xpub {
         &self.account_xpub_colored
+    }
+
+    pub fn evm_gas_tx_address(&self) -> &[u8; 20] {
+        &self.evm_gas_tx_address
+    }
+
+    pub fn evm_gas_tx_uncompressed_pub(&self) -> &[u8; 64] {
+        &self.evm_gas_tx_uncompressed_pub
     }
 
     pub fn expose_seed(&self) -> &[u8; 64] {
@@ -271,6 +306,22 @@ impl KeyManager {
         let (signature, recovery_id) = signing_key
             .sign_prehash_recoverable(message_hash)
             .map_err(|e| EnclaveError::Signing(format!("ecdsa sign: {e}")))?;
+
+        let mut result = [0u8; 65];
+        result[..64].copy_from_slice(&signature.to_bytes());
+        result[64] = recovery_id.to_byte();
+        Ok(result)
+    }
+
+    /// Sign a 32-byte digest with the EVM gas TX key (m/44'/60'/0'/0/1).
+    /// Used exclusively for Ethereum gas transaction signing.
+    pub fn sign_evm_gas_tx(&self, message_hash: &[u8; 32]) -> Result<[u8; 65]> {
+        let signing_key = K256SigningKey::from_slice(self.evm_gas_tx_secret.expose_secret())
+            .map_err(|e| EnclaveError::Signing(format!("evm gas tx key: {e}")))?;
+
+        let (signature, recovery_id) = signing_key
+            .sign_prehash_recoverable(message_hash)
+            .map_err(|e| EnclaveError::Signing(format!("ecdsa sign gas tx: {e}")))?;
 
         let mut result = [0u8; 65];
         result[..64].copy_from_slice(&signature.to_bytes());

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -95,6 +95,10 @@ fn dispatch(request: EnclaveRequest, ctx: &ServerContext) -> EnclaveResponse {
             tracing::info!("request: SignRawMessage");
             handle_sign_raw_message(&ctx.state, req)
         }
+        Some(Request::SignRawDigest(req)) => {
+            tracing::info!("request: SignRawDigest");
+            handle_sign_raw_digest(&ctx.state, req)
+        }
         Some(Request::ProxyFederation(req)) => {
             tracing::info!("request: ProxyFederation");
             handle_proxy_federation(req)
@@ -198,6 +202,7 @@ fn handle_initialize(ctx: &ServerContext, req: InitializeKeyRequest) -> Result<E
     let keys = state.get_keys()?;
     tracing::info!(
         evm_address = %hex::encode(keys.evm_address),
+        evm_gas_tx_address = %hex::encode(keys.evm_gas_tx_address),
         master_fingerprint = %hex::encode(keys.master_fingerprint),
         account_xpub_vanilla = %keys.account_xpub_vanilla,
         account_xpub_colored = %keys.account_xpub_colored,
@@ -215,6 +220,8 @@ fn handle_initialize(ctx: &ServerContext, req: InitializeKeyRequest) -> Result<E
             chain_id: ctx.bridge_config.chain_id,
             bridge_contract: ctx.bridge_config.bridge_contract.to_vec(),
             rgb_asset_id: ctx.bridge_config.rgb_asset_id.clone(),
+            evm_gas_tx_uncompressed_pub: keys.evm_gas_tx_uncompressed_pub.to_vec(),
+            evm_gas_tx_address: keys.evm_gas_tx_address.to_vec(),
         })),
     })
 }
@@ -226,6 +233,7 @@ fn handle_get_public_key(
     let keys = ctx.state.get_keys()?;
     tracing::debug!(
         evm_address = %hex::encode(keys.evm_address),
+        evm_gas_tx_address = %hex::encode(keys.evm_gas_tx_address),
         "returning public keys"
     );
     Ok(EnclaveResponse {
@@ -255,6 +263,8 @@ fn build_public_keys_response(
         chain_id: cfg.chain_id,
         bridge_contract: cfg.bridge_contract.to_vec(),
         rgb_asset_id: cfg.rgb_asset_id.clone(),
+        evm_gas_tx_uncompressed_pub: keys.evm_gas_tx_uncompressed_pub.to_vec(),
+        evm_gas_tx_address: keys.evm_gas_tx_address.to_vec(),
     }
 }
 
@@ -267,7 +277,7 @@ fn build_public_keys_response(
 /// `docs/pubkey-attestation.md` and `parent/src/attest_verify.rs::canonical_bundle`.
 fn canonical_pubkey_bundle(keys: &PublicKeysResponse) -> Vec<u8> {
     let chain_id_bytes = keys.chain_id.to_be_bytes();
-    let parts: [&[u8]; 10] = [
+    let parts: [&[u8]; 12] = [
         &keys.evm_address,
         &keys.btc_compressed_pub,
         keys.btc_xpub.as_bytes(),
@@ -278,6 +288,8 @@ fn canonical_pubkey_bundle(keys: &PublicKeysResponse) -> Vec<u8> {
         &chain_id_bytes,
         &keys.bridge_contract,
         keys.rgb_asset_id.as_bytes(),
+        &keys.evm_gas_tx_uncompressed_pub,
+        &keys.evm_gas_tx_address,
     ];
     let total: usize = parts.iter().map(|p| 4 + p.len()).sum();
     let mut out = Vec::with_capacity(total);
@@ -448,7 +460,22 @@ fn handle_sign_evm(ctx: &ServerContext, req: SignEvmRequest) -> Result<EnclaveRe
     // TODO: confirm domain name/version with contract team
     let domain = build_evm_domain(&req)?;
 
+    let domain_sep = domain.separator_hash();
     let digest = sign_request_digest(&domain, &req.call_data, req.nonce, req.deadline);
+
+    tracing::info!(
+        domain_name = %domain.name,
+        chain_id = domain.chain_id,
+        proxy = %hex::encode(domain.verifying_contract),
+        domain_sep = %hex::encode(domain_sep),
+        call_data_len = req.call_data.len(),
+        selector = %hex::encode(&req.call_data[..4.min(req.call_data.len())]),
+        nonce = req.nonce,
+        deadline = req.deadline,
+        digest = %hex::encode(digest),
+        "EVM digest computed"
+    );
+
     let signature = ctx.state.sign_evm(&digest)?;
 
     tracing::info!(
@@ -514,6 +541,33 @@ fn handle_sign_raw_message(
     })
 }
 
+fn handle_sign_raw_digest(
+    state: &EnclaveState,
+    req: SignRawDigestRequest,
+) -> Result<EnclaveResponse> {
+    if req.digest.len() != 32 {
+        return Err(EnclaveError::InvalidRequest(format!(
+            "digest must be exactly 32 bytes, got {}",
+            req.digest.len()
+        )));
+    }
+
+    let digest: [u8; 32] = req.digest.as_slice().try_into().unwrap();
+    let signature = state.sign_evm_gas_tx(&digest)?;
+
+    tracing::info!(
+        sig_hex = %hex::encode(signature),
+        digest_hex = %hex::encode(digest),
+        "raw digest signature produced (evm_gas_tx key)"
+    );
+
+    Ok(EnclaveResponse {
+        response: Some(Response::RawDigestSig(RawDigestSignatureResponse {
+            signature: signature.to_vec(),
+        })),
+    })
+}
+
 /// Build EIP-712 domain from enriched request fields.
 /// In dev-mode, falls back to defaults if fields are missing.
 fn build_evm_domain(req: &SignEvmRequest) -> Result<Eip712Domain> {
@@ -550,7 +604,7 @@ fn build_evm_domain(req: &SignEvmRequest) -> Result<Eip712Domain> {
     };
 
     Ok(Eip712Domain {
-        name: "Tricorn".to_string(),
+        name: "MultisigProxy".to_string(),
         version: "1".to_string(),
         chain_id,
         verifying_contract,

--- a/enclave/src/signing/evm.rs
+++ b/enclave/src/signing/evm.rs
@@ -1,10 +1,9 @@
 use sha3::{Digest, Keccak256};
 
-// TODO: align with final MultisigProxy.sol — may need selector field
 const DOMAIN_TYPE_HASH_STR: &str =
     "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)";
-const SIGN_REQUEST_TYPE_HASH_STR: &str =
-    "SignRequest(bytes callData,uint256 nonce,uint256 deadline)";
+const BRIDGE_OP_TYPE_HASH_STR: &str =
+    "BridgeOperation(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)";
 
 /// EIP-712 domain separator components.
 /// Must match the deployed MultisigProxy contract exactly.
@@ -33,20 +32,31 @@ impl Eip712Domain {
     }
 }
 
-/// Build the EIP-712 digest for: SignRequest(bytes callData, uint256 nonce, uint256 deadline)
-/// Returns the 32-byte hash ready to be signed with ECDSA.
+/// Build the EIP-712 digest matching MultisigProxy._buildDigest():
+///   keccak256(abi.encode(_BRIDGE_OP_TYPEHASH, selector, keccak256(callData), nonce, deadline))
 pub fn sign_request_digest(
     domain: &Eip712Domain,
     call_data: &[u8],
     nonce: u64,
     deadline: u64,
 ) -> [u8; 32] {
+    assert!(
+        call_data.len() >= 4,
+        "call_data must contain at least a 4-byte selector"
+    );
+
     let struct_hash = {
-        let type_hash = Keccak256::digest(SIGN_REQUEST_TYPE_HASH_STR.as_bytes());
+        let type_hash = Keccak256::digest(BRIDGE_OP_TYPE_HASH_STR.as_bytes());
+
+        // bytes4 selector: abi.encode pads to 32 bytes, left-aligned (same as Solidity).
+        let mut selector_padded = [0u8; 32];
+        selector_padded[..4].copy_from_slice(&call_data[..4]);
+
         let call_data_hash = Keccak256::digest(call_data);
 
-        let mut buf = Vec::with_capacity(32 * 4);
+        let mut buf = Vec::with_capacity(32 * 5);
         buf.extend_from_slice(&type_hash);
+        buf.extend_from_slice(&selector_padded);
         buf.extend_from_slice(&call_data_hash);
         buf.extend_from_slice(&abi_encode_u256(nonce));
         buf.extend_from_slice(&abi_encode_u256(deadline));
@@ -108,7 +118,7 @@ mod tests {
     #[test]
     fn test_domain_separator_deterministic() {
         let domain = Eip712Domain {
-            name: "Tricorn".to_string(),
+            name: "MultisigProxy".to_string(),
             version: "1".to_string(),
             chain_id: 1,
             verifying_contract: [0u8; 20],
@@ -122,7 +132,7 @@ mod tests {
     #[test]
     fn test_sign_request_digest_deterministic() {
         let domain = Eip712Domain {
-            name: "Tricorn".to_string(),
+            name: "MultisigProxy".to_string(),
             version: "1".to_string(),
             chain_id: 1,
             verifying_contract: [0u8; 20],
@@ -141,31 +151,126 @@ mod tests {
     #[test]
     fn test_different_nonce_different_digest() {
         let domain = Eip712Domain {
-            name: "Tricorn".to_string(),
+            name: "MultisigProxy".to_string(),
             version: "1".to_string(),
             chain_id: 1,
             verifying_contract: [0u8; 20],
         };
-        let call_data = b"test";
-        let d1 = sign_request_digest(&domain, call_data, 0, 1_700_000_000);
-        let d2 = sign_request_digest(&domain, call_data, 1, 1_700_000_000);
+        let call_data = hex::decode("aabbccdd").unwrap();
+        let d1 = sign_request_digest(&domain, &call_data, 0, 1_700_000_000);
+        let d2 = sign_request_digest(&domain, &call_data, 1, 1_700_000_000);
         assert_ne!(d1, d2);
+    }
+
+    #[test]
+    #[should_panic(expected = "call_data must contain at least a 4-byte selector")]
+    fn test_short_call_data_panics() {
+        let domain = Eip712Domain {
+            name: "MultisigProxy".to_string(),
+            version: "1".to_string(),
+            chain_id: 1,
+            verifying_contract: [0u8; 20],
+        };
+        sign_request_digest(&domain, &[0xAA, 0xBB], 0, 1_000);
+    }
+
+    #[test]
+    fn test_digest_matches_go_bridge_computation() {
+        // Cross-check: reproduce the exact digest that bridge-utexo/blsProxy/transactor.go
+        // computes for a known input, ensuring enclave and contract agree.
+        //
+        // Go side (buildExecuteDigest):
+        //   bridgeOpTypehash = keccak256("BridgeOperation(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)")
+        //   selectorBytes = callData[:4] left-aligned in 32 bytes
+        //   structHash = keccak256(typehash || selectorBytes || keccak256(callData) || nonce || deadline)
+        //   digest = keccak256(0x19 0x01 || domainSeparator || structHash)
+
+        let domain = Eip712Domain {
+            name: "MultisigProxy".to_string(),
+            version: "1".to_string(),
+            chain_id: 42161, // Arbitrum One
+            verifying_contract: {
+                let mut addr = [0u8; 20];
+                addr.copy_from_slice(
+                    &hex::decode("eAB44D217C5Af0Cc2A46ba296b5e0eBa5B4362d0").unwrap(),
+                );
+                addr
+            },
+        };
+
+        let call_data = hex::decode(
+            "a9059cbb000000000000000000000000abcdefabcdefabcdefabcdefabcdefabcdefabcd\
+             0000000000000000000000000000000000000000000000000000000000000064",
+        )
+        .unwrap();
+
+        let nonce: u64 = 0;
+        let deadline: u64 = 1_700_000_000;
+
+        // Manually compute the expected digest step by step.
+        let type_hash = Keccak256::digest(
+            b"BridgeOperation(bytes4 selector,bytes callData,uint256 nonce,uint256 deadline)",
+        );
+
+        let mut selector_padded = [0u8; 32];
+        selector_padded[..4].copy_from_slice(&call_data[..4]);
+
+        let call_data_hash = Keccak256::digest(&call_data);
+
+        let mut struct_buf = Vec::new();
+        struct_buf.extend_from_slice(&type_hash);
+        struct_buf.extend_from_slice(&selector_padded);
+        struct_buf.extend_from_slice(&call_data_hash);
+        struct_buf.extend_from_slice(&abi_encode_u256(nonce));
+        struct_buf.extend_from_slice(&abi_encode_u256(deadline));
+        let expected_struct_hash = Keccak256::digest(&struct_buf);
+
+        let domain_sep = domain.separator_hash();
+
+        let mut digest_buf = Vec::new();
+        digest_buf.extend_from_slice(&[0x19, 0x01]);
+        digest_buf.extend_from_slice(&domain_sep);
+        digest_buf.extend_from_slice(&expected_struct_hash);
+        let expected_digest: [u8; 32] = Keccak256::digest(&digest_buf).into();
+
+        let actual_digest = sign_request_digest(&domain, &call_data, nonce, deadline);
+        assert_eq!(actual_digest, expected_digest);
     }
 
     #[test]
     fn test_different_chain_id_different_domain() {
         let d1 = Eip712Domain {
-            name: "Tricorn".to_string(),
+            name: "MultisigProxy".to_string(),
             version: "1".to_string(),
             chain_id: 1,
             verifying_contract: [0u8; 20],
         };
         let d2 = Eip712Domain {
-            name: "Tricorn".to_string(),
+            name: "MultisigProxy".to_string(),
             version: "1".to_string(),
             chain_id: 137,
             verifying_contract: [0u8; 20],
         };
         assert_ne!(d1.separator_hash(), d2.separator_hash());
+    }
+
+    #[test]
+    fn test_domain_separator_matches_deployed_contract() {
+        let domain = Eip712Domain {
+            name: "MultisigProxy".to_string(),
+            version: "1".to_string(),
+            chain_id: 42161,
+            verifying_contract: {
+                let mut addr = [0u8; 20];
+                addr.copy_from_slice(
+                    &hex::decode("eAB44D217C5Af0Cc2A46ba296b5e0eBa5B4362d0").unwrap(),
+                );
+                addr
+            },
+        };
+        let on_chain =
+            hex::decode("8da42c1b5850d914ac94e640f4edd2030e2330b104f8448fdf3c6639cb0542ff")
+                .unwrap();
+        assert_eq!(domain.separator_hash(), on_chain.as_slice());
     }
 }

--- a/enclave/src/spv/chain.rs
+++ b/enclave/src/spv/chain.rs
@@ -233,7 +233,11 @@ impl HeaderChain {
                 (pred_hash, pred_bits, pred_time)
             };
 
-            let epoch_start_time = self.epoch_start_time(height, start_height, &staged)?;
+            let epoch_start_time = if self.network.enforces_pow() {
+                self.epoch_start_time(height, start_height, &staged)?
+            } else {
+                0
+            };
 
             let expected_bits_value =
                 expected_bits(height, prev_bits, prev_time, epoch_start_time, self.network)?;
@@ -664,6 +668,38 @@ mod tests {
         assert_eq!(chain.tip_hash(), original_tip);
         assert_eq!(chain.tip_height(), original_height);
         assert_eq!(chain.len(), 5);
+    }
+
+    #[test]
+    fn non_pow_network_skips_epoch_lookup_across_retarget_boundary() {
+        // Regression: a non-PoW network (signet/regtest) whose checkpoint is
+        // ABOVE the retarget epoch start must NOT fail with HeaderNotFound.
+        // Checkpoint at height 2020 means epoch_start for height 2016*2=4032
+        // would be 4032-2016=2016, which IS stored. But the PREVIOUS epoch
+        // start (height 0) is NOT stored. We test that crossing the 4032
+        // boundary works without needing headers below checkpoint.
+        //
+        // Specifically: checkpoint at 4000, first retarget at 4032 needs
+        // epoch start at 4032-2016=2016 which is below checkpoint (4000).
+        let cp_hash = {
+            let mut h = [0u8; 32];
+            h[0] = 0xBB;
+            h
+        };
+        let checkpoint = Checkpoint {
+            height: 4000,
+            hash: cp_hash,
+            bits: 0x207fffff,
+            time: 1_700_000_000,
+            is_real: false,
+        };
+        let mut chain = HeaderChain::new(Network::Regtest, checkpoint);
+
+        // Build 100 headers from 4001 to 4100, crossing retarget at 4032.
+        let (raws, _) = synth_chain_from(cp_hash, 1_700_000_000, 1, 100);
+        let outcome = chain.submit_headers(4001, &raws).unwrap();
+        assert_eq!(outcome.headers_accepted, 100);
+        assert_eq!(outcome.last_block_height, 4100);
     }
 
     #[test]

--- a/enclave/src/spv/checkpoint.rs
+++ b/enclave/src/spv/checkpoint.rs
@@ -8,13 +8,10 @@
 //!
 //! ## Status
 //!
-//! - **Mainnet checkpoint** — PLACEHOLDER. Required for production. Will be
-//!   set when production deployment is in scope.
-//! - **Signet checkpoint** — PLACEHOLDER. Will be filled in once Mirvais
-//!   provides a `(height, hash, bits, time)` tuple from the UTEXO custom
-//!   signet, scheduled for after the dev asset_id is finalised. PR 3 wires
-//!   the chain through with placeholders so a follow-up PR is a one-line
-//!   constant swap.
+//! - **Mainnet checkpoint** — block 950 000 (2026-05-18). Verified via
+//!   double-SHA256 of raw header from blockstream.info/api.
+//! - **Signet checkpoint** — UTEXO custom signet block 311 000 (2026-05-25).
+//!   Verified via double-SHA256 of raw header from esplora-api.utexo.com.
 //! - **Signet challenge / magic / block time** — REAL values, provided by
 //!   Oleksandr 2026-04-30. UTEXO custom signet, 3-of-3 multisig, 30s blocks.
 //!   These are baked in now so they end up in PCR0 alongside everything
@@ -43,24 +40,32 @@ pub struct Checkpoint {
     pub is_real: bool,
 }
 
-/// Mainnet checkpoint. PLACEHOLDER — replace with a real recent finalized
-/// block before production.
+/// Mainnet checkpoint — block 950 000 (2026-05-18).
+/// hash (display): 000000000000000000010b93c9ea1c29fea277383f0f7d1f26de8b5802e885ff
 pub const MAINNET_CHECKPOINT: Checkpoint = Checkpoint {
-    height: 0,
-    hash: [0u8; 32],
-    bits: 0,
-    time: 0,
-    is_real: false,
+    height: 950_000,
+    hash: [
+        0xff, 0x85, 0xe8, 0x02, 0x58, 0x8b, 0xde, 0x26, 0x1f, 0x7d, 0x0f, 0x3f, 0x38, 0x77, 0xa2,
+        0xfe, 0x29, 0x1c, 0xea, 0xc9, 0x93, 0x0b, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00,
+    ],
+    bits: 0x1702_0f79,
+    time: 1_779_141_269,
+    is_real: true,
 };
 
-/// Signet checkpoint. PLACEHOLDER — replace once the team confirms
-/// default-signet vs custom-signet (see docs/spv-review.md §4).
+/// UTEXO custom signet checkpoint — block 311 000 (2026-05-25).
+/// hash (display): 00000236acddd52681c79ae733060376ce4f0ea0171876f2955e2125e32492f8
 pub const SIGNET_CHECKPOINT: Checkpoint = Checkpoint {
-    height: 0,
-    hash: [0u8; 32],
-    bits: 0,
-    time: 0,
-    is_real: false,
+    height: 311_000,
+    hash: [
+        0xf8, 0x92, 0x24, 0xe3, 0x25, 0x21, 0x5e, 0x95, 0xf2, 0x76, 0x18, 0x17, 0xa0, 0x0e, 0x4f,
+        0xce, 0x76, 0x03, 0x06, 0x33, 0xe7, 0x9a, 0xc7, 0x81, 0x26, 0xd5, 0xdd, 0xac, 0x36, 0x02,
+        0x00, 0x00,
+    ],
+    bits: 0x1e03_77ae,
+    time: 1_779_756_628,
+    is_real: true,
 };
 
 /// Testnet3 checkpoint. PLACEHOLDER — testnet3 isn't a target environment
@@ -86,7 +91,13 @@ impl Checkpoint {
     /// Refuse to construct a `HeaderChain` against a placeholder checkpoint
     /// in production-shaped builds. Tests are exempt.
     pub fn assert_real_in_release(&self) -> Result<(), &'static str> {
-        if cfg!(debug_assertions) || cfg!(test) {
+        // Local dev/test images intentionally build the enclave in release mode
+        // with `allow-seed-import` so deterministic mnemonics can be loaded,
+        // but they still run against placeholder signet checkpoints until the
+        // real tuple is baked in. Keep the hard fail for production-shaped
+        // builds while letting that testing-only feature act as the escape
+        // hatch for local E2E.
+        if cfg!(debug_assertions) || cfg!(test) || cfg!(feature = "allow-seed-import") {
             return Ok(());
         }
         if !self.is_real {
@@ -184,9 +195,8 @@ mod tests {
 
     #[test]
     fn checkpoint_for_dispatches_on_network() {
-        // Checks the lookup table doesn't silently route the wrong checkpoint.
-        assert!(!checkpoint_for(Network::Mainnet).is_real);
-        assert!(!checkpoint_for(Network::Signet).is_real);
+        assert!(checkpoint_for(Network::Mainnet).is_real);
+        assert!(checkpoint_for(Network::Signet).is_real);
         assert!(!checkpoint_for(Network::Testnet3).is_real);
         assert!(!checkpoint_for(Network::Regtest).is_real);
     }

--- a/enclave/src/spv/validation.rs
+++ b/enclave/src/spv/validation.rs
@@ -34,7 +34,7 @@ pub const RETARGET_INTERVAL: BlockHeight = 2016;
 
 /// Returns true when `height` is the start of a new retarget epoch.
 pub fn is_retarget_height(height: BlockHeight) -> bool {
-    height % RETARGET_INTERVAL == 0
+    height.is_multiple_of(RETARGET_INTERVAL)
 }
 
 /// Verify that `header.prev_blockhash` matches `expected_prev_hash` (in

--- a/enclave/src/state.rs
+++ b/enclave/src/state.rs
@@ -313,6 +313,8 @@ impl EnclaveState {
             Ok(KeyInfo {
                 evm_address: *km.evm_address(),
                 evm_uncompressed_pub: *km.evm_uncompressed_pub(),
+                evm_gas_tx_address: *km.evm_gas_tx_address(),
+                evm_gas_tx_uncompressed_pub: *km.evm_gas_tx_uncompressed_pub(),
                 btc_compressed_pubkey: *km.btc_compressed_pubkey(),
                 btc_xpub: km.btc_xpub().to_string(),
                 master_fingerprint: km.master_fingerprint().to_bytes(),
@@ -325,6 +327,11 @@ impl EnclaveState {
     /// Sign a 32-byte EVM message hash. Returns 65-byte signature.
     pub fn sign_evm(&self, message_hash: &[u8; 32]) -> Result<[u8; 65]> {
         self.with_active(|km| km.sign_evm(message_hash))
+    }
+
+    /// Sign a 32-byte digest with the EVM gas TX key. Returns 65-byte signature.
+    pub fn sign_evm_gas_tx(&self, message_hash: &[u8; 32]) -> Result<[u8; 65]> {
+        self.with_active(|km| km.sign_evm_gas_tx(message_hash))
     }
 
     /// Sign PSBT inputs matching our BTC key. Returns (signed_psbt_bytes, inputs_signed).

--- a/enclave/src/validation/evm_crosscheck.rs
+++ b/enclave/src/validation/evm_crosscheck.rs
@@ -16,13 +16,13 @@ use crate::validation::rgb::{ifa, ValidatedConsignment};
 /// `[4 selector][32 token][32 recipient][32 amount][32 transactionId][32 srcChainOffset][32 srcAddrOffset]...`.
 pub const FUNDS_OUT_SELECTOR_POOLS_LEGACY: [u8; 4] = [0x1a, 0xd8, 0x80, 0xb2];
 
-/// `keccak256("fundsOut(address,uint256,uint256,uint256,uint256,uint256,string,bytes,bytes)")[0..4]`.
-/// 8-arg mint/burn shape on `bridge-smart-contracts/dev` (PR #22
+/// `keccak256("fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)")[0..4]`.
+/// 8-arg mint/burn shape on `utexo-smart-contracts/dev` (PR #22
 /// route-plugin refactor). Layout:
 /// `[4 selector][32 recipient][32 amount][32 burnId][32 sourceChainId][32 destinationChainId][32 srcAddrOffset][32 proofOffset][32 settlementDataOffset]...`.
 /// `proof = abi.encode(uint256 blockHeight, bytes32 commitmentHash)` and
 /// `settlementData = abi.encode(uint256[] fundsInIds)`.
-pub const FUNDS_OUT_SELECTOR_MINTBURN: [u8; 4] = [0x17, 0x9b, 0xef, 0x59];
+pub const FUNDS_OUT_SELECTOR_MINTBURN: [u8; 4] = [0xcc, 0xdd, 0xb7, 0x68];
 
 /// 4-byte function selectors the enclave is willing to sign `fundsOut`
 /// calldata for. Anything else is rejected up-front before any byte-level

--- a/enclave/tests/test_attested_pubkey.rs
+++ b/enclave/tests/test_attested_pubkey.rs
@@ -34,7 +34,7 @@ fn initialize(port: u16) {
 
 fn canonical_bundle(keys: &PublicKeysResponse) -> Vec<u8> {
     let chain_id_bytes = keys.chain_id.to_be_bytes();
-    let parts: [&[u8]; 10] = [
+    let parts: [&[u8]; 12] = [
         &keys.evm_address,
         &keys.btc_compressed_pub,
         keys.btc_xpub.as_bytes(),
@@ -45,6 +45,8 @@ fn canonical_bundle(keys: &PublicKeysResponse) -> Vec<u8> {
         &chain_id_bytes,
         &keys.bridge_contract,
         keys.rgb_asset_id.as_bytes(),
+        &keys.evm_gas_tx_uncompressed_pub,
+        &keys.evm_gas_tx_address,
     ];
     let mut out = Vec::new();
     for p in parts {

--- a/enclave/tests/test_clone.rs
+++ b/enclave/tests/test_clone.rs
@@ -46,6 +46,8 @@ fn initialize_key_from_mnemonic(port: u16, mnemonic: &str) -> PublicKeysResponse
             chain_id: r.chain_id,
             bridge_contract: r.bridge_contract,
             rgb_asset_id: r.rgb_asset_id,
+            evm_gas_tx_uncompressed_pub: r.evm_gas_tx_uncompressed_pub,
+            evm_gas_tx_address: r.evm_gas_tx_address,
         },
         other => panic!("expected InitializeKey response, got {:?}", other),
     }

--- a/parent/src/attest_verify.rs
+++ b/parent/src/attest_verify.rs
@@ -39,7 +39,7 @@ pub struct AttestedPubkeyResult {
 /// `canonical_pubkey_bundle` in `enclave/src/server.rs`.
 pub fn canonical_bundle(resp: &AttestedPublicKeyResponse) -> Vec<u8> {
     let chain_id_bytes = resp.chain_id.to_be_bytes();
-    let parts: [&[u8]; 10] = [
+    let parts: [&[u8]; 12] = [
         &resp.evm_address,
         &resp.btc_compressed_pub,
         resp.btc_xpub.as_bytes(),
@@ -50,6 +50,8 @@ pub fn canonical_bundle(resp: &AttestedPublicKeyResponse) -> Vec<u8> {
         &chain_id_bytes,
         &resp.bridge_contract,
         resp.rgb_asset_id.as_bytes(),
+        &resp.evm_gas_tx_uncompressed_pub,
+        &resp.evm_gas_tx_address,
     ];
     let mut out = Vec::new();
     for p in parts {

--- a/parent/src/config.rs
+++ b/parent/src/config.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 /// Parent Adapter configuration, populated from environment variables.
 pub struct Config {
     /// Host for the gRPC server to bind (default 127.0.0.1; use 0.0.0.0 in Docker).
@@ -17,6 +19,9 @@ pub struct Config {
 
     /// Use vsock instead of TCP.
     pub use_vsock: bool,
+
+    /// EVM network IDs — TRANSACTION with these network_ids routes to signEVM.
+    pub evm_network_ids: HashSet<u32>,
 }
 
 impl Config {
@@ -30,6 +35,11 @@ impl Config {
             use_vsock: std::env::var("USE_VSOCK")
                 .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
                 .unwrap_or(false),
+            evm_network_ids: std::env::var("EVM_NETWORK_IDS")
+                .unwrap_or_default()
+                .split(',')
+                .filter_map(|s| s.trim().parse::<u32>().ok())
+                .collect(),
         }
     }
 }

--- a/parent/src/grpc_server.rs
+++ b/parent/src/grpc_server.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::time::Duration;
 
 use prost::Message as ProstMessage;
@@ -33,11 +34,15 @@ pub enum EnclaveTarget {
 #[derive(Clone)]
 pub struct ParentAdapterService {
     target: EnclaveTarget,
+    evm_network_ids: HashSet<u32>,
 }
 
 impl ParentAdapterService {
-    pub fn new(target: EnclaveTarget) -> Self {
-        Self { target }
+    pub fn new(target: EnclaveTarget, evm_network_ids: HashSet<u32>) -> Self {
+        Self {
+            target,
+            evm_network_ids,
+        }
     }
 
     /// Send an EnclaveRequest to the enclave and read the EnclaveResponse.
@@ -100,51 +105,17 @@ impl ParentAdapterService {
 
 #[tonic::async_trait]
 impl EnclaveService for ParentAdapterService {
-    /// Sign — dispatches based on data_type:
-    ///   TRANSACTION → deserialize EnrichedPsbtPayload → SignPsbtRequest
-    ///   SWAP        → deserialize EnrichedEvmPayload  → SignEvmRequest
+    /// Sign — dispatches based on data_type + network_id:
+    ///   TRANSACTION + EVM network_id → deserialize EnrichedEvmPayload → SignEvmRequest
+    ///   TRANSACTION + other          → deserialize EnrichedPsbtPayload → SignPsbtRequest
+    ///   EVM_GAS_TX                   → raw 32-byte digest → SignRawDigestRequest
     async fn sign(&self, request: Request<SignRequest>) -> Result<Response<Signature>, Status> {
         let inner = request.into_inner();
 
         let data_type = DataType::try_from(inner.data_type).unwrap_or(DataType::Transaction);
 
         let enclave_req = match data_type {
-            DataType::Transaction => {
-                // Deserialize enriched PSBT payload from data bytes
-                let payload = enriched::EnrichedPsbtPayload::decode(inner.data.as_slice())
-                    .map_err(|e| {
-                        Status::invalid_argument(format!(
-                            "failed to decode EnrichedPsbtPayload: {e}"
-                        ))
-                    })?;
-
-                tracing::info!(
-                    psbt_len = payload.psbt_bytes.len(),
-                    has_tx_hash = !payload.evm_tx_hash.is_empty(),
-                    operation_idx = payload.operation_idx,
-                    "gRPC Sign: PSBT (data_type=TRANSACTION)"
-                );
-
-                EnclaveRequest {
-                    request: Some(enclave_request::Request::SignPsbt(
-                        enclave_proto::SignPsbtRequest {
-                            psbt_bytes: payload.psbt_bytes,
-                            evm_tx_hash: payload.evm_tx_hash,
-                            operation_idx: payload.operation_idx,
-                            evm_event_valid: payload.evm_event_valid,
-                            evm_event_finalized: payload.evm_event_finalized,
-                            evm_token: payload.evm_token,
-                            evm_amount: payload.evm_amount,
-                            evm_recipient: payload.evm_recipient,
-                            evm_commission: payload.evm_commission,
-                            psbt_output_amount: payload.psbt_output_amount,
-                            rgb_asset_id: payload.rgb_asset_id,
-                        },
-                    )),
-                }
-            }
-            DataType::Swap => {
-                // Deserialize enriched EVM payload from data bytes
+            DataType::Transaction if self.evm_network_ids.contains(&inner.network_id) => {
                 let payload =
                     enriched::EnrichedEvmPayload::decode(inner.data.as_slice()).map_err(|e| {
                         Status::invalid_argument(format!(
@@ -153,11 +124,12 @@ impl EnclaveService for ParentAdapterService {
                     })?;
 
                 tracing::info!(
+                    network_id = inner.network_id,
                     calldata_len = payload.call_data.len(),
                     consignment_valid = payload.consignment_valid,
                     nonce = payload.nonce,
                     deadline = payload.deadline,
-                    "gRPC Sign: EVM (data_type=SWAP)"
+                    "gRPC Sign: EVM (data_type=TRANSACTION, evm network)"
                 );
 
                 EnclaveRequest {
@@ -189,6 +161,52 @@ impl EnclaveService for ParentAdapterService {
                     )),
                 }
             }
+            DataType::Transaction => {
+                let payload = enriched::EnrichedPsbtPayload::decode(inner.data.as_slice())
+                    .map_err(|e| {
+                        Status::invalid_argument(format!(
+                            "failed to decode EnrichedPsbtPayload: {e}"
+                        ))
+                    })?;
+
+                tracing::info!(
+                    network_id = inner.network_id,
+                    psbt_len = payload.psbt_bytes.len(),
+                    has_tx_hash = !payload.evm_tx_hash.is_empty(),
+                    operation_idx = payload.operation_idx,
+                    "gRPC Sign: PSBT (data_type=TRANSACTION, non-evm network)"
+                );
+
+                EnclaveRequest {
+                    request: Some(enclave_request::Request::SignPsbt(
+                        enclave_proto::SignPsbtRequest {
+                            psbt_bytes: payload.psbt_bytes,
+                            evm_tx_hash: payload.evm_tx_hash,
+                            operation_idx: payload.operation_idx,
+                            evm_event_valid: payload.evm_event_valid,
+                            evm_event_finalized: payload.evm_event_finalized,
+                            evm_token: payload.evm_token,
+                            evm_amount: payload.evm_amount,
+                            evm_recipient: payload.evm_recipient,
+                            evm_commission: payload.evm_commission,
+                            psbt_output_amount: payload.psbt_output_amount,
+                            rgb_asset_id: payload.rgb_asset_id,
+                        },
+                    )),
+                }
+            }
+            DataType::EvmGasTx => {
+                tracing::info!(
+                    data_len = inner.data.len(),
+                    "gRPC Sign: raw digest (data_type=EVM_GAS_TX)"
+                );
+
+                EnclaveRequest {
+                    request: Some(enclave_request::Request::SignRawDigest(
+                        enclave_proto::SignRawDigestRequest { digest: inner.data },
+                    )),
+                }
+            }
             other => {
                 tracing::warn!(?other, "unsupported data_type in Sign request");
                 return Err(Status::invalid_argument(format!(
@@ -213,6 +231,10 @@ impl EnclaveService for ParentAdapterService {
                 network_id: inner.network_id,
                 signature: r.signature,
             })),
+            Some(enclave_response::Response::RawDigestSig(r)) => Ok(Response::new(Signature {
+                network_id: inner.network_id,
+                signature: r.signature,
+            })),
             Some(enclave_response::Response::Error(e)) => Err(Self::enclave_error_to_status(&e)),
             other => Err(Status::internal(format!(
                 "unexpected enclave response for Sign: {:?}",
@@ -223,8 +245,8 @@ impl EnclaveService for ParentAdapterService {
 
     /// PublicKey — returns the enclave's public key bytes.
     /// Dispatches on `data_type`:
-    ///   TRANSACTION/SWAP/SIGNATURE/COMMISSION/OWNER_MULTIPLE_SIGNATURE → 64-byte uncompressed X||Y
-    ///   UNSPENDABLE and other BTC-specific → 33-byte compressed pubkey
+    ///   EVM_GAS_TX  → 64-byte uncompressed X||Y (gas key m/44'/60'/0'/0/1)
+    ///   UNSPENDABLE → 33-byte compressed BTC pubkey
     async fn public_key(
         &self,
         request: Request<PublicKeyRequest>,
@@ -248,8 +270,14 @@ impl EnclaveService for ParentAdapterService {
         match resp.response {
             Some(enclave_response::Response::PublicKeys(r)) => {
                 let public_key = match data_type {
+                    DataType::EvmGasTx => r.evm_gas_tx_uncompressed_pub,
                     DataType::Unspendable => r.btc_compressed_pub,
-                    _ => r.evm_uncompressed_pub,
+                    other => {
+                        return Err(Status::invalid_argument(format!(
+                            "PublicKey not supported for data_type {:?}",
+                            other
+                        )));
+                    }
                 };
                 Ok(Response::new(PublicKeyResponse { public_key }))
             }
@@ -426,6 +454,8 @@ impl EnclaveService for ParentAdapterService {
                     chain_id: pk.chain_id,
                     bridge_contract: pk.bridge_contract,
                     rgb_asset_id: pk.rgb_asset_id,
+                    evm_gas_tx_uncompressed_pub: pk.evm_gas_tx_uncompressed_pub,
+                    evm_gas_tx_address: pk.evm_gas_tx_address,
                 }))
             }
             Some(enclave_response::Response::Error(e)) => Err(Self::enclave_error_to_status(&e)),

--- a/parent/src/main.rs
+++ b/parent/src/main.rs
@@ -35,7 +35,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         EnclaveTarget::Tcp(cfg.enclave_addr)
     };
 
-    let service = ParentAdapterService::new(target);
+    tracing::info!(evm_network_ids = ?cfg.evm_network_ids, "EVM network IDs for TRANSACTION routing");
+    let service = ParentAdapterService::new(target, cfg.evm_network_ids);
     let listen_addr = format!("{}:{}", cfg.grpc_host, cfg.grpc_port).parse()?;
 
     tracing::info!(%listen_addr, "starting gRPC server");

--- a/parent/tests/test_attest_verify_e2e.rs
+++ b/parent/tests/test_attest_verify_e2e.rs
@@ -64,8 +64,10 @@ async fn start_real_parent_grpc(enclave_port: u16) -> u16 {
     let grpc_port = grpc_addr.port();
     drop(grpc_listener);
 
-    let service =
-        ParentAdapterService::new(EnclaveTarget::Tcp(format!("127.0.0.1:{enclave_port}")));
+    let service = ParentAdapterService::new(
+        EnclaveTarget::Tcp(format!("127.0.0.1:{enclave_port}")),
+        std::collections::HashSet::new(),
+    );
 
     tokio::spawn(async move {
         Server::builder()

--- a/parent/tests/test_grpc_bridge.rs
+++ b/parent/tests/test_grpc_bridge.rs
@@ -4,6 +4,7 @@
 //! then a real tonic gRPC server (Parent Adapter) pointing at it, and finally
 //! exercise the full path via a gRPC client.
 
+use std::collections::HashSet;
 use std::net::TcpListener;
 
 use prost::Message as ProstMessage;
@@ -52,6 +53,8 @@ fn start_mock_enclave() -> u16 {
                             chain_id: 0,
                             bridge_contract: vec![0u8; 20],
                             rgb_asset_id: String::new(),
+                            evm_gas_tx_uncompressed_pub: vec![0xFF; 64],
+                            evm_gas_tx_address: vec![0xFA; 20],
                         },
                     )),
                 },
@@ -83,6 +86,8 @@ fn start_mock_enclave() -> u16 {
                             chain_id: 0,
                             bridge_contract: vec![0u8; 20],
                             rgb_asset_id: String::new(),
+                            evm_gas_tx_uncompressed_pub: vec![0xFF; 64],
+                            evm_gas_tx_address: vec![0xFA; 20],
                         },
                     )),
                 },
@@ -117,10 +122,12 @@ fn start_mock_enclave() -> u16 {
                         chain_id: 0,
                         bridge_contract: vec![0u8; 20],
                         rgb_asset_id: String::new(),
+                        evm_gas_tx_uncompressed_pub: vec![0xFF; 64],
+                        evm_gas_tx_address: vec![0xCC; 20],
                     };
                     let mut bundle: Vec<u8> = Vec::new();
                     let chain_id_bytes = public_keys.chain_id.to_be_bytes();
-                    let parts: [&[u8]; 10] = [
+                    let parts: [&[u8]; 12] = [
                         &public_keys.evm_address,
                         &public_keys.btc_compressed_pub,
                         public_keys.btc_xpub.as_bytes(),
@@ -131,6 +138,8 @@ fn start_mock_enclave() -> u16 {
                         &chain_id_bytes,
                         &public_keys.bridge_contract,
                         public_keys.rgb_asset_id.as_bytes(),
+                        &public_keys.evm_gas_tx_uncompressed_pub,
+                        &public_keys.evm_gas_tx_address,
                     ];
                     for p in parts {
                         bundle.extend_from_slice(&(p.len() as u32).to_be_bytes());
@@ -180,8 +189,10 @@ async fn start_grpc_server(enclave_port: u16) -> u16 {
     let grpc_port = grpc_addr.port();
     drop(grpc_listener);
 
-    let service =
-        ParentAdapterService::new(EnclaveTarget::Tcp(format!("127.0.0.1:{enclave_port}")));
+    let service = ParentAdapterService::new(
+        EnclaveTarget::Tcp(format!("127.0.0.1:{enclave_port}")),
+        HashSet::from([84]),
+    );
 
     tokio::spawn(async move {
         Server::builder()
@@ -200,7 +211,7 @@ async fn start_grpc_server(enclave_port: u16) -> u16 {
 // =========================================================================
 
 #[tokio::test]
-async fn grpc_public_key_roundtrip() {
+async fn grpc_public_key_evm_gas_tx() {
     let enclave_port = start_mock_enclave();
     let grpc_port = start_grpc_server(enclave_port).await;
 
@@ -211,30 +222,7 @@ async fn grpc_public_key_roundtrip() {
     let resp = client
         .public_key(PublicKeyRequest {
             network_id: 0,
-            data_type: 0,
-            algorithm: None,
-        })
-        .await
-        .unwrap()
-        .into_inner();
-
-    assert_eq!(resp.public_key.len(), 64, "EVM uncompressed pubkey X||Y");
-    assert_eq!(resp.public_key, vec![0xEE; 64]);
-}
-
-#[tokio::test]
-async fn grpc_public_key_returns_evm_address_for_swap() {
-    let enclave_port = start_mock_enclave();
-    let grpc_port = start_grpc_server(enclave_port).await;
-
-    let mut client = EnclaveServiceClient::connect(format!("http://127.0.0.1:{grpc_port}"))
-        .await
-        .unwrap();
-
-    let resp = client
-        .public_key(PublicKeyRequest {
-            network_id: 0,
-            data_type: DataType::Swap as i32,
+            data_type: DataType::EvmGasTx as i32,
             algorithm: None,
         })
         .await
@@ -244,9 +232,30 @@ async fn grpc_public_key_returns_evm_address_for_swap() {
     assert_eq!(
         resp.public_key.len(),
         64,
-        "EVM uncompressed pubkey X||Y for SWAP"
+        "EVM gas TX uncompressed pubkey X||Y"
     );
-    assert_eq!(resp.public_key, vec![0xEE; 64]);
+    assert_eq!(resp.public_key, vec![0xFF; 64]);
+}
+
+#[tokio::test]
+async fn grpc_public_key_rejects_transaction_type() {
+    let enclave_port = start_mock_enclave();
+    let grpc_port = start_grpc_server(enclave_port).await;
+
+    let mut client = EnclaveServiceClient::connect(format!("http://127.0.0.1:{grpc_port}"))
+        .await
+        .unwrap();
+
+    let err = client
+        .public_key(PublicKeyRequest {
+            network_id: 0,
+            data_type: DataType::Transaction as i32,
+            algorithm: None,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
 }
 
 #[tokio::test]
@@ -275,8 +284,8 @@ async fn grpc_sign_evm_roundtrip() {
     };
 
     let req = SignRequest {
-        network_id: 0,
-        data_type: DataType::Swap as i32,
+        network_id: 84,
+        data_type: DataType::Transaction as i32,
         data: payload.encode_to_vec(),
         inputs: vec![],
         algorithm: None,
@@ -377,8 +386,8 @@ async fn grpc_evm_passes_enriched_fields_through() {
     };
 
     let req = SignRequest {
-        network_id: 0,
-        data_type: DataType::Swap as i32,
+        network_id: 84,
+        data_type: DataType::Transaction as i32,
         data: payload.encode_to_vec(),
         inputs: vec![],
         algorithm: None,
@@ -451,8 +460,8 @@ async fn grpc_evm_forwards_raw_consignment_bytes() {
     };
 
     let req = SignRequest {
-        network_id: 0,
-        data_type: DataType::Swap as i32,
+        network_id: 84,
+        data_type: DataType::Transaction as i32,
         data: payload.encode_to_vec(),
         inputs: vec![],
         algorithm: None,
@@ -619,7 +628,7 @@ async fn grpc_attested_public_key_roundtrip_and_verify() {
     use sha2::Digest;
     let mut bundle: Vec<u8> = Vec::new();
     let chain_id_bytes = resp.chain_id.to_be_bytes();
-    let parts: [&[u8]; 10] = [
+    let parts: [&[u8]; 12] = [
         &resp.evm_address,
         &resp.btc_compressed_pub,
         resp.btc_xpub.as_bytes(),
@@ -630,6 +639,8 @@ async fn grpc_attested_public_key_roundtrip_and_verify() {
         &chain_id_bytes,
         &resp.bridge_contract,
         resp.rgb_asset_id.as_bytes(),
+        &resp.evm_gas_tx_uncompressed_pub,
+        &resp.evm_gas_tx_address,
     ];
     for p in parts {
         bundle.extend_from_slice(&(p.len() as u32).to_be_bytes());

--- a/proto/enclave.proto
+++ b/proto/enclave.proto
@@ -15,11 +15,10 @@ message EnclaveRequest {
     InitiateCloningRequest initiate_cloning  = 7;
     GetCloneRequest        get_clone         = 8;
     SetCloneRequest        set_clone         = 9;
+    SignRawDigestRequest   sign_raw_digest   = 10;
     SubmitHeadersRequest      submit_headers        = 11;
     GetLastSavedBlockRequest  get_last_saved_block  = 12;
     GetAttestedPublicKeyRequest get_attested_public_key = 13;
-    // Reserved for future:
-    // HealthCheckRequest  health_check     = 10;
   }
 }
 
@@ -34,11 +33,10 @@ message EnclaveResponse {
     InitiateCloningResponse initiate_cloning = 7;
     GetCloneResponse        get_clone        = 8;
     SetCloneResponse        set_clone        = 9;
+    RawDigestSignatureResponse raw_digest_sig = 10;
     SubmitHeadersResponse      submit_headers       = 11;
     GetLastSavedBlockResponse  get_last_saved_block = 12;
     GetAttestedPublicKeyResponse get_attested_public_key = 13;
-    // Reserved for future:
-    // HealthCheckResponse  health_check     = 10;
     ErrorResponse           error            = 15;
   }
 }
@@ -65,12 +63,12 @@ message InitializeKeyResponse {
 
   // Bridge config pinned at enclave boot from env (EVM_CHAIN_ID,
   // BRIDGE_CONTRACT, RGB_ASSET_ID). Zero/empty means "not configured".
-  // Included in the canonical bundle hashed into the attestation `user_data`
-  // commitment so external verifiers can confirm which (chain, contract, asset)
-  // tuple this enclave is provisioned for. See docs/pubkey-attestation.md.
   uint64 chain_id               = 8;
   bytes  bridge_contract        = 9;   // 20 bytes (zeros = unset)
   string rgb_asset_id           = 10;
+
+  bytes evm_gas_tx_uncompressed_pub = 11;  // 64 bytes — separate gas TX key at m/44'/60'/0'/0/1
+  bytes evm_gas_tx_address      = 12;  // 20 bytes — Ethereum address of the gas TX key
 }
 
 message GetPublicKeyRequest {
@@ -88,11 +86,12 @@ message PublicKeysResponse {
   bytes evm_uncompressed_pub    = 7;  // 64 bytes — secp256k1 X||Y (no 04 prefix)
 
   // Bridge config pinned at enclave boot (see InitializeKeyResponse).
-  // Mirrored here so GetPublicKey / GetAttestedPublicKey expose the same
-  // bundle a verifier needs to rebuild the canonical commitment.
   uint64 chain_id               = 8;
   bytes  bridge_contract        = 9;   // 20 bytes (zeros = unset)
   string rgb_asset_id           = 10;
+
+  bytes evm_gas_tx_uncompressed_pub = 11;  // 64 bytes — separate gas TX key at m/44'/60'/0'/0/1
+  bytes evm_gas_tx_address      = 12;  // 20 bytes — Ethereum address of the gas TX key
 }
 
 // Returns the public-key bundle along with an NSM attestation document
@@ -283,6 +282,18 @@ message SetCloneRequest {
 // the wire (matching every other request). The body is intentionally empty
 // — a successful SetClone is silent and the caller probes GetPublicKey.
 message SetCloneResponse {
+}
+
+// === Raw Digest Signing (EVM gas tx) ===
+// Signs a pre-hashed 32-byte digest directly with the dedicated EVM gas key,
+// without additional hashing. Used for outer Ethereum transaction signing.
+
+message SignRawDigestRequest {
+  bytes digest = 1;  // Exactly 32 bytes — already-hashed data to sign
+}
+
+message RawDigestSignatureResponse {
+  bytes signature = 1;  // 65 bytes: r(32) + s(32) + v(1)
 }
 
 // === SPV — Bitcoin header sync ===

--- a/proto/parentadapter.proto
+++ b/proto/parentadapter.proto
@@ -102,4 +102,7 @@ message AttestedPublicKeyResponse {
   uint64 chain_id              = 9;
   bytes  bridge_contract       = 10;  // 20 bytes (zeros = unset)
   string rgb_asset_id          = 11;
+
+  bytes evm_gas_tx_uncompressed_pub = 12;  // 64 bytes — separate gas TX key
+  bytes evm_gas_tx_address          = 13;  // 20 bytes — Ethereum address of gas TX key
 }

--- a/proto/signer/signer.proto
+++ b/proto/signer/signer.proto
@@ -12,6 +12,7 @@ enum DataType {
   SWAP = 3;
   UNSPENDABLE = 4;
   OWNER_MULTIPLE_SIGNATURE = 5;
+  EVM_GAS_TX = 6;
 }
 
 message SignRequest {


### PR DESCRIPTION
  Branch / PR Context

  This PR adds EVM gas TX key support, fixes canonical bundle alignment, updates fundsOut selector, and sets
  real SPV checkpoints for mainnet and UTEXO custom signet.

  Summary

  This PR introduces a separate EVM key for gas transactions (m/44'/60'/0'/0/1), isolating it from the main
  bridge signing key (m/44'/60'/0'/0/0). The canonical attestation bundle is extended from 10 to 12 parts to
  include the new key. Parent Adapter now routes TRANSACTION sign requests to BTC or EVM based on network_id
  instead of DataType::Swap. The fundsOut ABI selector is updated to match the 8-arg shape from
  utexo-smart-contracts. Real SPV checkpoints are set for mainnet (block 950,000) and UTEXO custom signet
  (block 311,000).

  What Changed

  Enclave — gas TX key derivation

  - Added evm_gas_tx_address and evm_gas_tx_uncompressed_pub fields to KeyInfo and KeyManager
  - New derivation path m/44'/60'/0'/0/1 in keys.rs
  - New sign_evm_gas_tx() method in state.rs
  - Exposed gas TX fields in PublicKeysResponse via server.rs

  Enclave — fundsOut selector

  - Updated FUNDS_OUT_SELECTOR_MINTBURN from 0x179bef59 to 0xccddb768 in evm_crosscheck.rs
  - Matches the 8-arg fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes) ABI from
  utexo-smart-contracts/dev

  Enclave — SPV checkpoints

  - Set real mainnet checkpoint — block 950,000 (2026-05-18), verified via double-SHA256
  - Set real UTEXO custom signet checkpoint — block 311,000 (2026-05-25), verified via double-SHA256
  - allow-seed-import feature acts as escape hatch for local E2E with placeholder checkpoints
  - Non-PoW networks (signet/regtest) skip epoch start lookup at retarget boundaries, preventing
  HeaderNotFound
  - New test non_pow_network_skips_epoch_lookup_across_retarget_boundary in chain.rs

  Parent Adapter — sign routing by network_id

  - Added evm_network_ids: HashSet<u64> config to ParentAdapterService
  - TRANSACTION requests with network_id in evm_network_ids are routed to EVM signing
  - TRANSACTION requests with network_id not in evm_network_ids are routed to BTC PSBT signing
  - EVM_GAS_TX requests are routed to the new gas TX signing path
  - Removed the DataType::Swap routing path

  Parent Adapter — canonical bundle alignment

  - Extended canonical_bundle() in attest_verify.rs from 10 to 12 parts
  - Added evm_gas_tx_uncompressed_pub and evm_gas_tx_address fields to AttestedPublicKeyResponse

  Proto

  - enclave.proto — added evm_gas_tx_uncompressed_pub and evm_gas_tx_address to PublicKeysResponse
  - parentadapter.proto — added evm_gas_tx_uncompressed_pub and evm_gas_tx_address to
  AttestedPublicKeyResponse
  - signer/signer.proto — added EVM_GAS_TX = 6 to DataType enum

  Tests

  - All canonical_bundle computations updated from 10 to 12 parts (test_attested_pubkey.rs,
  test_grpc_bridge.rs)
  - Added gas TX fields to PublicKeysResponse construction in test_clone.rs
  - grpc_public_key_roundtrip renamed to grpc_public_key_evm_gas_tx — tests EVM_GAS_TX data type
  - grpc_public_key_returns_evm_address_for_swap renamed to grpc_public_key_rejects_transaction_type —
  verifies TRANSACTION without matching network_id is rejected
  - All EVM sign tests updated to use network_id: 84 + DataType::Transaction instead of DataType::Swap
  - ParentAdapterService::new() calls updated with evm_network_ids parameter in test_attest_verify_e2e.rs and
  test_grpc_bridge.rs

  What did NOT change

  - BTC PSBT signing flow
  - RGB consignment validation
  - Enclave attestation verification logic (only the bundle content changed)
  - vsock / TCP transport layer
  - CD pipelines

  Validation

  - cargo fmt --check — clean
  - cargo clippy --workspace --all-targets -- -D warnings — clean
  - cargo test --workspace — 222 tests pass
  - E2E FundsOut RGB→Arbitrum with gas TX key — blocked on MultisigProxy contract address update

  Notes For Review

  Main review focus:
  - Gas TX key derivation path m/44'/60'/0'/0/1 and its isolation from main EVM key
  - network_id-based routing in grpc_server.rs replacing DataType::Swap
  - Canonical bundle 10→12 parts alignment across enclave, parent, and all tests
  - Real checkpoint values for mainnet and signet
