### PR TITLE
evm msig fix

### DIFF
--- a/enclave/src/spv/checkpoint.rs
+++ b/enclave/src/spv/checkpoint.rs
@@ -10,7 +10,7 @@
 //!
 //! - **Mainnet checkpoint** — block 950 000 (2026-05-18). Verified via
 //!   double-SHA256 of raw header from blockstream.info/api.
-//! - **Signet checkpoint** — UTEXO custom signet block 311 000 (2026-05-25).
+//! - **Signet checkpoint** — UTEXO custom signet block 334 000 (2026-06-02).
 //!   Verified via double-SHA256 of raw header from esplora-api.utexo.com.
 //! - **Signet challenge / magic / block time** — REAL values, provided by
 //!   Oleksandr 2026-04-30. UTEXO custom signet, 3-of-3 multisig, 30s blocks.
@@ -54,17 +54,17 @@ pub const MAINNET_CHECKPOINT: Checkpoint = Checkpoint {
     is_real: true,
 };
 
-/// UTEXO custom signet checkpoint — block 311 000 (2026-05-25).
-/// hash (display): 00000236acddd52681c79ae733060376ce4f0ea0171876f2955e2125e32492f8
+/// UTEXO custom signet checkpoint — block 334 000 (2026-06-02).
+/// hash (display): 000000ac5fccb8a26d3bf859952e164b4fb65190c8f29c8339c6a2c39f3aeb66
 pub const SIGNET_CHECKPOINT: Checkpoint = Checkpoint {
-    height: 311_000,
+    height: 334_000,
     hash: [
-        0xf8, 0x92, 0x24, 0xe3, 0x25, 0x21, 0x5e, 0x95, 0xf2, 0x76, 0x18, 0x17, 0xa0, 0x0e, 0x4f,
-        0xce, 0x76, 0x03, 0x06, 0x33, 0xe7, 0x9a, 0xc7, 0x81, 0x26, 0xd5, 0xdd, 0xac, 0x36, 0x02,
+        0x66, 0xeb, 0x3a, 0x9f, 0xc3, 0xa2, 0xc6, 0x39, 0x83, 0x9c, 0xf2, 0xc8, 0x90, 0x51, 0xb6,
+        0x4f, 0x4b, 0x16, 0x2e, 0x95, 0x59, 0xf8, 0x3b, 0x6d, 0xa2, 0xb8, 0xcc, 0x5f, 0xac, 0x00,
         0x00, 0x00,
     ],
     bits: 0x1e03_77ae,
-    time: 1_779_756_628,
+    time: 1_780_464_472,
     is_real: true,
 };
 

--- a/enclave/src/validation/rgb.rs
+++ b/enclave/src/validation/rgb.rs
@@ -52,7 +52,7 @@ pub struct ValidatedConsignment {
     /// per asset; derived from the genesis operation in RGB 0.11.
     pub contract_id: String,
     /// Bitcoin network the consignment is anchored to, in rgbstd's prefix
-    /// form: `"bc"`, `"bc:testnet3"`, `"bc:signet"`, or `"bc:regtest"`.
+    /// form: `"bc"`, `"bc:testnet3"`/`"tb"`, `"bc:signet"`/`"sb"`, or `"bc:regtest"`.
     /// Used to reject cross-network replay (e.g. a regtest consignment
     /// presented to a mainnet enclave).
     pub chain_net: String,

--- a/enclave/src/validation/spv_crosscheck.rs
+++ b/enclave/src/validation/spv_crosscheck.rs
@@ -183,16 +183,16 @@ pub fn assert_chain_not_stale(
 /// some niche flow) can never accidentally let a wrong-network consignment
 /// reach the signing path.
 pub fn assert_chain_net(consignment_chain_net: &str, enclave_network: Network) -> Result<()> {
-    let expected = match enclave_network {
-        Network::Mainnet => "bc",
-        Network::Signet => "bc:signet",
-        Network::Testnet3 => "bc:testnet3",
-        Network::Regtest => "bc:regtest",
+    let accepted: &[&str] = match enclave_network {
+        Network::Mainnet => &["bc"],
+        Network::Signet => &["bc:signet", "sb"],
+        Network::Testnet3 => &["bc:testnet3", "tb"],
+        Network::Regtest => &["bc:regtest"],
     };
-    if consignment_chain_net != expected {
+    if !accepted.contains(&consignment_chain_net) {
         return Err(EnclaveError::Spv(format!(
             "consignment chain_net {consignment_chain_net:?} does not match \
-             enclave network {enclave_network:?} (expected {expected:?})"
+             enclave network {enclave_network:?} (expected one of {accepted:?})"
         )));
     }
     Ok(())
@@ -662,7 +662,9 @@ mod tests {
     fn assert_chain_net_accepts_matching_pair() {
         assert_chain_net("bc", Network::Mainnet).unwrap();
         assert_chain_net("bc:signet", Network::Signet).unwrap();
+        assert_chain_net("sb", Network::Signet).unwrap();
         assert_chain_net("bc:testnet3", Network::Testnet3).unwrap();
+        assert_chain_net("tb", Network::Testnet3).unwrap();
         assert_chain_net("bc:regtest", Network::Regtest).unwrap();
     }
 

--- a/parent/src/grpc_server.rs
+++ b/parent/src/grpc_server.rs
@@ -271,7 +271,7 @@ impl EnclaveService for ParentAdapterService {
             Some(enclave_response::Response::PublicKeys(r)) => {
                 let public_key = match data_type {
                     DataType::EvmGasTx => r.evm_gas_tx_uncompressed_pub,
-                    DataType::Unspendable => r.btc_compressed_pub,
+                    DataType::Transaction | DataType::Unspendable => r.btc_compressed_pub,
                     other => {
                         return Err(Status::invalid_argument(format!(
                             "PublicKey not supported for data_type {:?}",

--- a/parent/tests/test_grpc_bridge.rs
+++ b/parent/tests/test_grpc_bridge.rs
@@ -238,7 +238,7 @@ async fn grpc_public_key_evm_gas_tx() {
 }
 
 #[tokio::test]
-async fn grpc_public_key_rejects_transaction_type() {
+async fn grpc_public_key_transaction_type() {
     let enclave_port = start_mock_enclave();
     let grpc_port = start_grpc_server(enclave_port).await;
 
@@ -246,16 +246,22 @@ async fn grpc_public_key_rejects_transaction_type() {
         .await
         .unwrap();
 
-    let err = client
+    let resp = client
         .public_key(PublicKeyRequest {
             network_id: 0,
             data_type: DataType::Transaction as i32,
             algorithm: None,
         })
         .await
-        .unwrap_err();
+        .unwrap()
+        .into_inner();
 
-    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    assert_eq!(
+        resp.public_key.len(),
+        33,
+        "Transaction type returns BTC compressed pubkey"
+    );
+    assert_eq!(resp.public_key, vec![0xBB; 33]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
# PR Summary: `evm-msig-fix` → `dev` (utexo-bridge-enclave-signer)

## Overview

Small but critical enclave-side fixes: chain_net compatibility for new rgb-lib versions, updated SPV checkpoint, and `DataType::Transaction` support in the parent adapter.

**5 files changed, 28 insertions, 20 deletions**

---

## Changes

### 1. `DataType::Transaction` support in parent adapter
**File:** `parent/src/grpc_server.rs`

**Problem:** The `public_key()` gRPC handler only supported `DataType::EvmGasTx` and `DataType::Unspendable` — `DataType::Transaction` was rejected with `InvalidArgument`. After the bridge switched from `SWAP` to `TRANSACTION` for RGB→EVM signing, the listener couldn't get the BTC compressed public key.

**Fix:** Added `DataType::Transaction` to the match arm alongside `Unspendable`, both returning `btc_compressed_pub` (33-byte compressed secp256k1 key).

```rust
DataType::EvmGasTx => r.evm_gas_tx_uncompressed_pub,
DataType::Transaction | DataType::Unspendable => r.btc_compressed_pub,
```

### 2. Test updated: `grpc_public_key_rejects_transaction_type` → `grpc_public_key_transaction_type`
**File:** `parent/tests/test_grpc_bridge.rs`

The test previously expected `Transaction` to return an error. Now it expects success and verifies the response contains a 33-byte BTC compressed pubkey (`vec![0xBB; 33]` from mock).

### 3. Chain_net compatibility: `bc:signet`/`sb`, `bc:testnet3`/`tb`
**File:** `enclave/src/validation/spv_crosscheck.rs`

**Problem:** Newer versions of rgb-lib (beta.22+) emit chain_net as short form (`"sb"` for signet, `"tb"` for testnet3) instead of the long form (`"bc:signet"`, `"bc:testnet3"`). The enclave's `assert_chain_net()` only accepted the long form, causing valid consignments to be rejected.

**Fix:** Changed from single-string equality to array of accepted values:
- Mainnet: `["bc"]`
- Signet: `["bc:signet", "sb"]`
- Testnet3: `["bc:testnet3", "tb"]`
- Regtest: `["bc:regtest"]`

Tests updated to verify both forms are accepted.

### 4. Signet SPV checkpoint updated: 311,000 → 334,000
**File:** `enclave/src/spv/checkpoint.rs`

Updated the UTEXO custom signet checkpoint from block 311,000 (2026-05-25) to block 334,000 (2026-06-02) with new hash, timestamp, and same difficulty bits. This keeps the enclave's SPV chain validation efficient (less headers to sync from checkpoint to tip).

### 5. Doc fix: chain_net comment
**File:** `enclave/src/validation/rgb.rs`

Updated `ValidatedConsignment.chain_net` doc comment to list both long and short forms.
