### PR TITLE
fix(crosscheck): treat the single fundsOut selector as the transfer flow

### DIFF
--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -395,21 +395,24 @@ fn handle_sign_evm(ctx: &ServerContext, req: SignEvmRequest) -> Result<EnclaveRe
     #[cfg(not(feature = "dev-mode"))]
     validation::evm_crosscheck::validate_evm_request(&req, &ctx.bridge_config)?;
 
-    // Consignment-bound amount cross-check for both fundsOut selectors.
-    // Every fundsOut signature must be backed by a validated consignment
-    // and an amount that the consignment's last transition actually
-    // accounts for. This is the second half of the bypass closure
-    // started in `validate_evm_request`: that function rejects empty
-    // bytes; this block rejects "bytes present but validator didn't run"
-    // and binds the EVM-side amount to the RGB-side amount.
+    // Consignment-bound amount cross-check for the `fundsOut` transfer
+    // flow. Every fundsOut signature must be backed by a validated
+    // consignment and an amount the consignment's last transition
+    // actually accounts for. This is the second half of the bypass
+    // closure started in `validate_evm_request`: that function rejects
+    // empty bytes; this block rejects "bytes present but validator
+    // didn't run" and binds the EVM-side amount to the RGB-side amount.
     //
-    // `validate_funds_out_burn` / `validate_funds_out_transfer` each
-    // no-op when the selector isn't theirs, so calling both here is
-    // safe — exactly one fires per request.
+    // The contract exposes a single `fundsOut` selector shared by the
+    // pools/transfer flow (live) and the future mint/burn unlock flow,
+    // disambiguated by contract address. Only the transfer check is
+    // wired today — a burn consignment on this selector is rejected by
+    // `validate_funds_out_transfer` ("requires a Transfer transition").
+    // `validate_funds_out_burn` is wired in the mint/burn epic (by the
+    // dedicated mint/burn contract address).
     #[cfg(all(feature = "rgb-validation", not(feature = "dev-mode")))]
     if req.call_data.len() >= 4
-        && (req.call_data[..4] == validation::evm_crosscheck::FUNDS_OUT_SELECTOR_MINTBURN
-            || req.call_data[..4] == validation::evm_crosscheck::FUNDS_OUT_SELECTOR_POOLS_LEGACY)
+        && req.call_data[..4] == validation::evm_crosscheck::FUNDS_OUT_SELECTOR_POOLS
     {
         let validated = validated_consignment.as_ref().ok_or_else(|| {
             EnclaveError::CrossCheck(
@@ -418,7 +421,6 @@ fn handle_sign_evm(ctx: &ServerContext, req: SignEvmRequest) -> Result<EnclaveRe
                     .into(),
             )
         })?;
-        validation::evm_crosscheck::validate_funds_out_burn(&req, validated)?;
         validation::evm_crosscheck::validate_funds_out_transfer(&req, validated)?;
     }
 

--- a/enclave/src/validation/evm_crosscheck.rs
+++ b/enclave/src/validation/evm_crosscheck.rs
@@ -10,41 +10,41 @@ use crate::proto::SignEvmRequest;
 #[cfg(feature = "rgb-validation")]
 use crate::validation::rgb::{ifa, ValidatedConsignment};
 
-/// `keccak256("fundsOut(address,address,uint256,uint256,string,string)")[0..4]`.
-/// 6-arg shape produced by the current `bridge-utexo` listener and
-/// accepted by the currently-deployed `Bridge` contract. Layout:
-/// `[4 selector][32 token][32 recipient][32 amount][32 transactionId][32 srcChainOffset][32 srcAddrOffset]...`.
-pub const FUNDS_OUT_SELECTOR_POOLS_LEGACY: [u8; 4] = [0x1a, 0xd8, 0x80, 0xb2];
-
 /// `keccak256("fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)")[0..4]`.
-/// 8-arg mint/burn shape on `utexo-smart-contracts/dev` (PR #22
-/// route-plugin refactor). Layout:
+///
+/// The deployed `Bridge` contract (`utexo-smart-contracts/dev`, route-plugin
+/// refactor) exposes a **single** `fundsOut`. The pre-refactor 6-arg
+/// `fundsOut(address,address,uint256,uint256,string,string)` (`0x1ad880b2`)
+/// no longer exists. Both the pools/transfer flow (live now) and the
+/// future mint/burn unlock flow go through this one selector — they are
+/// deployed as separate `Bridge` instances and disambiguated by
+/// **contract address**, not by selector.
+///
+/// Layout:
 /// `[4 selector][32 recipient][32 amount][32 burnId][32 sourceChainId][32 destinationChainId][32 srcAddrOffset][32 proofOffset][32 settlementDataOffset]...`.
 /// `proof = abi.encode(uint256 blockHeight, bytes32 commitmentHash)` and
-/// `settlementData = abi.encode(uint256[] fundsInIds)`.
-pub const FUNDS_OUT_SELECTOR_MINTBURN: [u8; 4] = [0xcc, 0xdd, 0xb7, 0x68];
+/// `settlementData = abi.encode(uint256[] fundsInIds)` (mint/burn only).
+pub const FUNDS_OUT_SELECTOR_POOLS: [u8; 4] = [0xcc, 0xdd, 0xb7, 0x68];
 
 /// 4-byte function selectors the enclave is willing to sign `fundsOut`
 /// calldata for. Anything else is rejected up-front before any byte-level
 /// extraction runs.
 ///
-/// Per-selector dispatch happens further down inside
-/// [`validate_evm_request`] — the legacy pools selector keeps its old
-/// amount@68 / commission@100 byte-level checks; the new mint/burn
-/// selector defers amount validation to [`validate_funds_out_burn`]
-/// which compares against the consignment's burn-asset metadata.
-const FUNDS_OUT_SELECTORS: &[[u8; 4]] =
-    &[FUNDS_OUT_SELECTOR_POOLS_LEGACY, FUNDS_OUT_SELECTOR_MINTBURN];
+/// One entry today — the contract has a single `fundsOut`. The handler
+/// routes it to [`validate_funds_out_transfer`] (the live pools flow).
+/// Mint/burn unlock validation ([`validate_funds_out_burn`]) is not wired
+/// yet; it lands in the mint/burn epic, dispatched by contract address.
+const FUNDS_OUT_SELECTORS: &[[u8; 4]] = &[FUNDS_OUT_SELECTOR_POOLS];
 
-/// Byte offset of `amount` in the new 8-arg mint/burn `fundsOut`
-/// calldata. After the 4-byte selector and the 32-byte `recipient`
-/// head slot, `amount` (uint256) sits at byte 36..68.
+/// Byte offset of `amount` in the `fundsOut` calldata. After the 4-byte
+/// selector and the 32-byte `recipient` head slot, `amount` (uint256)
+/// sits at byte 36..68. Shared by the transfer and (future) burn paths
+/// since both use the same ABI.
 ///
-/// Only consumed by [`validate_funds_out_burn`], which lives behind
-/// `rgb-validation`; gate the const the same way so default builds
-/// don't warn about an unused symbol.
+/// Only consumed by the cross-check helpers behind `rgb-validation`;
+/// gate the const the same way so default builds don't warn.
 #[cfg(feature = "rgb-validation")]
-const MINTBURN_AMOUNT_OFFSET: usize = 36;
+const FUNDS_OUT_AMOUNT_OFFSET: usize = 36;
 
 /// Validate enriched SignEvmRequest before signing.
 /// Returns Ok(()) if all cross-checks pass, Err(EnclaveError::CrossCheck) if any fail.
@@ -130,46 +130,15 @@ pub fn validate_evm_request(req: &SignEvmRequest, bridge_config: &BridgeConfig) 
             ));
         }
 
-        // 2 + 3. Per-selector amount cross-checks. The legacy pools shape
-        //    has `calldata_commission`/`calldata_amount` listener-supplied
-        //    plus byte-level offset checks (the binding to the consignment's
-        //    actual asset amount lives in `validate_funds_out_transfer`,
-        //    called from the handler). The new mint/burn shape has no
-        //    commission slot at all and stores `amount` at a different
-        //    offset — its burn-side amount validation lives in
-        //    `validate_funds_out_burn`, also called from the handler.
-        if selector == FUNDS_OUT_SELECTOR_POOLS_LEGACY {
-            let required = req
-                .calldata_amount
-                .checked_add(req.calldata_commission)
-                .ok_or_else(|| {
-                    EnclaveError::CrossCheck("calldata amount + commission overflow".into())
-                })?;
-            if req.rgb_amount < required {
-                return Err(EnclaveError::CrossCheck(format!(
-                    "amount mismatch: rgb_amount ({}) < calldata_amount ({}) + calldata_commission ({})",
-                    req.rgb_amount, req.calldata_amount, req.calldata_commission
-                )));
-            }
-
-            // Calldata verification for the legacy 6-arg shape:
-            //   fundsOut(address token, address recipient, uint256 amount, uint256 transactionId, ...)
-            //   amount at offset 68, transactionId (historically named "commission") at offset 100.
-            let cd_amount = extract_uint256_as_u64(&req.call_data, 68)?;
-            if cd_amount != req.calldata_amount {
-                return Err(EnclaveError::CrossCheck(format!(
-                    "calldata amount mismatch: extracted {} != declared {}",
-                    cd_amount, req.calldata_amount
-                )));
-            }
-            let cd_commission = extract_uint256_as_u64(&req.call_data, 100)?;
-            if cd_commission != req.calldata_commission {
-                return Err(EnclaveError::CrossCheck(format!(
-                    "calldata commission mismatch: extracted {} != declared {}",
-                    cd_commission, req.calldata_commission
-                )));
-            }
-        }
+        // 2 + 3. Amount binding to the consignment is done in
+        //    `validate_funds_out_transfer` (called from the handler):
+        //    it reads `amount` from calldata at FUNDS_OUT_AMOUNT_OFFSET
+        //    and binds it to the validated transfer's output value. The
+        //    contract's `fundsOut` carries no commission slot (commission
+        //    is taken on-chain by `CommissionManager`), so there is no
+        //    commission to cross-check here, and we don't trust the
+        //    listener-supplied `rgb_amount`/`calldata_*` fields for the
+        //    amount decision — the consignment is authoritative.
 
         // 4. Chain/domain present
         if req.chain_id == 0 {
@@ -306,34 +275,37 @@ pub fn bind_asset_identity(
     Ok(())
 }
 
-/// Mint/burn-side amount cross-check for the new 8-arg `fundsOut`
-/// (selector [`FUNDS_OUT_SELECTOR_MINTBURN`]).
+/// Mint/burn-side amount cross-check for the unlock flow.
+///
+/// **Not wired into the handler yet.** The contract exposes a single
+/// `fundsOut` selector ([`FUNDS_OUT_SELECTOR_POOLS`]) shared by the
+/// pools/transfer flow (live) and the mint/burn unlock flow (future),
+/// disambiguated by **contract address**. Until the mint/burn `Bridge`
+/// deployment exists and the handler routes to it by address, the
+/// handler sends this selector to [`validate_funds_out_transfer`] only,
+/// so a burn consignment is rejected there ("requires a Transfer
+/// transition"). This function is kept (and tested) so the unlock-side
+/// logic is ready to wire in the mint/burn epic (issues #57 / #59 / #66).
 ///
 /// Enforces the bridge-spec §8 invariant: an unlock can only release at
 /// most as many EVM units as the RGB side actually destroyed. Concretely:
 ///
 ///   1. The consignment's most recent transition must be an IFA `Burn`
-///      (`transition_type == ifa::TS_BURN`). Any other shape on the
-///      mint/burn selector path means the listener has cooked up a
-///      consignment that doesn't authorise an unlock.
+///      (`transition_type == ifa::TS_BURN`).
 ///   2. The burn transition must carry an `MS_BURNED_ASSET` metadata
 ///      value (the destroyed amount). rgbstd validation rejects burns
 ///      with no such metadata, so reaching this branch with `None`
 ///      indicates a schema mismatch.
-///   3. The calldata's `amount` (at byte offset 36 in the 8-arg shape)
-///      must be ≤ the burned amount. Equal is fine; over is the
-///      attack we're blocking.
+///   3. The calldata's `amount` (at [`FUNDS_OUT_AMOUNT_OFFSET`]) must be
+///      ≤ the burned amount. Equal is fine; over is the attack we block.
 ///
-/// A no-op for any other selector — the caller is expected to invoke
-/// this only after the main [`validate_evm_request`] has whitelisted
-/// the selector, but the no-op guard keeps the function safe to call
-/// unconditionally.
+/// A no-op for any other selector.
 #[cfg(feature = "rgb-validation")]
 pub fn validate_funds_out_burn(
     req: &SignEvmRequest,
     validated: &ValidatedConsignment,
 ) -> Result<()> {
-    if req.call_data.len() < 4 || req.call_data[..4] != FUNDS_OUT_SELECTOR_MINTBURN {
+    if req.call_data.len() < 4 || req.call_data[..4] != FUNDS_OUT_SELECTOR_POOLS {
         return Ok(());
     }
 
@@ -355,7 +327,7 @@ pub fn validate_funds_out_burn(
         )
     })?;
 
-    let calldata_amount = extract_uint256_as_u64(&req.call_data, MINTBURN_AMOUNT_OFFSET)?;
+    let calldata_amount = extract_uint256_as_u64(&req.call_data, FUNDS_OUT_AMOUNT_OFFSET)?;
     if burned < calldata_amount {
         return Err(EnclaveError::CrossCheck(format!(
             "burn amount mismatch: burned ({}) < calldata amount ({})",
@@ -365,27 +337,30 @@ pub fn validate_funds_out_burn(
     Ok(())
 }
 
-/// Pools-side amount cross-check for the legacy 6-arg `fundsOut`
-/// (selector [`FUNDS_OUT_SELECTOR_POOLS_LEGACY`]).
+/// Pools-side amount cross-check for the `fundsOut` transfer flow
+/// (selector [`FUNDS_OUT_SELECTOR_POOLS`]).
 ///
-/// Binds `calldata_amount + calldata_commission` to the consignment's
-/// actual asset value, closing the host-supplied `rgb_amount` trust
-/// gap that the byte-level checks in [`validate_evm_request`] cannot
-/// catch on their own. Concretely:
+/// Binds the calldata `amount` to the consignment's actual asset value,
+/// closing the host-supplied trust gap that a byte-level check in
+/// [`validate_evm_request`] cannot catch on its own. Concretely:
 ///
 ///   1. The consignment's most recent transition must be an IFA
 ///      `Transfer` (`transition_type == ifa::TS_TRANSFER`). Pools-mode
 ///      `fundsOut` releases funds against a federation-bound transfer;
-///      any other shape on this selector means the listener has cooked
-///      up a consignment that doesn't authorise a release.
+///      any other shape (e.g. a burn) on this selector means a
+///      consignment that doesn't authorise a pools release — and, until
+///      the mint/burn flow is wired by contract address, that includes
+///      rejecting burn consignments outright.
 ///   2. The transition's `total_output_amount` (sum across recipient
-///      and change legs) must cover the EVM-side release
-///      (`amount + commission`). This is a coarse binding — it doesn't
-///      verify which output landed on the federation seal — but with
-///      the existing SPV + contract_id cross-checks it raises the bar
-///      to "attacker must have a real, confirmed RGB transfer to the
-///      bridge for ≥ the withdrawal amount" rather than "attacker
-///      sets a field on the wire."
+///      and change legs) must cover the EVM-side release `amount`. This
+///      is a coarse binding — it doesn't yet verify which output landed
+///      on the federation seal (issue #58) — but with the SPV +
+///      contract_id pins it raises the bar to "attacker must have a
+///      real, confirmed RGB transfer to the bridge for ≥ the withdrawal
+///      amount" rather than "attacker sets a field on the wire."
+///
+/// The contract's `fundsOut` carries no commission slot (commission is
+/// taken on-chain by `CommissionManager`), so only `amount` is checked.
 ///
 /// A no-op for any other selector — same dispatch convention as
 /// [`validate_funds_out_burn`].
@@ -394,39 +369,33 @@ pub fn validate_funds_out_transfer(
     req: &SignEvmRequest,
     validated: &ValidatedConsignment,
 ) -> Result<()> {
-    if req.call_data.len() < 4 || req.call_data[..4] != FUNDS_OUT_SELECTOR_POOLS_LEGACY {
+    if req.call_data.len() < 4 || req.call_data[..4] != FUNDS_OUT_SELECTOR_POOLS {
         return Ok(());
     }
 
     let last = validated.last_transition.as_ref().ok_or_else(|| {
         EnclaveError::CrossCheck(
-            "pools-legacy fundsOut requires a consignment with at least one transition".into(),
+            "pools fundsOut requires a consignment with at least one transition".into(),
         )
     })?;
     if last.transition_type != ifa::TS_TRANSFER {
         return Err(EnclaveError::CrossCheck(format!(
-            "pools-legacy fundsOut requires a Transfer transition (last transition_type = {}, want {})",
+            "pools fundsOut requires a Transfer transition (last transition_type = {}, want {})",
             last.transition_type,
             ifa::TS_TRANSFER
         )));
     }
 
-    // Re-extract from raw calldata bytes rather than trusting
-    // `req.calldata_*` — same defence-in-depth pattern as
-    // `validate_funds_out_burn`. `validate_evm_request` has already
-    // checked that the byte-level extracts match the declared fields,
-    // so the two paths agree, but this keeps the consignment binding
-    // independent of any future refactor of the declared fields.
-    let calldata_amount = extract_uint256_as_u64(&req.call_data, 68)?;
-    let calldata_commission = extract_uint256_as_u64(&req.call_data, 100)?;
-    let required = calldata_amount
-        .checked_add(calldata_commission)
-        .ok_or_else(|| EnclaveError::CrossCheck("calldata amount + commission overflow".into()))?;
+    // Read `amount` straight from the calldata bytes rather than
+    // trusting `req.calldata_amount`, then bind it to the consignment's
+    // output value — the consignment is the authority on how much RGB
+    // actually moved to the bridge.
+    let calldata_amount = extract_uint256_as_u64(&req.call_data, FUNDS_OUT_AMOUNT_OFFSET)?;
 
-    if last.total_output_amount < required {
+    if last.total_output_amount < calldata_amount {
         return Err(EnclaveError::CrossCheck(format!(
-            "transfer amount mismatch: consignment total_output_amount ({}) < calldata_amount ({}) + calldata_commission ({})",
-            last.total_output_amount, calldata_amount, calldata_commission
+            "transfer amount mismatch: consignment total_output_amount ({}) < calldata amount ({})",
+            last.total_output_amount, calldata_amount
         )));
     }
     Ok(())
@@ -478,30 +447,23 @@ mod tests {
         }
     }
 
-    /// Build a mock fundsOut calldata with the given amount and commission.
-    /// Selector is the 6-arg `fundsOut(address,address,uint256,uint256,string,string)`
-    /// = `0x1ad880b2` — the one entry in `FUNDS_OUT_SELECTORS`.
-    fn mock_funds_out_calldata(amount: u64, commission: u64) -> Vec<u8> {
-        let mut data = Vec::with_capacity(4 + 7 * 32);
-        data.extend_from_slice(&FUNDS_OUT_SELECTORS[0]);
-        // address token (32 bytes, left-padded)
-        let mut padded = [0u8; 32];
-        padded[12..].copy_from_slice(&[0x11; 20]);
-        data.extend_from_slice(&padded);
-        // address recipient (32 bytes, left-padded)
-        let mut padded = [0u8; 32];
-        padded[12..].copy_from_slice(&[0x22; 20]);
-        data.extend_from_slice(&padded);
-        // uint256 amount
-        let mut padded = [0u8; 32];
-        padded[24..].copy_from_slice(&amount.to_be_bytes());
-        data.extend_from_slice(&padded);
-        // uint256 commission
-        let mut padded = [0u8; 32];
-        padded[24..].copy_from_slice(&commission.to_be_bytes());
-        data.extend_from_slice(&padded);
-        // remaining params — zero-fill
-        data.extend_from_slice(&[0u8; 32 * 3]);
+    /// Build a mock `fundsOut` calldata in the 8-arg shape
+    /// (`fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)`
+    /// = [`FUNDS_OUT_SELECTOR_POOLS`]) with `amount` at
+    /// [`FUNDS_OUT_AMOUNT_OFFSET`] (byte 36). Remaining head slots are
+    /// zero-filled — `validate_evm_request` doesn't read them.
+    fn mock_funds_out_calldata(amount: u64) -> Vec<u8> {
+        let mut data = Vec::with_capacity(4 + 8 * 32);
+        data.extend_from_slice(&FUNDS_OUT_SELECTOR_POOLS);
+        // recipient (32, address)
+        data.extend_from_slice(&[0u8; 32]);
+        // amount (uint256) @ offset 36
+        let mut amt = [0u8; 32];
+        amt[24..].copy_from_slice(&amount.to_be_bytes());
+        data.extend_from_slice(&amt);
+        // 6 more head slots zero-filled (burnId, sourceChainId,
+        // destinationChainId, srcAddrOffset, proofOffset, settlementDataOffset).
+        data.extend_from_slice(&[0u8; 32 * 6]);
         data
     }
 
@@ -528,7 +490,7 @@ mod tests {
         let amount = 1000u64;
         let commission = 50u64;
         SignEvmRequest {
-            call_data: mock_funds_out_calldata(amount, commission),
+            call_data: mock_funds_out_calldata(amount),
             nonce: 1,
             deadline: u64::MAX, // far future
             consignment_valid: true,
@@ -582,26 +544,11 @@ mod tests {
         assert!(validate_evm_request(&req, &unconfigured()).is_ok());
     }
 
-    #[cfg(feature = "rgb-validation")]
-    #[test]
-    fn rejects_amount_mismatch_rgb_less_than_calldata() {
-        let mut req = valid_evm_request();
-        req.rgb_amount = 1049; // 1000 + 50 = 1050, so 1049 is insufficient
-        let err = validate_evm_request(&req, &unconfigured()).unwrap_err();
-        assert!(err.to_string().contains("amount mismatch"));
-    }
-
-    #[cfg(feature = "rgb-validation")]
-    #[test]
-    fn rejects_calldata_extraction_mismatch() {
-        let mut req = valid_evm_request();
-        // Declare a different amount than what's in the actual call_data bytes
-        req.calldata_amount = 9999;
-        // Bump rgb_amount so we pass the consignment amount check first
-        req.rgb_amount = 99999;
-        let err = validate_evm_request(&req, &unconfigured()).unwrap_err();
-        assert!(err.to_string().contains("calldata amount mismatch"));
-    }
+    // Amount binding moved out of `validate_evm_request` (no more
+    // `rgb_amount < calldata_amount + commission` or byte-offset-68
+    // checks) and into `validate_funds_out_transfer`, which binds the
+    // calldata amount to the consignment. See the `transfer` submodule
+    // for that coverage.
 
     #[cfg(feature = "rgb-validation")]
     #[test]
@@ -643,15 +590,6 @@ mod tests {
             err.to_string().contains("rgb-validation"),
             "expected feature-gate rejection, got: {err}"
         );
-    }
-
-    #[cfg(feature = "rgb-validation")]
-    #[test]
-    fn accepts_exact_amount_match() {
-        let mut req = valid_evm_request();
-        // rgb_amount == calldata_amount + calldata_commission exactly
-        req.rgb_amount = req.calldata_amount + req.calldata_commission;
-        assert!(validate_evm_request(&req, &unconfigured()).is_ok());
     }
 
     #[test]
@@ -743,12 +681,14 @@ mod tests {
         use crate::validation::rgb::{TransitionOutput, TransitionSummary, ValidatedConsignment};
 
         /// Build mint/burn-shape calldata with the given `amount` at
-        /// `MINTBURN_AMOUNT_OFFSET`. Everything else (recipient, burnId,
+        /// `FUNDS_OUT_AMOUNT_OFFSET`. Everything else (recipient, burnId,
         /// chain ids, dynamic offsets) is zero-filled — none of those
-        /// fields are inspected by `validate_funds_out_burn` today.
+        /// fields are inspected by `validate_funds_out_burn` today. Uses
+        /// the single `fundsOut` selector; burn-vs-transfer is decided by
+        /// the consignment's transition type, not the selector.
         fn mock_mintburn_calldata(amount: u64) -> Vec<u8> {
             let mut data = Vec::with_capacity(4 + 8 * 32);
-            data.extend_from_slice(&FUNDS_OUT_SELECTOR_MINTBURN);
+            data.extend_from_slice(&FUNDS_OUT_SELECTOR_POOLS);
             // recipient (32, address)
             data.extend_from_slice(&[0u8; 32]);
             // amount (uint256) — offset 36
@@ -868,21 +808,21 @@ mod tests {
         }
 
         #[test]
-        fn no_op_for_non_mintburn_selector() {
-            // Legacy pools-selector calldata — `validate_funds_out_burn`
-            // must not run any burn-side checks against it. Pair it
-            // with a deliberately-bad consignment (Transfer with no
-            // burn metadata) to make sure the function bails before
-            // reading anything.
+        fn no_op_for_non_funds_out_selector() {
+            // Calldata with a selector that isn't `fundsOut` —
+            // `validate_funds_out_burn` must not run any burn-side checks
+            // against it. Pair it with a deliberately-bad consignment
+            // (Transfer with no burn metadata) to make sure the function
+            // bails before reading anything.
             let mut req = req_with_calldata(vec![0u8; 100]);
-            req.call_data[..4].copy_from_slice(&FUNDS_OUT_SELECTOR_POOLS_LEGACY);
+            req.call_data[..4].copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
             let validated = validated_with_last(burn_transition(None));
             assert!(validate_funds_out_burn(&req, &validated).is_ok());
         }
     }
 
     // =========================================================================
-    // Pools-legacy fundsOut tests — `validate_funds_out_transfer`
+    // Pools fundsOut tests — `validate_funds_out_transfer`
     // =========================================================================
 
     #[cfg(feature = "rgb-validation")]
@@ -910,26 +850,21 @@ mod tests {
             }
         }
 
-        /// Pools-legacy calldata with the given `amount` at byte 68 and
-        /// `commission` at byte 100, mirroring the test helper for the
-        /// main `validate_evm_request` tests.
-        fn mock_pools_legacy_calldata(amount: u64, commission: u64) -> Vec<u8> {
-            let mut data = Vec::with_capacity(4 + 7 * 32);
-            data.extend_from_slice(&FUNDS_OUT_SELECTOR_POOLS_LEGACY);
-            // token (32, address)
-            data.extend_from_slice(&[0u8; 32]);
+        /// 8-arg `fundsOut` calldata with `amount` at
+        /// [`FUNDS_OUT_AMOUNT_OFFSET`] (byte 36). The contract carries no
+        /// commission slot, so there's nothing else for the transfer
+        /// check to read.
+        fn mock_pools_calldata(amount: u64) -> Vec<u8> {
+            let mut data = Vec::with_capacity(4 + 8 * 32);
+            data.extend_from_slice(&FUNDS_OUT_SELECTOR_POOLS);
             // recipient (32, address)
             data.extend_from_slice(&[0u8; 32]);
-            // amount @ offset 68
+            // amount (uint256) @ offset 36
             let mut amt = [0u8; 32];
             amt[24..].copy_from_slice(&amount.to_be_bytes());
             data.extend_from_slice(&amt);
-            // commission @ offset 100
-            let mut com = [0u8; 32];
-            com[24..].copy_from_slice(&commission.to_be_bytes());
-            data.extend_from_slice(&com);
-            // 3 more head-slots zero-filled (transactionId, srcChainOffset, srcAddrOffset).
-            data.extend_from_slice(&[0u8; 32 * 3]);
+            // 6 more head slots zero-filled.
+            data.extend_from_slice(&[0u8; 32 * 6]);
             data
         }
 
@@ -952,26 +887,26 @@ mod tests {
         }
 
         #[test]
-        fn passes_when_total_output_covers_calldata_total() {
-            let req = req_with_calldata(mock_pools_legacy_calldata(1000, 50));
-            let validated = validated_with_last(transfer_transition(1050));
+        fn passes_when_total_output_covers_calldata_amount() {
+            let req = req_with_calldata(mock_pools_calldata(1000));
+            let validated = validated_with_last(transfer_transition(1000));
             assert!(validate_funds_out_transfer(&req, &validated).is_ok());
         }
 
         #[test]
-        fn passes_when_total_output_exceeds_calldata_total() {
-            let req = req_with_calldata(mock_pools_legacy_calldata(1000, 50));
+        fn passes_when_total_output_exceeds_calldata_amount() {
+            let req = req_with_calldata(mock_pools_calldata(1000));
             let validated = validated_with_last(transfer_transition(2000));
             assert!(validate_funds_out_transfer(&req, &validated).is_ok());
         }
 
-        /// P0 regression for Yulia's #3: even with a valid consignment
-        /// that deserializes and validates, the EVM-side release cannot
-        /// exceed the RGB-side transfer total. A consignment for 1 unit
-        /// must not authorise a withdrawal for 10^9.
+        /// P0 regression: even with a valid consignment that deserializes
+        /// and validates, the EVM-side release cannot exceed the RGB-side
+        /// transfer total. A consignment for 1 unit must not authorise a
+        /// withdrawal for 10^9.
         #[test]
-        fn rejects_when_total_output_less_than_calldata_total() {
-            let req = req_with_calldata(mock_pools_legacy_calldata(1_000_000_000, 0));
+        fn rejects_when_total_output_less_than_calldata_amount() {
+            let req = req_with_calldata(mock_pools_calldata(1_000_000_000));
             let validated = validated_with_last(transfer_transition(1));
             let err = validate_funds_out_transfer(&req, &validated).unwrap_err();
             assert!(
@@ -980,9 +915,12 @@ mod tests {
             );
         }
 
+        /// A burn consignment arriving on the (single) `fundsOut`
+        /// selector must be rejected by the transfer check — this is how
+        /// mint/burn stays off until it's wired by contract address.
         #[test]
         fn rejects_when_last_transition_is_not_transfer() {
-            let req = req_with_calldata(mock_pools_legacy_calldata(500, 0));
+            let req = req_with_calldata(mock_pools_calldata(500));
             let mut t = transfer_transition(500);
             t.transition_type = crate::validation::rgb::ifa::TS_BURN;
             let validated = validated_with_last(t);
@@ -995,7 +933,7 @@ mod tests {
 
         #[test]
         fn rejects_when_consignment_has_no_transition() {
-            let req = req_with_calldata(mock_pools_legacy_calldata(500, 0));
+            let req = req_with_calldata(mock_pools_calldata(500));
             let validated = ValidatedConsignment {
                 contract_id: "rgb:test".into(),
                 chain_net: "bc".into(),
@@ -1011,11 +949,12 @@ mod tests {
         }
 
         #[test]
-        fn no_op_for_non_pools_legacy_selector() {
-            // Mint/burn-selector calldata — `validate_funds_out_transfer`
-            // must not run any transfer-side checks against it.
+        fn no_op_for_non_funds_out_selector() {
+            // Calldata with a selector that isn't `fundsOut` —
+            // `validate_funds_out_transfer` must not run any transfer-side
+            // checks against it.
             let mut req = req_with_calldata(vec![0u8; 4 + 8 * 32]);
-            req.call_data[..4].copy_from_slice(&FUNDS_OUT_SELECTOR_MINTBURN);
+            req.call_data[..4].copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
             let validated = validated_with_last(transfer_transition(0));
             assert!(validate_funds_out_transfer(&req, &validated).is_ok());
         }

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -19,38 +19,25 @@ fn pinned_bridge_config() -> BridgeConfig {
     }
 }
 
-/// Build a mock fundsOut calldata with the given amount and commission.
-/// fundsOut(address token, address recipient, uint256 amount, uint256 commission, ...)
-///
-/// Selector `0x1ad880b2` is the 6-arg
-/// `fundsOut(address,address,uint256,uint256,string,string)` accepted by
-/// `validation::evm_crosscheck`'s whitelist.
-fn mock_funds_out_calldata(
-    token: [u8; 20],
-    recipient: [u8; 20],
-    amount: u64,
-    commission: u64,
-) -> Vec<u8> {
-    let mut data = Vec::with_capacity(4 + 7 * 32);
-    data.extend_from_slice(&[0x1a, 0xd8, 0x80, 0xb2]);
-    // address token (padded to 32 bytes)
-    let mut padded = [0u8; 32];
-    padded[12..].copy_from_slice(&token);
-    data.extend_from_slice(&padded);
-    // address recipient (padded to 32 bytes)
+/// Build a mock `fundsOut` calldata in the 8-arg shape
+/// `fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)`
+/// (selector `0xccddb768`) — the single `fundsOut` on the deployed
+/// contract, accepted by `validation::evm_crosscheck`'s whitelist.
+/// `amount` sits at offset 36 (after selector + recipient).
+fn mock_funds_out_calldata(recipient: [u8; 20], amount: u64) -> Vec<u8> {
+    let mut data = Vec::with_capacity(4 + 8 * 32);
+    data.extend_from_slice(&[0xcc, 0xdd, 0xb7, 0x68]);
+    // recipient (address, padded to 32 bytes) @ offset 4
     let mut padded = [0u8; 32];
     padded[12..].copy_from_slice(&recipient);
     data.extend_from_slice(&padded);
-    // uint256 amount
+    // amount (uint256) @ offset 36
     let mut padded = [0u8; 32];
     padded[24..].copy_from_slice(&amount.to_be_bytes());
     data.extend_from_slice(&padded);
-    // uint256 commission
-    let mut padded = [0u8; 32];
-    padded[24..].copy_from_slice(&commission.to_be_bytes());
-    data.extend_from_slice(&padded);
-    // remaining params (transactionId, sourceChain, sourceAddress) — zero-fill
-    data.extend_from_slice(&[0u8; 32 * 3]);
+    // 6 more head slots zero-filled (burnId, sourceChainId,
+    // destinationChainId, srcAddrOffset, proofOffset, settlementDataOffset).
+    data.extend_from_slice(&[0u8; 32 * 6]);
     data
 }
 
@@ -68,10 +55,12 @@ fn placeholder_consignment_hash() -> Vec<u8> {
     Keccak256::digest(PLACEHOLDER_CONSIGNMENT).to_vec()
 }
 
-/// Build a valid enriched SignEvmRequest for testing.
+/// Build a valid enriched SignEvmRequest for testing. `commission` is
+/// retained on the proto fields for wire-compat but is no longer part of
+/// the calldata (the contract takes commission on-chain).
 fn valid_sign_evm_request(amount: u64, commission: u64) -> SignEvmRequest {
     SignEvmRequest {
-        call_data: mock_funds_out_calldata([0x11; 20], [0x22; 20], amount, commission),
+        call_data: mock_funds_out_calldata([0x22; 20], amount),
         nonce: 1,
         deadline: u64::MAX,
         consignment_valid: true,
@@ -359,73 +348,17 @@ fn test_sign_evm_rejects_unconfigured_bridge_config() {
     }
 }
 
-// The two amount-mismatch tests below exercise byte-level cross-checks
-// inside `validate_evm_request` that only run under `--features
-// rgb-validation` (the rest of the function is gated behind that cfg
-// now that fundsOut signing requires real consignment bytes). Default
-// builds refuse fundsOut outright, covered by the
-// `rejects_funds_out_in_default_build` test further down.
-#[cfg(feature = "rgb-validation")]
-#[test]
-fn test_sign_evm_rejects_amount_mismatch() {
-    let port = common::start_test_server();
-
-    let init_req = EnclaveRequest {
-        request: Some(Request::InitializeKey(InitializeKeyRequest {
-            seed: vec![],
-            mnemonic: String::new(),
-        })),
-    };
-    common::send_request(port, &init_req);
-
-    let mut req = valid_sign_evm_request(90, 20);
-    req.rgb_amount = 100; // 90 + 20 = 110 > 100 => should fail
-
-    let sign_req = EnclaveRequest {
-        request: Some(Request::SignEvm(req)),
-    };
-    let resp = common::send_request(port, &sign_req);
-
-    match &resp.response {
-        Some(Response::Error(e)) => {
-            assert_eq!(e.code, 3);
-            assert!(e.message.contains("amount mismatch"));
-        }
-        other => panic!("expected ErrorResponse, got {:?}", other),
-    }
-}
-
-#[cfg(feature = "rgb-validation")]
-#[test]
-fn test_sign_evm_rejects_calldata_extraction_mismatch() {
-    let port = common::start_test_server();
-
-    let init_req = EnclaveRequest {
-        request: Some(Request::InitializeKey(InitializeKeyRequest {
-            seed: vec![],
-            mnemonic: String::new(),
-        })),
-    };
-    common::send_request(port, &init_req);
-
-    let mut req = valid_sign_evm_request(1000, 50);
-    // Lie about the calldata amount — doesn't match what's in the raw bytes
-    req.calldata_amount = 9999;
-    req.rgb_amount = 99999; // make sure the amount check passes first
-
-    let sign_req = EnclaveRequest {
-        request: Some(Request::SignEvm(req)),
-    };
-    let resp = common::send_request(port, &sign_req);
-
-    match &resp.response {
-        Some(Response::Error(e)) => {
-            assert_eq!(e.code, 3);
-            assert!(e.message.contains("calldata amount mismatch"));
-        }
-        other => panic!("expected ErrorResponse, got {:?}", other),
-    }
-}
+// Amount binding now lives in `validate_funds_out_transfer`, which runs
+// against a `ValidatedConsignment` (the consignment is authoritative on
+// the amount, not the listener-supplied `rgb_amount`/`calldata_*`
+// fields). It's exhaustively unit-tested in
+// `validation::evm_crosscheck::tests::transfer`. The old integration
+// tests here asserted the removed `rgb_amount < calldata_amount +
+// commission` / byte-offset-68 checks in `validate_evm_request`; those
+// checks are gone with the single-`fundsOut` ABI (no commission slot,
+// amount bound to the consignment instead), so the integration cases
+// were removed rather than ported — they can't run without a configured
+// in-enclave validator, which the harness doesn't wire.
 
 /// Default-build coverage: `--features rgb-validation` is required to
 /// sign fundsOut at all. The cross-check fails fast with a message


### PR DESCRIPTION
## Problem

The deployed `Bridge` contract collapsed to a **single** `fundsOut` — `fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)`, selector `0xccddb768`. The pre-refactor 6-arg `fundsOut(address,address,uint256,uint256,string,string)` (`0x1ad880b2`) no longer exists, and the backend now uses the 8-arg ABI for the **live pools/transfer flow**.

The enclave still mapped `0xccddb768` to burn-only validation, so every transfer-backed `fundsOut` was rejected:

```
cross-check failed: mint/burn fundsOut requires a Burn transition (last transition_type = 10000, want 8010)
```

Not a logic bug — a stale assumption. The contract used to have two `fundsOut` shapes (one per flow); it now has one, shared by transfer (live) and the future mint/burn unlock (separate deploy, disambiguated by **contract address**).

## Changes

- Collapse the two selector constants into one, `FUNDS_OUT_SELECTOR_POOLS = 0xccddb768`; drop the obsolete 6-arg selector and the mint/burn alias. Whitelist now has one entry.
- Rename the amount offset to `FUNDS_OUT_AMOUNT_OFFSET = 36` (recipient is the first head slot, amount the second), shared by the transfer and future burn paths.
- Remove the legacy `amount@68 / commission@100 / rgb_amount` byte-level checks from `validate_evm_request`. The 8-arg shape has no commission slot (taken on-chain by `CommissionManager`); amount binding now lives entirely in `validate_funds_out_transfer` (reads `amount@36`, binds to the consignment's transfer output value).
- Wire only `validate_funds_out_transfer` from the handler. A burn consignment on this selector is cleanly rejected by the transfer check until mint/burn is switched on — which will be dispatched by the dedicated mint/burn contract address. `validate_funds_out_burn` is kept (inert, still unit-tested), ready for that epic.

## Tests

- Transfer/burn unit submodules rebuilt for the 8-arg layout; no-op tests use a non-`fundsOut` selector.
- Removed the unit + integration tests that asserted the deleted `validate_evm_request` amount/offset-68 behaviour — coverage moved to the `transfer` submodule (which binds amount to the consignment).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo build -p utexo-bridge-enclave --features vsock,rgb-validation,spv`
- [x] `cargo clippy -p utexo-bridge-enclave --features vsock,rgb-validation,spv --all-targets -- -D warnings`
- [x] `cargo test -p utexo-bridge-enclave --features spv` — 201 lib tests + integration, all green

## Follow-up

Mint/burn unlock validation (`validate_funds_out_burn`, the BtcRelay-agreement check, burnId / recipient binding) is wired in the mint/burn epic, keyed on the dedicated mint/burn `Bridge` contract address — issues #57 / #59 / #66.