### PR TITLE
fix(enclave): audit fixes #92 #94 #85

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2059,6 +2059,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb-schemas"
+version = "0.11.1-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1903961c836cc3f6963b06c69cb47491a815309f265439f20c932e0a3aa16a78"
+dependencies = [
+ "amplify",
+ "rgb-aluvm",
+ "rgb-ops",
+ "rgb-strict-types",
+]
+
+[[package]]
 name = "rgb-strict-encoding"
 version = "1.0.1"
 source = "git+https://github.com/rgb-protocol/rgb-strict-encoding?branch=master#ddeae3b546b9668cda8fb11efa9eafd0c61ef467"
@@ -2920,6 +2932,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rgb-consignment",
  "rgb-ops",
+ "rgb-schemas",
  "secrecy",
  "serde",
  "sha2",

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -57,6 +57,12 @@ rgb-ops = { version = "0.11.1-rc.7", features = ["esplora_blocking"], optional =
 # parser's `main` branch directly; Cargo.lock pins the exact rev for
 # reproducible builds.
 rgb-consignment = { git = "ssh://git@github.com/UTEXO-Protocol/rgb-consignment-parser.git", branch = "main", default-features = false, optional = true }
+# Canonical RGB schema definitions (NIA/UDA/CFA/IFA). Source of the trusted
+# strict type-system the validator pins consignments against — the same crate
+# rgb-lib uses (`AssetSchema::types()` -> `InflatableFungibleAsset::types()`).
+# Pins per schema_id so a consignment cannot self-validate its own types
+# (audit 4th W-01 / #92). `default-features = false` skips the CLI bin deps.
+rgb-schemas = { version = "=0.11.1-rc.10", default-features = false, optional = true }
 
 # Attestation verification (COSE_Sign1 + AWS Nitro cert chain) lives in
 # the workspace `attestation-verify` crate so the parent CLI binary and
@@ -89,7 +95,7 @@ allow-seed-import = []
 # Skips cross-check validation on signing requests. Development/testing only.
 dev-mode = []
 # In-enclave RGB consignment validation via rgbstd + Esplora.
-rgb-validation = ["rgb-ops", "rgb-consignment"]
+rgb-validation = ["rgb-ops", "rgb-consignment", "rgb-schemas"]
 # Bitcoin SPV verification of consignment witness txids before signing EVM
 # transactions. Implies `rgb-validation` because SPV needs the consignment
 # parsed to extract witness txids. When the feature is OFF, handle_sign_evm

--- a/enclave/src/config.rs
+++ b/enclave/src/config.rs
@@ -53,12 +53,37 @@ impl BridgeConfig {
         }
     }
 
-    /// True if any of the three fields was set via env. Used to gate the
-    /// strict cross-check: when no operator config is present we fall back
-    /// to the legacy "trust the request" behaviour so dev / mock builds
-    /// keep working without ceremony.
+    /// True only when **all three** fields are set to non-zero / non-empty
+    /// values (audit 4th M-03 / #94). Used to gate the strict cross-check:
+    /// only a fully-pinned config authorises bridge signing.
+    ///
+    /// This is deliberately an AND, not an OR. The previous OR let a
+    /// partially-pinned enclave report "configured" while a field was still
+    /// zero, which had two bad consequences in `validate_evm_request`:
+    /// a zero `chain_id` can never match a real request (rejected as
+    /// `chain_id must be > 0`), so the enclave was permanently un-signable yet
+    /// claimed configured; and a zero `bridge_contract` meant an EVM request
+    /// for the **zero address** matched the pin and was accepted.
+    ///
+    /// Requiring all three closes both: a zero `chain_id` or zero
+    /// `bridge_contract` is never treated as a valid pin. A fully-empty
+    /// config (dev / mock builds) still degrades to the legacy
+    /// "trust the request" path; a *partial* config is a misconfiguration —
+    /// see [`is_partially_configured`](Self::is_partially_configured).
     pub fn is_configured(&self) -> bool {
-        self.chain_id != 0 || self.bridge_contract != [0u8; 20] || !self.rgb_asset_id.is_empty()
+        self.chain_id != 0 && self.bridge_contract != [0u8; 20] && !self.rgb_asset_id.is_empty()
+    }
+
+    /// True when the operator set **some but not all** pin fields. This is a
+    /// botched production config (e.g. `EVM_CHAIN_ID` set but `BRIDGE_CONTRACT`
+    /// left at the zero address), distinct from a fully-empty config that
+    /// intentionally selects the legacy dev path. Callers fail closed on this
+    /// rather than silently falling back to listener-trusting mode
+    /// (audit 4th M-03 / #94).
+    pub fn is_partially_configured(&self) -> bool {
+        let any =
+            self.chain_id != 0 || self.bridge_contract != [0u8; 20] || !self.rgb_asset_id.is_empty();
+        any && !self.is_configured()
     }
 }
 
@@ -113,15 +138,42 @@ mod tests {
             rgb_asset_id: String::new(),
         };
         assert!(!c.is_configured());
+        assert!(!c.is_partially_configured());
     }
 
     #[test]
-    fn configured_when_any_set() {
+    fn configured_only_when_all_three_set() {
+        let c = BridgeConfig {
+            chain_id: 1,
+            bridge_contract: [1u8; 20],
+            rgb_asset_id: "rgb:asset".into(),
+        };
+        assert!(c.is_configured());
+        assert!(!c.is_partially_configured());
+    }
+
+    #[test]
+    fn partial_config_is_not_configured() {
+        // chain_id set, contract still zero, asset set: a botched pin. The
+        // OR-logic bug (#94) used to report this "configured" and then accept
+        // an EVM request for the zero address.
         let c = BridgeConfig {
             chain_id: 1,
             bridge_contract: [0u8; 20],
-            rgb_asset_id: String::new(),
+            rgb_asset_id: "rgb:asset".into(),
         };
-        assert!(c.is_configured());
+        assert!(!c.is_configured());
+        assert!(c.is_partially_configured());
+    }
+
+    #[test]
+    fn zero_chain_id_is_not_configured() {
+        let c = BridgeConfig {
+            chain_id: 0,
+            bridge_contract: [1u8; 20],
+            rgb_asset_id: "rgb:asset".into(),
+        };
+        assert!(!c.is_configured());
+        assert!(c.is_partially_configured());
     }
 }

--- a/enclave/src/config.rs
+++ b/enclave/src/config.rs
@@ -81,8 +81,9 @@ impl BridgeConfig {
     /// rather than silently falling back to listener-trusting mode
     /// (audit 4th M-03 / #94).
     pub fn is_partially_configured(&self) -> bool {
-        let any =
-            self.chain_id != 0 || self.bridge_contract != [0u8; 20] || !self.rgb_asset_id.is_empty();
+        let any = self.chain_id != 0
+            || self.bridge_contract != [0u8; 20]
+            || !self.rgb_asset_id.is_empty();
         any && !self.is_configured()
     }
 }

--- a/enclave/src/main.rs
+++ b/enclave/src/main.rs
@@ -44,6 +44,17 @@ fn main() {
             rgb_asset_id = %bridge_config.rgb_asset_id,
             "bridge config pinned from env"
         );
+    } else if bridge_config.is_partially_configured() {
+        // Some-but-not-all pin fields set: a botched production config. SignEvm
+        // fails closed on this (audit 4th M-03 / #94); warn loudly at boot so
+        // the operator sees it before the first rejected request.
+        tracing::error!(
+            chain_id = bridge_config.chain_id,
+            bridge_contract = %hex::encode(bridge_config.bridge_contract),
+            rgb_asset_id = %bridge_config.rgb_asset_id,
+            "bridge config PARTIALLY set — EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID must all \
+             be set (non-zero) or all unset; SignEvm will refuse to sign with this ambiguous pin"
+        );
     } else {
         tracing::warn!(
             "bridge config unconfigured (EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID unset) — \

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -516,6 +516,23 @@ fn handle_sign_psbt(ctx: &ServerContext, req: SignPsbtRequest) -> Result<Enclave
 
     let (signed_psbt, inputs_signed) = ctx.state.sign_psbt(&req.psbt_bytes)?;
 
+    // Reject a "successful" no-op (audit 3rd W-03 / #85). KeyManager::sign_psbt
+    // returns Ok((bytes, 0)) when no PSBT input belongs to this enclave; a
+    // caller that checks only RPC success would treat that as a valid signer
+    // contribution and mis-account quorum. Fail closed in production signing
+    // mode so a 0-signature response can never be mistaken for a contribution.
+    // Partial signing (0 < count < num_inputs) is still allowed. The
+    // KeyManager 0-return stays as a primitive; the policy lives here at the
+    // handler boundary. dev-mode keeps the 0-count path for inspect/dry-run.
+    #[cfg(not(feature = "dev-mode"))]
+    if inputs_signed == 0 {
+        return Err(EnclaveError::Signing(
+            "sign_psbt signed 0 inputs: no PSBT input belongs to this enclave — refusing to \
+             return a no-op as a successful signing response"
+                .into(),
+        ));
+    }
+
     tracing::info!(inputs_signed, "PSBT signed");
 
     Ok(EnclaveResponse {

--- a/enclave/src/validation/evm_crosscheck.rs
+++ b/enclave/src/validation/evm_crosscheck.rs
@@ -151,15 +151,32 @@ pub fn validate_evm_request(req: &SignEvmRequest, bridge_config: &BridgeConfig) 
             )));
         }
 
-        // 4a. Fail-closed when unconfigured (audit TEE-SE-12). A build that
-        //     can validate consignments (rgb-validation enabled — this whole
-        //     block) must refuse to sign when the operator pinned nothing:
-        //     otherwise a misprovisioned-but-running enclave silently degrades
-        //     to the pre-pin, listener-trusting model. The escape hatch is
-        //     intentionally narrow: dev-mode skips this function entirely (see
-        //     `handle_sign_evm`), and the library unit tests (`cfg(test)`) keep
-        //     exercising the legacy unconfigured path. Integration tests pin a
-        //     config explicitly via `start_test_server_with_config`.
+        // 4a. Partial config is always a hard error (audit 4th M-03 / #94).
+        //     The operator set some of EVM_CHAIN_ID / BRIDGE_CONTRACT /
+        //     RGB_ASSET_ID but not all, so the pin is ambiguous: a zero
+        //     chain_id can never match a real request, and a zero
+        //     bridge_contract would otherwise accept an EVM request for the
+        //     zero address. This is never a legitimate dev shape, so — unlike
+        //     the fully-unconfigured fallback below — it is not gated on
+        //     cfg(test).
+        if bridge_config.is_partially_configured() {
+            return Err(EnclaveError::CrossCheck(
+                "bridge config partially set: EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID \
+                 must all be set (non-zero) or all unset — refusing to sign with an ambiguous pin"
+                    .into(),
+            ));
+        }
+
+        // 4b. Fail-closed when fully unconfigured (audit TEE-SE-12). A build
+        //     that can validate consignments (rgb-validation enabled — this
+        //     whole block) must refuse to sign when the operator pinned
+        //     nothing: otherwise a misprovisioned-but-running enclave silently
+        //     degrades to the pre-pin, listener-trusting model. The escape
+        //     hatch is intentionally narrow: dev-mode skips this function
+        //     entirely (see `handle_sign_evm`), and the library unit tests
+        //     (`cfg(test)`) keep exercising the legacy unconfigured path.
+        //     Integration tests pin a config explicitly via
+        //     `start_test_server_with_config`.
         #[cfg(not(test))]
         if !bridge_config.is_configured() {
             return Err(EnclaveError::CrossCheck(
@@ -169,13 +186,15 @@ pub fn validate_evm_request(req: &SignEvmRequest, bridge_config: &BridgeConfig) 
             ));
         }
 
-        // 4b. Pinned-config cross-check. When the operator configured
+        // 4c. Pinned-config cross-check. When the operator configured
         //     EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID at boot, the
         //     listener-supplied values MUST match — otherwise a compromised
         //     listener could redirect signatures to a different chain or
         //     contract. The same values are committed into the attestation
         //     `user_data` so an external verifier can confirm what this
-        //     enclave is provisioned for.
+        //     enclave is provisioned for. `is_configured()` now guarantees all
+        //     three fields are non-zero / non-empty (audit 4th M-03 / #94), so
+        //     none of the comparisons below can be satisfied by a zero pin.
         if bridge_config.is_configured() {
             if req.chain_id != bridge_config.chain_id {
                 return Err(EnclaveError::CrossCheck(format!(
@@ -192,17 +211,10 @@ pub fn validate_evm_request(req: &SignEvmRequest, bridge_config: &BridgeConfig) 
             }
             // rgb_asset_id is optional on the request only when the listener
             // sends nothing (legacy path). Once a request declares an asset,
-            // it must match the pin. The pin itself is always required when
-            // configured — if the operator pinned chain/contract but left
-            // RGB_ASSET_ID unset, the bridge cannot identify the asset and
-            // we'd be back to trusting the listener.
-            if bridge_config.rgb_asset_id.is_empty() {
-                return Err(EnclaveError::CrossCheck(
-                    "bridge config pinned chain/contract but RGB_ASSET_ID is empty — \
-                     set all three env vars or none"
-                        .into(),
-                ));
-            }
+            // it must match the pin. The pin's own non-emptiness is now
+            // guaranteed by `is_configured()` (audit 4th M-03 / #94), so the
+            // previous "pinned chain/contract but RGB_ASSET_ID empty" branch is
+            // unreachable and has been removed.
             if !req.rgb_asset_id.is_empty() && req.rgb_asset_id != bridge_config.rgb_asset_id {
                 return Err(EnclaveError::CrossCheck(format!(
                     "rgb_asset_id mismatch: request {} != pinned {}",
@@ -1107,7 +1119,8 @@ mod tests {
     fn pinned_config_rejects_partial_pin_missing_asset() {
         // Operator misconfiguration: pinned chain/contract but no asset.
         // The function must fail-closed instead of silently allowing any
-        // asset, since the half-pin gives a misleading attestation.
+        // asset, since the half-pin gives a misleading attestation. After
+        // #94 this is caught by the unified partial-config gate.
         let half_pinned = BridgeConfig {
             chain_id: 1,
             bridge_contract: [0xAA; 20],
@@ -1115,8 +1128,23 @@ mod tests {
         };
         let err = validate_evm_request(&valid_evm_request(), &half_pinned).unwrap_err();
         assert!(
-            err.to_string().contains("RGB_ASSET_ID is empty"),
+            err.to_string().contains("partially set"),
             "got: {err}"
         );
+    }
+
+    #[cfg(feature = "rgb-validation")]
+    #[test]
+    fn pinned_config_rejects_zero_bridge_contract() {
+        // A zero bridge_contract is a partial pin (audit 4th M-03 / #94): it
+        // must never be treated as a valid pin that would accept an EVM
+        // request for the zero address.
+        let zero_contract = BridgeConfig {
+            chain_id: 1,
+            bridge_contract: [0u8; 20],
+            rgb_asset_id: "rgb:asset".into(),
+        };
+        let err = validate_evm_request(&valid_evm_request(), &zero_contract).unwrap_err();
+        assert!(err.to_string().contains("partially set"), "got: {err}");
     }
 }

--- a/enclave/src/validation/evm_crosscheck.rs
+++ b/enclave/src/validation/evm_crosscheck.rs
@@ -1127,10 +1127,7 @@ mod tests {
             rgb_asset_id: String::new(),
         };
         let err = validate_evm_request(&valid_evm_request(), &half_pinned).unwrap_err();
-        assert!(
-            err.to_string().contains("partially set"),
-            "got: {err}"
-        );
+        assert!(err.to_string().contains("partially set"), "got: {err}");
     }
 
     #[cfg(feature = "rgb-validation")]

--- a/enclave/src/validation/rgb.rs
+++ b/enclave/src/validation/rgb.rs
@@ -45,6 +45,55 @@ pub mod ifa {
     pub const MS_BURNED_ASSET: u16 = 1001;
 }
 
+/// Resolve the **trusted** strict type-system the validator must pin a
+/// consignment against, sourced from the canonical `rgb-schemas` crate by the
+/// consignment's `schema_id` — exactly as rgb-lib does
+/// (`AssetSchema::types()` → `InflatableFungibleAsset::types()` etc.).
+///
+/// **Audit 4th W-01 / #92.** RGB's `ValidationConfig.trusted_typesystem` must
+/// come from an enclave-pinned source, never from the consignment under
+/// validation: feeding `transfer.types` back in makes rgbstd compare the
+/// consignment's types against themselves (`validator.rs::validate_schema`),
+/// so the control always passes and a malicious consignment can ship its own
+/// type definitions for the schema's `SemId`s. Instead we look the schema_id
+/// up against the schema definitions compiled into `rgb-schemas` and hand the
+/// validator *that* type system; rgbstd then rejects any consignment whose
+/// types differ from the canonical set.
+///
+/// All four standard fungible/collectible schemas are accepted here; the
+/// bridge additionally pins the exact asset via `contract_id` →
+/// `RGB_ASSET_ID` (`bind_asset_identity`), so schema breadth at this layer is
+/// not asset-scoping. An **unknown** schema_id is rejected fail-closed.
+///
+/// Schema ids are compared by their canonical string form so the comparison
+/// is robust to `rgb-schemas` resolving a different `rgb-consensus` build than
+/// the enclave's validator (the `SchemaId` *value* is a content commitment and
+/// stringifies identically across versions).
+#[cfg(feature = "rgb-validation")]
+fn trusted_typesystem_for_schema(schema_id: &str) -> Result<rgbstd::TypeSystem> {
+    use rgbstd::contract::IssuerWrapper;
+    use schemata::{
+        CollectibleFungibleAsset, InflatableFungibleAsset, NonInflatableAsset, UniqueDigitalAsset,
+        CFA_SCHEMA_ID, IFA_SCHEMA_ID, NIA_SCHEMA_ID, UDA_SCHEMA_ID,
+    };
+
+    let types = if schema_id == IFA_SCHEMA_ID.to_string() {
+        InflatableFungibleAsset::types()
+    } else if schema_id == NIA_SCHEMA_ID.to_string() {
+        NonInflatableAsset::types()
+    } else if schema_id == CFA_SCHEMA_ID.to_string() {
+        CollectibleFungibleAsset::types()
+    } else if schema_id == UDA_SCHEMA_ID.to_string() {
+        UniqueDigitalAsset::types()
+    } else {
+        return Err(EnclaveError::CrossCheck(format!(
+            "consignment uses unknown/unsupported RGB schema {schema_id} — refusing to validate \
+             (cannot source a trusted type system)"
+        )));
+    };
+    Ok(types)
+}
+
 /// Data extracted from a successfully validated RGB consignment.
 #[derive(Debug, Clone)]
 pub struct ValidatedConsignment {
@@ -292,10 +341,22 @@ impl RgbValidator {
         // treats them as tentative witnesses (not yet mined).
         resolver.add_consignment_txes(&transfer);
 
+        // Pin the trusted type system (audit 4th W-01 / #92). Source it from
+        // the canonical `rgb-schemas` definitions keyed on the consignment's
+        // schema_id, NOT from `transfer.types`. Passing the consignment's own
+        // types makes rgbstd compare them against themselves (always passes);
+        // the canonical set makes `validate()` reject any consignment that
+        // ships substituted type definitions for the schema's SemIds. An
+        // unknown schema_id is rejected fail-closed inside the helper.
+        let schema_id = transfer.genesis.schema_id.to_string();
+        let trusted_typesystem = trusted_typesystem_for_schema(&schema_id).inspect_err(|_| {
+            tracing::warn!(%contract_id, %schema_id, "no trusted type system for consignment schema");
+        })?;
+
         // 3. Build validation config.
         let config = ValidationConfig {
             chain_net: self.chain_net,
-            trusted_typesystem: transfer.types.clone(),
+            trusted_typesystem,
             build_opouts_dag: true,
             ..Default::default()
         };
@@ -605,6 +666,34 @@ mod tests {
         // round-trip lives behind the validator-level path (which needs
         // network access for Esplora), tracked separately.
         assert_eq!(last.burned_asset_amount, None);
+    }
+
+    #[test]
+    fn trusted_typesystem_sourced_from_schema_not_consignment() {
+        // The W-01 fix (#92): the trusted type system must come from the
+        // canonical rgb-schemas definitions, not from `transfer.types`.
+        // The in-tree fixture is an NIA consignment, so its schema_id resolves
+        // to a canonical type system whose id matches NIA's.
+        let t = Transfer::load(Cursor::new(TRANSFER_FIXTURE)).expect("load transfer fixture");
+        let schema_id = t.genesis.schema_id.to_string();
+
+        let trusted =
+            trusted_typesystem_for_schema(&schema_id).expect("fixture schema must be known");
+
+        // The canonical type system is what rgb-schemas ships for this schema,
+        // and the fixture's own types match it (a legit consignment).
+        assert_eq!(
+            trusted.id().to_string(),
+            t.types.id().to_string(),
+            "canonical type system for the fixture's schema should match the fixture's types"
+        );
+
+        // An unknown schema id is rejected fail-closed.
+        let err = trusted_typesystem_for_schema("rgb:sch:unknown-schema-id").unwrap_err();
+        assert!(
+            err.to_string().contains("unknown/unsupported RGB schema"),
+            "expected unknown-schema rejection, got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
- #92 pin trusted typesystem from rgb-schemas by schema_id (no self-validate)
- #94 require all of chain_id/bridge_contract/rgb_asset_id; reject partial pin
- #85 reject SignPsbt success with inputs_signed == 0 in production mode