### PR TITLE
fix(signing): soft in-memory dedup for EVM→RGB bridge PSBT operations (#84)

### DIFF
--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -514,6 +514,47 @@ fn handle_sign_psbt(ctx: &ServerContext, req: SignPsbtRequest) -> Result<Enclave
         psbt_consignment_crosscheck(ctx, &req)?;
     }
 
+    // Soft operation-uniqueness guard (audit W-02 / #84). In bridge mode,
+    // record the operation tuple and reject a same-op resubmission inside the
+    // TTL window. Check-and-record sits in the critical section — after every
+    // validation above has passed and immediately before signing — so we only
+    // ever record an operation we are actually about to sign, and a duplicate
+    // is rejected before a second signature is produced. Recording before the
+    // sign means a transient `sign_psbt` failure also blocks retries of that
+    // exact tuple until the TTL lapses; that is acceptable for a soft guard
+    // (the concern is double-*success*, and the set self-heals).
+    //
+    // This is defense-in-depth only: the guard is in-memory, per-instance, and
+    // volatile across restart, so it does not replace the durable on-chain
+    // double-spend control (#84/#93). See `EnclaveState::op_replay_guard`.
+    #[cfg(not(feature = "dev-mode"))]
+    if !req.evm_tx_hash.is_empty() {
+        let op_key = validation::psbt_crosscheck::psbt_operation_key(
+            ctx.bridge_config.chain_id,
+            &ctx.bridge_config.bridge_contract,
+            &req.evm_tx_hash,
+            req.operation_idx,
+            &req.rgb_asset_id,
+        );
+        match ctx.state.op_replay_guard.check_and_record(op_key) {
+            Ok(()) => {}
+            Err(EnclaveError::NonceReplay) => {
+                tracing::warn!(
+                    operation_idx = req.operation_idx,
+                    evm_tx_hash = %hex::encode(&req.evm_tx_hash),
+                    "rejecting duplicate bridge PSBT operation (soft replay guard, #84)"
+                );
+                return Err(EnclaveError::CrossCheck(
+                    "duplicate bridge operation: this (chain, contract, evm_tx_hash, \
+                     operation_idx, rgb_asset_id) was already signed recently — refusing to \
+                     sign a replay (soft in-memory guard; durable guard is on-chain)"
+                        .into(),
+                ));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
     let (signed_psbt, inputs_signed) = ctx.state.sign_psbt(&req.psbt_bytes)?;
 
     tracing::info!(inputs_signed, "PSBT signed");

--- a/enclave/src/state.rs
+++ b/enclave/src/state.rs
@@ -49,6 +49,20 @@ const DEFAULT_NONCE_TTL: Duration = Duration::from_secs(60 * 60);
 /// Default hard memory ceiling on recorded nonces.
 const DEFAULT_NONCE_MAX: usize = 10_000;
 
+/// Default TTL for the PSBT bridge-operation dedup guard. Far longer than
+/// the cloning nonce TTL: an EVM→RGB deposit can legitimately be retried
+/// for as long as it remains unsettled, and the window must comfortably
+/// outlast normal listener retry/confirmation latency so a same-op
+/// resubmission is still caught. 24h is generous while keeping the set
+/// self-cleaning in steady state. See [`EnclaveState::op_replay_guard`].
+const DEFAULT_OP_DEDUP_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Hard memory ceiling on recorded bridge operations. At ~80 bytes/entry
+/// this caps the guard near ~8 MB. On overflow inside one TTL window the
+/// oldest entry is evicted (never wedge signing) — see the soft-guard
+/// caveats on [`EnclaveState::op_replay_guard`].
+const DEFAULT_OP_DEDUP_MAX: usize = 100_000;
+
 /// Replay guard for attestation nonces, bounded by **time** (not just
 /// count) so a flooding parent cannot permanently wedge cloning.
 ///
@@ -196,6 +210,23 @@ pub struct EnclaveState {
     donor_cloning_secret: Mutex<Option<SecretBox<String>>>,
     /// Replay guard for nonces in peer attestations.
     pub replay_guard: NonceReplayGuard,
+    /// **Soft** dedup guard for EVM→RGB bridge PSBT operations, keyed on a
+    /// hash of `(chain_id, bridge_contract, evm_tx_hash, operation_idx,
+    /// rgb_asset_id)` (see `validation::psbt_crosscheck::psbt_operation_key`).
+    /// Rejects a same-operation resubmission inside the TTL window before
+    /// signing (audit W-02 / #84).
+    ///
+    /// This is **defense-in-depth, not a sufficient double-spend control**.
+    /// Nitro has no persistent storage, so the set is:
+    ///   - **volatile** — wiped on restart;
+    ///   - **per-instance** — a sibling enclave in the cluster never saw it,
+    ///     so the host can route a duplicate to a fresh peer;
+    ///   - **TTL-bounded** — a replay after eviction is admitted again.
+    ///
+    /// A compromised host that varies any keyed field also bypasses it. It
+    /// stops honest listener retries and naive same-tuple replay; the durable
+    /// cross-instance/cross-restart guard remains an on-chain ticket (#84/#93).
+    pub op_replay_guard: NonceReplayGuard,
 }
 
 impl Default for EnclaveState {
@@ -211,6 +242,10 @@ impl EnclaveState {
             network,
             donor_cloning_secret: Mutex::new(None),
             replay_guard: NonceReplayGuard::default(),
+            op_replay_guard: NonceReplayGuard::with_capacity(
+                DEFAULT_OP_DEDUP_MAX,
+                DEFAULT_OP_DEDUP_TTL,
+            ),
         }
     }
 

--- a/enclave/src/validation/psbt_crosscheck.rs
+++ b/enclave/src/validation/psbt_crosscheck.rs
@@ -5,6 +5,39 @@ use crate::proto::SignPsbtRequest;
 #[cfg(feature = "rgb-validation")]
 use crate::validation::rgb::{ifa, ValidatedConsignment};
 
+/// Derive the soft-dedup key for an EVM→RGB bridge PSBT operation.
+///
+/// 32-byte keccak over `(chain_id, bridge_contract, evm_tx_hash,
+/// operation_idx, rgb_asset_id)`. `chain_id` and `bridge_contract` come from
+/// the enclave's **pinned** [`crate::config::BridgeConfig`] (not the request),
+/// so they can't be varied per-call. The variable-length fields are
+/// length-prefixed and a domain tag is mixed in so two distinct tuples can't
+/// hash to the same key by concatenation ambiguity.
+///
+/// Consumed by the **soft** in-memory replay guard
+/// ([`crate::state::EnclaveState::op_replay_guard`]) — see its doc for why
+/// this is defense-in-depth and not a sufficient double-spend control (#84).
+pub fn psbt_operation_key(
+    chain_id: u64,
+    bridge_contract: &[u8; 20],
+    evm_tx_hash: &[u8],
+    operation_idx: u64,
+    rgb_asset_id: &str,
+) -> [u8; 32] {
+    use sha3::{Digest, Keccak256};
+
+    let mut h = Keccak256::new();
+    h.update(b"utexo:psbt-op:v1");
+    h.update(chain_id.to_be_bytes());
+    h.update(bridge_contract);
+    h.update((evm_tx_hash.len() as u64).to_be_bytes());
+    h.update(evm_tx_hash);
+    h.update(operation_idx.to_be_bytes());
+    h.update((rgb_asset_id.len() as u64).to_be_bytes());
+    h.update(rgb_asset_id.as_bytes());
+    h.finalize().into()
+}
+
 /// Validate enriched SignPsbtRequest before signing.
 ///
 /// Two modes:
@@ -412,6 +445,58 @@ mod tests {
             err.to_string().contains("no inputs"),
             "expected no-inputs rejection, got: {err}"
         );
+    }
+
+    // =========================================================================
+    // Operation-dedup key — `psbt_operation_key` (audit W-02 / #84)
+    // =========================================================================
+
+    #[test]
+    fn op_key_is_deterministic() {
+        let a = psbt_operation_key(1, &[0x11; 20], &[0xAA; 32], 7, "rgb:asset");
+        let b = psbt_operation_key(1, &[0x11; 20], &[0xAA; 32], 7, "rgb:asset");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn op_key_varies_with_every_field() {
+        let base = psbt_operation_key(1, &[0x11; 20], &[0xAA; 32], 7, "rgb:asset");
+        assert_ne!(
+            base,
+            psbt_operation_key(2, &[0x11; 20], &[0xAA; 32], 7, "rgb:asset"),
+            "chain_id must change the key"
+        );
+        assert_ne!(
+            base,
+            psbt_operation_key(1, &[0x22; 20], &[0xAA; 32], 7, "rgb:asset"),
+            "bridge_contract must change the key"
+        );
+        assert_ne!(
+            base,
+            psbt_operation_key(1, &[0x11; 20], &[0xBB; 32], 7, "rgb:asset"),
+            "evm_tx_hash must change the key"
+        );
+        assert_ne!(
+            base,
+            psbt_operation_key(1, &[0x11; 20], &[0xAA; 32], 8, "rgb:asset"),
+            "operation_idx must change the key"
+        );
+        assert_ne!(
+            base,
+            psbt_operation_key(1, &[0x11; 20], &[0xAA; 32], 7, "rgb:other"),
+            "rgb_asset_id must change the key"
+        );
+    }
+
+    #[test]
+    fn op_key_length_prefix_blocks_concatenation_collision() {
+        // Without length-prefixing the variable fields, moving a byte from the
+        // end of evm_tx_hash to the front of rgb_asset_id would collide. The
+        // prefix must keep these distinct. evm_tx_hash is fixed at 32 bytes in
+        // practice, but the key fn must not rely on that for separation.
+        let k1 = psbt_operation_key(1, &[0x11; 20], b"AB", 0, "C");
+        let k2 = psbt_operation_key(1, &[0x11; 20], b"A", 0, "BC");
+        assert_ne!(k1, k2);
     }
 
     // =========================================================================


### PR DESCRIPTION
The enclave never recorded that a bridge-mode SignPsbt operation was consumed, so the same finalized deposit could be presented repeatedly to get multiple BTC/RGB releases (audit W-02). The on-chain contract does not close this: RgbSettlementModule's DuplicateOperationId only dedups the EVM *deposit*; the RGB release happens on Bitcoin and is never marked consumed on-chain.

Add a soft operation-uniqueness guard, reusing the time-bounded NonceReplayGuard mechanism. EnclaveState gains op_replay_guard (24h TTL, evict-oldest, ~8MB cap), keyed by psbt_operation_key() — a domain-tagged, length-prefixed keccak over (chain_id, bridge_contract, evm_tx_hash, operation_idx, rgb_asset_id), with chain_id/contract taken from the pinned BridgeConfig rather than the request. handle_sign_psbt check-and-records in the critical section, after every validation and immediately before signing, in bridge mode only and gated not(dev-mode). A same-tuple resubmission inside the TTL window is rejected before a second signature is produced. This also reads operation_idx, previously a dead field.

This is defense-in-depth, NOT a sufficient double-spend control: the set is in-memory, per-instance, and wiped on restart (Nitro has no persistent storage), and a compromised host that varies a keyed field bypasses it. It stops honest listener retries and naive replay; the durable cross-instance/cross-restart guard remains an on-chain ticket. #84 stays open for that piece.