### PR TITLE
fix(signing): bind asset identity to pin, fail-closed unconfigured, guard dev features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, dev]
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,7 @@ jobs:
   # misconfigured Dockerfile / CI matrix can never ship one. Each feature is
   # built individually with `--release`; the build MUST fail, and fail via
   # our guard rather than some unrelated error. Runs separately from `ci`
-  # because these builds are expected to fail. None of the three features
-  # pulls the private SSH-hosted rgb dep, so no deploy key is needed here.
+  # because these builds are expected to fail.
   release-guards:
     runs-on: ubuntu-latest
     strategy:
@@ -97,6 +96,15 @@ jobs:
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
+
+      # `rgb-consignment` is an optional git dep, but cargo still resolves
+      # (and fetches) it from its pinned lockfile revision even when the
+      # feature is off — so the build needs the deploy key to reach the
+      # `compile_error!`, just like the `ci` job above.
+      - name: Set up SSH for private RGB deps
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.RGB_CONSIGNMENT_PARSER_DEPLOY_KEY }}
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,50 @@ jobs:
       # what the SPV unit + integration tests exercise.
       - name: Test (--features spv)
         run: cargo test -p utexo-bridge-enclave --features spv
+
+  # Assert the dev-only features `compile_error!` in a release build, so a
+  # misconfigured Dockerfile / CI matrix can never ship one. Each feature is
+  # built individually with `--release`; the build MUST fail, and fail via
+  # our guard rather than some unrelated error. Runs separately from `ci`
+  # because these builds are expected to fail. None of the three features
+  # pulls the private SSH-hosted rgb dep, so no deploy key is needed here.
+  release-guards:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        feature: [allow-seed-import, mock-attestation, dev-mode]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust 1.89
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.89"
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-guards-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-release-guards-
+
+      - name: Assert release build is rejected with ${{ matrix.feature }}
+        run: |
+          if cargo build -p utexo-bridge-enclave --release --features ${{ matrix.feature }} 2>build.log; then
+            echo "::error::release build unexpectedly SUCCEEDED with '${{ matrix.feature }}' — the compile_error release guard is missing or not firing"
+            exit 1
+          fi
+          if ! grep -q "must not be enabled in a release build" build.log; then
+            echo "::error::release build failed, but not via the expected compile_error guard for '${{ matrix.feature }}'"
+            cat build.log
+            exit 1
+          fi
+          echo "OK: release build correctly rejected '${{ matrix.feature }}' via the compile_error guard"

--- a/build/Dockerfile.enclave-dev
+++ b/build/Dockerfile.enclave-dev
@@ -37,10 +37,16 @@ WORKDIR /build/enclave
 # the enclave fails-closed on any request that carries merkle_proofs,
 # which is what we want — build mismatch should always fail loudly.
 #
+# DEBUG build (no `--release`): `allow-seed-import` is one of the dev-only
+# features that `compile_error!`s in a release build (`debug_assertions`
+# off) — see the release guards in `enclave/src/lib.rs`. Building the dev
+# image in debug keeps `debug_assertions` on so the guard stays quiet while
+# still refusing the feature in any production (release) build.
+#
 # `--mount=type=ssh` exposes the SSH_AUTH_SOCK forwarded by `--ssh default`
 # only for the duration of this RUN, so no credentials end up in the
 # image layers.
-RUN --mount=type=ssh cargo build --release --features allow-seed-import,spv
+RUN --mount=type=ssh cargo build --features allow-seed-import,spv
 
 # ===== Runtime Stage =====
 FROM debian:bookworm-slim
@@ -52,7 +58,7 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /home/enclave
 
-COPY --from=builder /build/target/release/utexo-bridge-enclave ./utexo-bridge-enclave
+COPY --from=builder /build/target/debug/utexo-bridge-enclave ./utexo-bridge-enclave
 
 RUN chown -R enclave:enclave .
 

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -1,5 +1,46 @@
 #![deny(unsafe_code)]
 
+// Release guards (audit TEE-IK-01 / TEE-CL-02 + dev-mode). Three dev-only
+// features are catastrophic if accidentally enabled in a shipped build:
+//
+//   * `allow-seed-import` — the parent can install a chosen seed on a fresh
+//     enclave, defeating the in-enclave key custody.
+//   * `mock-attestation`  — zero-PCR attestation documents are accepted, so
+//     a forged "enclave" passes verification.
+//   * `dev-mode`          — every signing cross-check is skipped.
+//
+// A release build (`debug_assertions` off) must never carry any of them, so
+// each trips a `compile_error!` instead of producing a binary. A misconfigured
+// Dockerfile or CI matrix fails loudly at build time rather than shipping a
+// trust-defeating enclave. `not(test)` exempts `cargo test --release`, which
+// legitimately exercises the dev paths; local dev images build in debug
+// (`build/Dockerfile.enclave-dev`), which keeps `debug_assertions` on.
+//
+// `dev_feature_release_guard!` keeps the three checks in one place so the
+// pattern can't drift between features.
+macro_rules! dev_feature_release_guard {
+    ($feature:literal, $msg:literal) => {
+        #[cfg(all(feature = $feature, not(debug_assertions), not(test)))]
+        compile_error!($msg);
+    };
+}
+
+dev_feature_release_guard!(
+    "allow-seed-import",
+    "`allow-seed-import` must not be enabled in a release build (debug_assertions off): \
+     it lets the parent install a chosen seed. Build dev images in debug mode."
+);
+dev_feature_release_guard!(
+    "mock-attestation",
+    "`mock-attestation` must not be enabled in a release build (debug_assertions off): \
+     it accepts zero-PCR attestation documents."
+);
+dev_feature_release_guard!(
+    "dev-mode",
+    "`dev-mode` must not be enabled in a release build (debug_assertions off): \
+     it skips all signing cross-checks."
+);
+
 pub mod attestation;
 pub mod cloning;
 pub mod config;

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -368,13 +368,20 @@ fn handle_sign_evm(ctx: &ServerContext, req: SignEvmRequest) -> Result<EnclaveRe
                 witness_txids_count = v.witness_txids.len(),
                 "RGB consignment validated in-enclave"
             );
-            // Cross-check contract_id against declared rgb_asset_id if present
-            if !req.rgb_asset_id.is_empty() && v.contract_id != req.rgb_asset_id {
-                return Err(EnclaveError::CrossCheck(format!(
-                    "contract_id mismatch: consignment has {} but request declares {}",
-                    v.contract_id, req.rgb_asset_id
-                )));
-            }
+            // Asset-identity binding (audit TEE-SE-01). Bind the validated
+            // consignment's authoritative `contract_id` to the pinned
+            // RGB_ASSET_ID and fail closed when either is absent — closes
+            // the bypass where an empty `req.rgb_asset_id` skipped the
+            // identity check entirely. Skipped under dev-mode like the
+            // other cross-checks (#64 compile-guards dev-mode out of
+            // release); the qualified path avoids depending on the
+            // dev-mode-gated `validation` import alias.
+            #[cfg(not(feature = "dev-mode"))]
+            crate::validation::evm_crosscheck::bind_asset_identity(
+                &v.contract_id,
+                &req.rgb_asset_id,
+                &ctx.bridge_config.rgb_asset_id,
+            )?;
             Some(v)
         } else {
             tracing::warn!("RGB validator not configured, skipping in-enclave validation");

--- a/enclave/src/validation/evm_crosscheck.rs
+++ b/enclave/src/validation/evm_crosscheck.rs
@@ -182,6 +182,24 @@ pub fn validate_evm_request(req: &SignEvmRequest, bridge_config: &BridgeConfig) 
             )));
         }
 
+        // 4a. Fail-closed when unconfigured (audit TEE-SE-12). A build that
+        //     can validate consignments (rgb-validation enabled — this whole
+        //     block) must refuse to sign when the operator pinned nothing:
+        //     otherwise a misprovisioned-but-running enclave silently degrades
+        //     to the pre-pin, listener-trusting model. The escape hatch is
+        //     intentionally narrow: dev-mode skips this function entirely (see
+        //     `handle_sign_evm`), and the library unit tests (`cfg(test)`) keep
+        //     exercising the legacy unconfigured path. Integration tests pin a
+        //     config explicitly via `start_test_server_with_config`.
+        #[cfg(not(test))]
+        if !bridge_config.is_configured() {
+            return Err(EnclaveError::CrossCheck(
+                "bridge config unconfigured: set EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID \
+                 — refusing to sign in listener-trusting mode"
+                    .into(),
+            ));
+        }
+
         // 4b. Pinned-config cross-check. When the operator configured
         //     EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID at boot, the
         //     listener-supplied values MUST match — otherwise a compromised
@@ -235,6 +253,57 @@ pub fn validate_evm_request(req: &SignEvmRequest, bridge_config: &BridgeConfig) 
 
         Ok(())
     }
+}
+
+/// Asset-identity binding (audit TEE-SE-01).
+///
+/// The in-enclave RGB validator derives `contract_id` from the
+/// consignment's genesis — it is the authoritative asset identity, not
+/// anything the listener declares. This binds that identity to the
+/// operator-pinned `RGB_ASSET_ID` and **fails closed when either side is
+/// absent**: without both, the enclave cannot prove the consignment is
+/// against the bridge's own asset, so a foreign-asset burn could otherwise
+/// authorise a USDT0 unlock (the listener-triggerable funds-theft path the
+/// finding describes).
+///
+/// `declared_rgb_asset_id` is the listener-supplied `req.rgb_asset_id`:
+/// advisory only. When present it must agree with the validated identity,
+/// but — unlike the previous check — an *empty* declared value no longer
+/// short-circuits the binding. The pin and the validated `contract_id` are
+/// what authorise the unlock.
+#[cfg(feature = "rgb-validation")]
+pub fn bind_asset_identity(
+    validated_contract_id: &str,
+    declared_rgb_asset_id: &str,
+    pinned_rgb_asset_id: &str,
+) -> Result<()> {
+    if pinned_rgb_asset_id.is_empty() {
+        return Err(EnclaveError::CrossCheck(
+            "asset-identity pin missing: RGB_ASSET_ID is not configured — refusing to bind \
+             consignment to an unknown asset"
+                .into(),
+        ));
+    }
+    if validated_contract_id.is_empty() {
+        return Err(EnclaveError::CrossCheck(
+            "validated consignment has empty contract_id — cannot bind asset identity".into(),
+        ));
+    }
+    if validated_contract_id != pinned_rgb_asset_id {
+        return Err(EnclaveError::CrossCheck(format!(
+            "contract_id mismatch: consignment asset {} != pinned RGB_ASSET_ID {}",
+            validated_contract_id, pinned_rgb_asset_id
+        )));
+    }
+    // Defence-in-depth: when the listener declares an asset it must agree
+    // with the validated identity. Never load-bearing on its own.
+    if !declared_rgb_asset_id.is_empty() && validated_contract_id != declared_rgb_asset_id {
+        return Err(EnclaveError::CrossCheck(format!(
+            "contract_id mismatch: consignment has {} but request declares {}",
+            validated_contract_id, declared_rgb_asset_id
+        )));
+    }
+    Ok(())
 }
 
 /// Mint/burn-side amount cross-check for the new 8-arg `fundsOut`
@@ -951,6 +1020,84 @@ mod tests {
             assert!(validate_funds_out_transfer(&req, &validated).is_ok());
         }
     }
+
+    // =========================================================================
+    // Asset-identity binding — `bind_asset_identity` (audit TEE-SE-01,
+    // coverage map U-1 / T-01). The validated consignment's `contract_id`
+    // must match the pinned RGB_ASSET_ID; neither side may be absent.
+    // =========================================================================
+
+    #[cfg(feature = "rgb-validation")]
+    mod asset_bind {
+        use super::*;
+
+        const PIN: &str = "rgb:test-asset";
+
+        /// Happy path: validated contract_id == pin, listener agrees.
+        #[test]
+        fn binds_when_contract_id_matches_pin() {
+            assert!(bind_asset_identity(PIN, PIN, PIN).is_ok());
+        }
+
+        /// Listener may stay silent; the pin + validated identity carry it.
+        #[test]
+        fn binds_when_declared_is_empty() {
+            assert!(bind_asset_identity(PIN, "", PIN).is_ok());
+        }
+
+        /// The core bypass: an empty `req.rgb_asset_id` must NOT skip the
+        /// binding. A foreign-asset consignment with no declared id must be
+        /// rejected against the pin rather than waved through.
+        #[test]
+        fn rejects_foreign_asset_even_when_declared_is_empty() {
+            let err = bind_asset_identity("rgb:foreign-asset", "", PIN).unwrap_err();
+            assert!(
+                err.to_string().contains("contract_id mismatch")
+                    && err.to_string().contains("pinned RGB_ASSET_ID"),
+                "expected pin mismatch, got: {err}"
+            );
+        }
+
+        /// Fail-closed when the operator pinned no asset.
+        #[test]
+        fn rejects_when_pin_absent() {
+            let err = bind_asset_identity(PIN, PIN, "").unwrap_err();
+            assert!(
+                err.to_string().contains("asset-identity pin missing"),
+                "expected pin-missing rejection, got: {err}"
+            );
+        }
+
+        /// Fail-closed when the consignment yields no contract identity.
+        #[test]
+        fn rejects_when_contract_id_absent() {
+            let err = bind_asset_identity("", PIN, PIN).unwrap_err();
+            assert!(
+                err.to_string().contains("empty contract_id"),
+                "expected empty-contract_id rejection, got: {err}"
+            );
+        }
+
+        /// Listener declares a different asset than the validated identity:
+        /// the defence-in-depth leg fires even though the pin matches.
+        #[test]
+        fn rejects_when_declared_disagrees_with_validated() {
+            let err = bind_asset_identity(PIN, "rgb:listener-lied", PIN).unwrap_err();
+            assert!(
+                err.to_string().contains("request declares"),
+                "expected declared-mismatch rejection, got: {err}"
+            );
+        }
+    }
+
+    // =========================================================================
+    // Fail-closed when unconfigured (4a) — `validate_evm_request` rejects in
+    // production builds (audit TEE-SE-12). The unconfigured guard is compiled
+    // out under `cfg(test)`, so this is asserted at the integration layer
+    // (`enclave/tests/test_signing.rs`) where the library is built without
+    // `cfg(test)`. The unit tests here continue to exercise the legacy
+    // unconfigured path via `unconfigured()`.
+    // =========================================================================
 
     // =========================================================================
     // Pinned-config cross-check (4b) — `validate_evm_request` with pinned

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -1,8 +1,23 @@
 mod common;
 
+use utexo_bridge_enclave::config::BridgeConfig;
 use utexo_bridge_enclave::proto::enclave_request::Request;
 use utexo_bridge_enclave::proto::enclave_response::Response;
 use utexo_bridge_enclave::proto::*;
+
+/// Pinned `BridgeConfig` matching the defaults of `valid_sign_evm_request`
+/// (chain_id 1, proxy/bridge contract `0xAA…`, asset `rgb:test`). Tests
+/// that need to pass the production fail-closed gate (audit TEE-SE-12) and
+/// the pinned cross-check inject this rather than relying on env, which is
+/// the empty/unconfigured default in CI.
+#[allow(dead_code)]
+fn pinned_bridge_config() -> BridgeConfig {
+    BridgeConfig {
+        chain_id: 1,
+        bridge_contract: [0xAA; 20],
+        rgb_asset_id: "rgb:test".into(),
+    }
+}
 
 /// Build a mock fundsOut calldata with the given amount and commission.
 /// fundsOut(address token, address recipient, uint256 amount, uint256 commission, ...)
@@ -264,7 +279,10 @@ fn test_sign_evm_rejects_consignment_valid_with_empty_bytes() {
 #[cfg(feature = "rgb-validation")]
 #[test]
 fn test_sign_evm_rejects_funds_out_without_validator() {
-    let port = common::start_test_server();
+    // Pinned config so the request clears the production fail-closed gate
+    // (TEE-SE-12) and the pinned cross-check, leaving the handler-level
+    // "validator didn't run" check as the failing predicate under test.
+    let port = common::start_test_server_with_config(|_| {}, pinned_bridge_config());
 
     let init_req = EnclaveRequest {
         request: Some(Request::InitializeKey(InitializeKeyRequest {
@@ -288,6 +306,52 @@ fn test_sign_evm_rejects_funds_out_without_validator() {
             assert!(
                 e.message.contains("validated consignment"),
                 "expected validated-consignment rejection, got: {}",
+                e.message
+            );
+        }
+        other => panic!("expected ErrorResponse, got {:?}", other),
+    }
+}
+
+/// Fail-closed regression (audit TEE-SE-12): a build that can validate
+/// consignments must refuse to sign when no operator config is pinned,
+/// rather than silently degrading to the listener-trusting model. The
+/// integration harness builds the library without `cfg(test)`, so the
+/// production guard in `validate_evm_request` is active here — exactly the
+/// path a misprovisioned-but-running enclave would hit. Uses an
+/// unconfigured `BridgeConfig` (constructed explicitly so a developer's
+/// env can't accidentally configure it away).
+#[cfg(feature = "rgb-validation")]
+#[test]
+fn test_sign_evm_rejects_unconfigured_bridge_config() {
+    let unconfigured = BridgeConfig {
+        chain_id: 0,
+        bridge_contract: [0u8; 20],
+        rgb_asset_id: String::new(),
+    };
+    let port = common::start_test_server_with_config(|_| {}, unconfigured);
+
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+            mnemonic: String::new(),
+        })),
+    };
+    common::send_request(port, &init_req);
+
+    // A fully-formed, otherwise-valid fundsOut request — the only thing
+    // wrong is that the enclave was never provisioned with a pin.
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignEvm(valid_sign_evm_request(1000, 50))),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    match &resp.response {
+        Some(Response::Error(e)) => {
+            assert_eq!(e.code, 3, "cross-check failures should use code 3");
+            assert!(
+                e.message.contains("unconfigured"),
+                "expected unconfigured fail-closed rejection, got: {}",
                 e.message
             );
         }


### PR DESCRIPTION
Closes #62, #71, #64. Three pre-mainnet audit findings on the `SignEvm` funds surface, in scope order.

## #62 — Asset-identity bypass (TEE-SE-01)
An empty `req.rgb_asset_id` short-circuited the in-enclave `contract_id` check, so a valid foreign-asset burn consignment could authorise a USDT0 unlock — a listener-triggerable funds-theft path.

- New `bind_asset_identity` in `evm_crosscheck.rs` binds the validated consignment's **authoritative** `contract_id` to the operator-pinned `RGB_ASSET_ID`, and **fails closed when either side is absent**.
- The listener-declared `req.rgb_asset_id` is now advisory: it must agree when present, but an empty value no longer skips the binding.
- Wired into `handle_sign_evm` in place of the old declared-only check (skipped under `dev-mode`, like the other cross-checks).

## #71 — Fail-closed when `BridgeConfig` is unconfigured (TEE-SE-12)
Completes #62 — an unconfigured enclave previously logged a warning and proceeded in listener-trusting mode (no chain/contract/asset pin).

- Under `rgb-validation`, `validate_evm_request` now rejects when `BridgeConfig` is unconfigured instead of falling back to the legacy path.
- Escape hatch is narrow: `dev-mode` skips the cross-check function entirely, and the library unit tests (`cfg(test)`) keep exercising the legacy unconfigured path. Integration tests pin a config explicitly via `start_test_server_with_config`.

## #64 — Release guards for dangerous dev features (TEE-IK-01 / TEE-CL-02 + dev-mode)
- `allow-seed-import`, `mock-attestation`, and `dev-mode` each `compile_error!` in a release build (`debug_assertions` off), via a single `dev_feature_release_guard!` macro in `lib.rs`. A misconfigured Dockerfile or CI matrix now fails loudly at build time.
- `build/Dockerfile.enclave-dev` moves to a **debug** build so it can keep using `allow-seed-import` (debug keeps `debug_assertions` on; `checkpoint.rs` already exempts debug builds).
- New `release-guards` CI matrix job builds `--release` with each feature individually and asserts the build fails **via the guard** (not some unrelated error).

## Tests
- `bind_asset_identity` unit regression (coverage-map U-1 / T-01), incl. the empty-declared-id bypass.
- `test_sign_evm_rejects_unconfigured_bridge_config` integration test (production guard active without `cfg(test)`).
- Repointed `test_sign_evm_rejects_funds_out_without_validator` to a pinned config so it still isolates the handler-level check.

## Local CI (all green)
`cargo fmt --all -- --check` · `cargo clippy --workspace --all-targets -D warnings` · `cargo test --workspace` · production combo `--features vsock,rgb-validation,spv` (clippy + build) · `cargo test -p utexo-bridge-enclave --features spv`. Verified each release guard fires in `--release` and the debug dev-image build still compiles.