### PR TITLE
fix(crosscheck): bind fundsOut burnId to the RGB operation OpId (#93)

### DIFF
--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -82,7 +82,7 @@ aws-nitro-enclaves-nsm-api = "0.4"
 prost-build = "0.14.3"
 
 [features]
-default = [ "rgb-validation", "bind-burn-id" ]
+default = []
 vsock = []
 # DANGER: allows importing a raw seed over the wire. Testing only.
 allow-seed-import = []

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -103,12 +103,13 @@ rgb-validation = ["rgb-ops", "rgb-consignment", "rgb-schemas"]
 # fail-closed against build mismatches between listener and enclave.
 spv = ["rgb-validation"]
 # RGB->EVM operation-uniqueness binding (audit M-02 / #93, #63). When ON,
-# `fundsOut` signing REQUIRES the calldata `burnId` to equal uint256(OpId) of
+# `fundsOut` signing REQUIRES the calldata `burnId` to equal keccak256(OpId) of
 # the consignment's release transition: binding the contract's single-use
 # `consumedBurnIds` guard to the actual RGB operation so the same burn can't be
-# replayed under a fresh burnId. Default OFF: the orchestrator (bridge-utexo)
+# replayed under a fresh burnId. keccak256(raw 32-byte OpId) is the shared
+# transform with bridge-utexo and #97 (#63). Default OFF: the orchestrator
 # currently sends an unrelated `TransferID` as `burnId`, so enabling this before
-# it derives burnId = uint256(OpId) would reject every live fundsOut. Compile-
+# it derives burnId = keccak256(OpId) would reject every live fundsOut. Compile-
 # time (not env) so the posture is PCR-attested and can't be weakened at
 # runtime. Implies `rgb-validation` (the binding needs the parsed consignment).
 bind-burn-id = ["rgb-validation"]

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -96,6 +96,16 @@ rgb-validation = ["rgb-ops", "rgb-consignment"]
 # additionally REJECTS any request that carries non-empty merkle_proofs —
 # fail-closed against build mismatches between listener and enclave.
 spv = ["rgb-validation"]
+# RGB->EVM operation-uniqueness binding (audit M-02 / #93, #63). When ON,
+# `fundsOut` signing REQUIRES the calldata `burnId` to equal uint256(OpId) of
+# the consignment's release transition: binding the contract's single-use
+# `consumedBurnIds` guard to the actual RGB operation so the same burn can't be
+# replayed under a fresh burnId. Default OFF: the orchestrator (bridge-utexo)
+# currently sends an unrelated `TransferID` as `burnId`, so enabling this before
+# it derives burnId = uint256(OpId) would reject every live fundsOut. Compile-
+# time (not env) so the posture is PCR-attested and can't be weakened at
+# runtime. Implies `rgb-validation` (the binding needs the parsed consignment).
+bind-burn-id = ["rgb-validation"]
 # Mock attestation path: skip NSM / COSE / cert-chain checks and use raw CBOR docs.
 # Testing only — never enable in production builds.
 mock-attestation = ["attestation-verify/mock"]

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -82,7 +82,7 @@ aws-nitro-enclaves-nsm-api = "0.4"
 prost-build = "0.14.3"
 
 [features]
-default = []
+default = [ "rgb-validation", "bind-burn-id" ]
 vsock = []
 # DANGER: allows importing a raw seed over the wire. Testing only.
 allow-seed-import = []

--- a/enclave/src/validation/evm_crosscheck.rs
+++ b/enclave/src/validation/evm_crosscheck.rs
@@ -46,6 +46,13 @@ const FUNDS_OUT_SELECTORS: &[[u8; 4]] = &[FUNDS_OUT_SELECTOR_POOLS];
 #[cfg(feature = "rgb-validation")]
 const FUNDS_OUT_AMOUNT_OFFSET: usize = 36;
 
+/// Byte offset of `burnId` in the `fundsOut` calldata: after the selector,
+/// `recipient`, and `amount` head slots it sits at byte 68..100. Consumed by
+/// the burnId-to-OpId binding ([`verify_burn_id_binding`]); `test` keeps it
+/// available for that helper's unit tests in default builds.
+#[cfg(any(feature = "bind-burn-id", test))]
+const FUNDS_OUT_BURN_ID_OFFSET: usize = 68;
+
 /// Validate enriched SignEvmRequest before signing.
 /// Returns Ok(()) if all cross-checks pass, Err(EnclaveError::CrossCheck) if any fail.
 ///
@@ -386,6 +393,17 @@ pub fn validate_funds_out_transfer(
         )));
     }
 
+    // Operation-uniqueness binding (audit M-02 / #93, #63). The contract's
+    // single-use `consumedBurnIds[burnId]` guard is only sound if `burnId`
+    // canonically identifies the RGB operation being released against;
+    // otherwise the same burn replayed under a fresh `burnId` double-releases.
+    // Require the calldata `burnId` to equal uint256(OpId) of the release
+    // transition. Compile-time gated (PCR-attested) and OFF by default until
+    // bridge-utexo derives `burnId` the same way - see the `bind-burn-id`
+    // feature in Cargo.toml.
+    #[cfg(feature = "bind-burn-id")]
+    verify_burn_id_binding(&req.call_data, &last.op_id)?;
+
     // Read `amount` straight from the calldata bytes rather than
     // trusting `req.calldata_amount`, then bind it to the consignment's
     // output value — the consignment is the authority on how much RGB
@@ -396,6 +414,55 @@ pub fn validate_funds_out_transfer(
         return Err(EnclaveError::CrossCheck(format!(
             "transfer amount mismatch: consignment total_output_amount ({}) < calldata amount ({})",
             last.total_output_amount, calldata_amount
+        )));
+    }
+    Ok(())
+}
+
+/// Bind the `fundsOut` calldata `burnId` to the RGB operation it releases
+/// against (audit M-02 / #93, #63).
+///
+/// The canonical `burnId` is `uint256(OpId)`: the 32-byte commitment hash of
+/// the release transition, taken big-endian. rgbstd's [`OpId`] is
+/// `#[display(Self::to_hex)]` over a `Bytes32`, so `op_id_hex` is the 64-char
+/// lowercase hex of those bytes; a uint256 word is the same 32 bytes
+/// big-endian, so we compare the calldata `burnId` slot to the decoded OpId
+/// byte-for-byte (no endianness conversion).
+///
+/// Assumes one RGB release transition maps to one `fundsOut` (the live pools model);
+/// it does not support partial releases of a single operation under multiple
+/// burnIds (none exist today). Fail-closed: any decode failure or mismatch
+/// rejects.
+///
+/// [`OpId`]: https://docs.rs/rgb-consensus
+#[cfg(any(feature = "bind-burn-id", test))]
+fn verify_burn_id_binding(call_data: &[u8], op_id_hex: &str) -> Result<()> {
+    let end = FUNDS_OUT_BURN_ID_OFFSET + 32;
+    if call_data.len() < end {
+        return Err(EnclaveError::CrossCheck(format!(
+            "call_data too short for burnId: need {end} bytes, got {}",
+            call_data.len()
+        )));
+    }
+    let burn_id = &call_data[FUNDS_OUT_BURN_ID_OFFSET..end];
+
+    let expected = hex::decode(op_id_hex).map_err(|e| {
+        EnclaveError::CrossCheck(format!("consignment op_id is not valid hex: {e}"))
+    })?;
+    if expected.len() != 32 {
+        return Err(EnclaveError::CrossCheck(format!(
+            "consignment op_id decoded to {} bytes, want 32",
+            expected.len()
+        )));
+    }
+
+    if burn_id != expected.as_slice() {
+        return Err(EnclaveError::CrossCheck(format!(
+            "burnId not bound to the RGB operation: calldata burnId 0x{} != uint256(OpId) 0x{} \
+             of the release transition - refusing to sign a fundsOut that the same burn could \
+             replay under a different burnId",
+            hex::encode(burn_id),
+            op_id_hex
         )));
     }
     Ok(())
@@ -846,9 +913,16 @@ mod tests {
             }
         }
 
+        /// Canonical test OpId. rgbstd's `OpId` Displays as lowercase hex of
+        /// its 32-byte commitment, so the string form is 64 hex chars and the
+        /// byte form is what a matching `burnId` calldata slot must contain.
+        const TEST_OP_ID_BYTES: [u8; 32] = [0x11; 32];
+        const TEST_OP_ID_HEX: &str =
+            "1111111111111111111111111111111111111111111111111111111111111111";
+
         fn transfer_transition(total_output_amount: u64) -> TransitionSummary {
             TransitionSummary {
-                op_id: "transfer-op".into(),
+                op_id: TEST_OP_ID_HEX.into(),
                 transition_type: crate::validation::rgb::ifa::TS_TRANSFER,
                 total_output_amount,
                 outputs: Vec::<TransitionOutput>::new(),
@@ -869,8 +943,11 @@ mod tests {
             let mut amt = [0u8; 32];
             amt[24..].copy_from_slice(&amount.to_be_bytes());
             data.extend_from_slice(&amt);
-            // 6 more head slots zero-filled.
-            data.extend_from_slice(&[0u8; 32 * 6]);
+            // burnId @ offset 68 - set to the canonical test OpId so the
+            // (default-off) bind-burn-id check passes transparently when the
+            // feature is compiled in. The other 5 head slots stay zero-filled.
+            data.extend_from_slice(&TEST_OP_ID_BYTES);
+            data.extend_from_slice(&[0u8; 32 * 5]);
             data
         }
 
@@ -965,6 +1042,78 @@ mod tests {
             req.call_data[..4].copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
             let validated = validated_with_last(transfer_transition(0));
             assert!(validate_funds_out_transfer(&req, &validated).is_ok());
+        }
+
+        /// End-to-end: with `bind-burn-id` on, a calldata `burnId` that does
+        /// not equal uint256(OpId) of the release transition is rejected
+        /// before the amount check (audit M-02 / #93).
+        #[cfg(feature = "bind-burn-id")]
+        #[test]
+        fn rejects_burn_id_not_bound_to_op_id() {
+            let mut cd = mock_pools_calldata(1000);
+            // Flip a byte of the burnId so it no longer matches TEST_OP_ID.
+            cd[FUNDS_OUT_BURN_ID_OFFSET] ^= 0xFF;
+            let req = req_with_calldata(cd);
+            let validated = validated_with_last(transfer_transition(1000));
+            let err = validate_funds_out_transfer(&req, &validated).unwrap_err();
+            assert!(
+                err.to_string().contains("burnId not bound"),
+                "expected burnId-binding rejection, got: {err}"
+            );
+        }
+    }
+
+    // =========================================================================
+    // burnId-to-OpId binding - `verify_burn_id_binding` (audit M-02 / #93, #63).
+    // Runs in default `cargo test` (helper is `cfg(any(bind-burn-id, test))`).
+    // =========================================================================
+    mod burn_id_binding {
+        use super::*;
+
+        fn calldata_with_burn_id(burn_id: &[u8; 32]) -> Vec<u8> {
+            let mut d = mock_funds_out_calldata(1000);
+            d[FUNDS_OUT_BURN_ID_OFFSET..FUNDS_OUT_BURN_ID_OFFSET + 32].copy_from_slice(burn_id);
+            d
+        }
+
+        #[test]
+        fn accepts_matching_burn_id() {
+            let op = [0xABu8; 32];
+            let cd = calldata_with_burn_id(&op);
+            assert!(verify_burn_id_binding(&cd, &hex::encode(op)).is_ok());
+        }
+
+        #[test]
+        fn rejects_mismatched_burn_id() {
+            let op = [0xABu8; 32];
+            let cd = calldata_with_burn_id(&[0xCDu8; 32]); // calldata burnId differs
+            let err = verify_burn_id_binding(&cd, &hex::encode(op)).unwrap_err();
+            assert!(err.to_string().contains("burnId not bound"), "got: {err}");
+        }
+
+        #[test]
+        fn rejects_calldata_too_short_for_burn_id() {
+            let op = [0xABu8; 32];
+            let err = verify_burn_id_binding(&[0u8; 50], &hex::encode(op)).unwrap_err();
+            assert!(
+                err.to_string().contains("too short for burnId"),
+                "got: {err}"
+            );
+        }
+
+        #[test]
+        fn rejects_non_hex_op_id() {
+            let cd = calldata_with_burn_id(&[0u8; 32]);
+            let err = verify_burn_id_binding(&cd, "not-hex-zz").unwrap_err();
+            assert!(err.to_string().contains("not valid hex"), "got: {err}");
+        }
+
+        #[test]
+        fn rejects_wrong_length_op_id() {
+            let cd = calldata_with_burn_id(&[0u8; 32]);
+            let short = "11".repeat(30); // 30 bytes, not 32
+            let err = verify_burn_id_binding(&cd, &short).unwrap_err();
+            assert!(err.to_string().contains("want 32"), "got: {err}");
         }
     }
 

--- a/enclave/src/validation/evm_crosscheck.rs
+++ b/enclave/src/validation/evm_crosscheck.rs
@@ -398,11 +398,21 @@ pub fn validate_funds_out_transfer(
     // canonically identifies the RGB operation being released against;
     // otherwise the same burn replayed under a fresh `burnId` double-releases.
     // Require the calldata `burnId` to equal uint256(OpId) of the release
-    // transition. Compile-time gated (PCR-attested) and OFF by default until
-    // bridge-utexo derives `burnId` the same way - see the `bind-burn-id`
-    // feature in Cargo.toml.
+    // transition, where the OpId is read from the rgbstd-VALIDATED transfer
+    // (`last_transfer_op_id`), not the flat parser. Compile-time gated
+    // (PCR-attested) and OFF by default until bridge-utexo derives `burnId`
+    // the same way - see the `bind-burn-id` feature in Cargo.toml.
     #[cfg(feature = "bind-burn-id")]
-    verify_burn_id_binding(&req.call_data, &last.op_id)?;
+    {
+        let expected_op_id = validated.last_transfer_op_id.as_ref().ok_or_else(|| {
+            EnclaveError::CrossCheck(
+                "fundsOut burnId binding requires the validated OpId of the release transition, \
+                 but none was extracted - refusing to sign"
+                    .into(),
+            )
+        })?;
+        verify_burn_id_binding(&req.call_data, expected_op_id)?;
+    }
 
     // Read `amount` straight from the calldata bytes rather than
     // trusting `req.calldata_amount`, then bind it to the consignment's
@@ -423,20 +433,19 @@ pub fn validate_funds_out_transfer(
 /// against (audit M-02 / #93, #63).
 ///
 /// The canonical `burnId` is `uint256(OpId)`: the 32-byte commitment hash of
-/// the release transition, taken big-endian. rgbstd's [`OpId`] is
-/// `#[display(Self::to_hex)]` over a `Bytes32`, so `op_id_hex` is the 64-char
-/// lowercase hex of those bytes; a uint256 word is the same 32 bytes
-/// big-endian, so we compare the calldata `burnId` slot to the decoded OpId
-/// byte-for-byte (no endianness conversion).
+/// the release transition, taken big-endian. `expected_op_id` is that hash,
+/// sourced by the caller from the rgbstd-VALIDATED transfer
+/// (`ValidatedConsignment::last_transfer_op_id`) - NOT from a parallel parse,
+/// so the comparison is against data `validate()` authenticated. A uint256 ABI
+/// word is the same 32 bytes big-endian, so we compare the calldata `burnId`
+/// slot to the OpId byte-for-byte (no endianness conversion).
 ///
-/// Assumes one RGB release transition maps to one `fundsOut` (the live pools model);
-/// it does not support partial releases of a single operation under multiple
-/// burnIds (none exist today). Fail-closed: any decode failure or mismatch
-/// rejects.
-///
-/// [`OpId`]: https://docs.rs/rgb-consensus
+/// Assumes one RGB release transition maps to one `fundsOut` (the live pools
+/// model); it does not support partial releases of a single operation under
+/// multiple burnIds (none exist today). Fail-closed: a short calldata or any
+/// mismatch rejects.
 #[cfg(any(feature = "bind-burn-id", test))]
-fn verify_burn_id_binding(call_data: &[u8], op_id_hex: &str) -> Result<()> {
+fn verify_burn_id_binding(call_data: &[u8], expected_op_id: &[u8; 32]) -> Result<()> {
     let end = FUNDS_OUT_BURN_ID_OFFSET + 32;
     if call_data.len() < end {
         return Err(EnclaveError::CrossCheck(format!(
@@ -446,23 +455,13 @@ fn verify_burn_id_binding(call_data: &[u8], op_id_hex: &str) -> Result<()> {
     }
     let burn_id = &call_data[FUNDS_OUT_BURN_ID_OFFSET..end];
 
-    let expected = hex::decode(op_id_hex).map_err(|e| {
-        EnclaveError::CrossCheck(format!("consignment op_id is not valid hex: {e}"))
-    })?;
-    if expected.len() != 32 {
-        return Err(EnclaveError::CrossCheck(format!(
-            "consignment op_id decoded to {} bytes, want 32",
-            expected.len()
-        )));
-    }
-
-    if burn_id != expected.as_slice() {
+    if burn_id != expected_op_id.as_slice() {
         return Err(EnclaveError::CrossCheck(format!(
             "burnId not bound to the RGB operation: calldata burnId 0x{} != uint256(OpId) 0x{} \
              of the release transition - refusing to sign a fundsOut that the same burn could \
              replay under a different burnId",
             hex::encode(burn_id),
-            op_id_hex
+            hex::encode(expected_op_id)
         )));
     }
     Ok(())
@@ -778,6 +777,7 @@ mod tests {
                 last_transition: Some(transition),
                 last_transfer_witness_txid: None,
                 last_transfer_witness_prevouts: None,
+                last_transfer_op_id: None,
             }
         }
 
@@ -870,6 +870,7 @@ mod tests {
                 last_transition: None,
                 last_transfer_witness_txid: None,
                 last_transfer_witness_prevouts: None,
+                last_transfer_op_id: None,
             };
             let err = validate_funds_out_burn(&req, &validated).unwrap_err();
             assert!(
@@ -910,6 +911,10 @@ mod tests {
                 last_transition: Some(transition),
                 last_transfer_witness_txid: None,
                 last_transfer_witness_prevouts: None,
+                // Validated OpId of the release transition. Matches the burnId
+                // that mock_pools_calldata writes, so the bind-burn-id check
+                // passes transparently; the mismatch test corrupts the calldata.
+                last_transfer_op_id: Some(TEST_OP_ID_BYTES),
             }
         }
 
@@ -1025,6 +1030,7 @@ mod tests {
                 last_transition: None,
                 last_transfer_witness_txid: None,
                 last_transfer_witness_prevouts: None,
+                last_transfer_op_id: None,
             };
             let err = validate_funds_out_transfer(&req, &validated).unwrap_err();
             assert!(
@@ -1080,21 +1086,21 @@ mod tests {
         fn accepts_matching_burn_id() {
             let op = [0xABu8; 32];
             let cd = calldata_with_burn_id(&op);
-            assert!(verify_burn_id_binding(&cd, &hex::encode(op)).is_ok());
+            assert!(verify_burn_id_binding(&cd, &op).is_ok());
         }
 
         #[test]
         fn rejects_mismatched_burn_id() {
             let op = [0xABu8; 32];
             let cd = calldata_with_burn_id(&[0xCDu8; 32]); // calldata burnId differs
-            let err = verify_burn_id_binding(&cd, &hex::encode(op)).unwrap_err();
+            let err = verify_burn_id_binding(&cd, &op).unwrap_err();
             assert!(err.to_string().contains("burnId not bound"), "got: {err}");
         }
 
         #[test]
         fn rejects_calldata_too_short_for_burn_id() {
             let op = [0xABu8; 32];
-            let err = verify_burn_id_binding(&[0u8; 50], &hex::encode(op)).unwrap_err();
+            let err = verify_burn_id_binding(&[0u8; 50], &op).unwrap_err();
             assert!(
                 err.to_string().contains("too short for burnId"),
                 "got: {err}"
@@ -1102,18 +1108,13 @@ mod tests {
         }
 
         #[test]
-        fn rejects_non_hex_op_id() {
-            let cd = calldata_with_burn_id(&[0u8; 32]);
-            let err = verify_burn_id_binding(&cd, "not-hex-zz").unwrap_err();
-            assert!(err.to_string().contains("not valid hex"), "got: {err}");
-        }
-
-        #[test]
-        fn rejects_wrong_length_op_id() {
-            let cd = calldata_with_burn_id(&[0u8; 32]);
-            let short = "11".repeat(30); // 30 bytes, not 32
-            let err = verify_burn_id_binding(&cd, &short).unwrap_err();
-            assert!(err.to_string().contains("want 32"), "got: {err}");
+        fn single_bit_flip_in_burn_id_is_rejected() {
+            let op = [0x11u8; 32];
+            let mut bad = op;
+            bad[31] ^= 0x01; // calldata burnId off by one bit
+            let cd = calldata_with_burn_id(&bad);
+            let err = verify_burn_id_binding(&cd, &op).unwrap_err();
+            assert!(err.to_string().contains("burnId not bound"), "got: {err}");
         }
     }
 

--- a/enclave/src/validation/evm_crosscheck.rs
+++ b/enclave/src/validation/evm_crosscheck.rs
@@ -1530,7 +1530,8 @@ mod tests {
             v.last_transfer_op_id = None;
             let err = apply_op_id_binding(&cd, &v).unwrap_err();
             assert!(
-                err.to_string().contains("validated OpId of the release transition"),
+                err.to_string()
+                    .contains("validated OpId of the release transition"),
                 "got: {err}"
             );
         }
@@ -1592,7 +1593,10 @@ mod tests {
         #[test]
         fn rejects_non_hex_op_id() {
             let cd = mock_funds_out([0xEE; 32], &[]);
-            let v = validated(Some(transition(OP_ID, ifa::TS_TRANSFER)), vec!["not-hex".into()]);
+            let v = validated(
+                Some(transition(OP_ID, ifa::TS_TRANSFER)),
+                vec!["not-hex".into()],
+            );
             let err = apply_op_id_binding(&cd, &v).unwrap_err();
             assert!(
                 err.to_string().contains("hex-decodable")
@@ -1616,7 +1620,8 @@ mod tests {
             let v = validated(None, vec![]);
             let err = apply_op_id_binding(&cd, &v).unwrap_err();
             assert!(
-                err.to_string().contains("validated OpId of the release transition"),
+                err.to_string()
+                    .contains("validated OpId of the release transition"),
                 "got: {err}"
             );
         }

--- a/enclave/src/validation/evm_crosscheck.rs
+++ b/enclave/src/validation/evm_crosscheck.rs
@@ -514,8 +514,11 @@ fn op_id_to_calldata_id(op_id: &str) -> Result<[u8; 32]> {
 /// The enclave does NOT trust — or even read — the listener's
 /// `burnId`/`fundsInIds`. It derives them from the consignment it validated
 /// and **overwrites** the calldata it is about to sign:
-///   - `burnId` (offset 68) := `op_id_to_calldata_id(last transition OpId)`
-///     (the burn for unlock, the federation transfer for pools); and
+///   - `burnId` (offset 68) := `keccak256(validated release-transition OpId)`,
+///     where the OpId is `ValidatedConsignment::last_transfer_op_id` - read
+///     from the rgbstd-**validated** `Transfer`, NOT the flat parser (audit
+///     M-02 / #93). This binds the contract's single-use `consumedBurnIds`
+///     guard to the operation `validate()` actually authenticated; and
 ///   - `settlementData` := `abi.encode(uint256[] fundsInIds)` over
 ///     `op_id_to_calldata_id(opid)` for **every** IFA `TS_INFLATION` (mint)
 ///     transition in the consignment's history.
@@ -534,12 +537,19 @@ fn op_id_to_calldata_id(op_id: &str) -> Result<[u8; 32]> {
 /// rebuilt in place; `sourceAddress` and the SPV `proof` are preserved exactly.
 #[cfg(feature = "rgb-validation")]
 pub fn apply_op_id_binding(call_data: &[u8], validated: &ValidatedConsignment) -> Result<Vec<u8>> {
-    let last = validated.last_transition.as_ref().ok_or_else(|| {
+    // burnId is derived from the rgbstd-VALIDATED OpId of the release
+    // (TS_TRANSFER) transition (`last_transfer_op_id`), not the flat parser -
+    // so the contract's single-use `consumedBurnIds` key is bound to the
+    // operation `validate()` authenticated (audit M-02 / #93). Fail closed if
+    // it wasn't extracted (no bundles, or a non-Transfer last transition).
+    let op_id = validated.last_transfer_op_id.ok_or_else(|| {
         EnclaveError::CrossCheck(
-            "OpId binding requires a consignment with at least one transition".into(),
+            "OpId binding requires the validated OpId of the release transition, but none was \
+             extracted (the last transition is not a validated Transfer) - refusing to sign"
+                .into(),
         )
     })?;
-    let burn_id = op_id_to_calldata_id(&last.op_id)?;
+    let burn_id: [u8; 32] = Keccak256::digest(op_id).into();
     let funds_in_ids: Vec<[u8; 32]> = validated
         .mint_op_ids
         .iter()
@@ -1107,6 +1117,7 @@ mod tests {
                 last_transition: Some(transition),
                 last_transfer_witness_txid: None,
                 last_transfer_witness_prevouts: None,
+                last_transfer_op_id: None,
                 non_mined_witness_txids: vec![],
             }
         }
@@ -1201,6 +1212,7 @@ mod tests {
                 last_transition: None,
                 last_transfer_witness_txid: None,
                 last_transfer_witness_prevouts: None,
+                last_transfer_op_id: None,
                 non_mined_witness_txids: vec![],
             };
             let err = validate_funds_out_burn(&req, &validated).unwrap_err();
@@ -1243,6 +1255,7 @@ mod tests {
                 last_transition: Some(transition),
                 last_transfer_witness_txid: None,
                 last_transfer_witness_prevouts: None,
+                last_transfer_op_id: None,
                 non_mined_witness_txids: vec![],
             }
         }
@@ -1371,6 +1384,7 @@ mod tests {
                 last_transition: None,
                 last_transfer_witness_txid: None,
                 last_transfer_witness_prevouts: None,
+                last_transfer_op_id: None,
                 non_mined_witness_txids: vec![],
             };
             let err = validate_funds_out_transfer(&req, &validated).unwrap_err();
@@ -1458,10 +1472,21 @@ mod tests {
             }
         }
 
+        /// The validated last-transfer OpId bytes for a given hex OpId - the
+        /// authoritative burnId source (`ValidatedConsignment::last_transfer_op_id`).
+        fn op_id_bytes(op_id: &str) -> [u8; 32] {
+            hex::decode(op_id).unwrap().try_into().unwrap()
+        }
+
         fn validated(
             last: Option<TransitionSummary>,
             mint_op_ids: Vec<String>,
         ) -> ValidatedConsignment {
+            // The burnId is derived from the rgbstd-VALIDATED OpId, so mirror
+            // production: `last_transfer_op_id` carries the same OpId as the
+            // last transition (set by `read_last_transfer_witness` for a
+            // TS_TRANSFER last transition).
+            let last_transfer_op_id = last.as_ref().map(|t| op_id_bytes(&t.op_id));
             ValidatedConsignment {
                 contract_id: "rgb:test".into(),
                 chain_net: "bc".into(),
@@ -1474,18 +1499,20 @@ mod tests {
                 last_transition: last,
                 last_transfer_witness_txid: None,
                 last_transfer_witness_prevouts: None,
+                last_transfer_op_id,
                 non_mined_witness_txids: vec![],
             }
         }
 
         // ---- apply_op_id_binding (override, not verify) ----
 
-        /// Writes burnId@68 = id(last transition OpId), overriding whatever the
-        /// bridge put there.
+        /// Writes burnId@68 = keccak256(validated OpId), overriding whatever the
+        /// bridge put there. The OpId is sourced from the rgbstd-validated
+        /// transfer (`last_transfer_op_id`), not the flat parser (audit M-02 / #93).
         #[test]
-        fn writes_burn_id_from_last_transition() {
+        fn writes_burn_id_from_validated_op_id() {
             let cd = mock_funds_out([0xEE; 32], &[]); // bogus burnId in input
-            let v = validated(Some(transition(OP_ID, ifa::TS_BURN)), vec![]);
+            let v = validated(Some(transition(OP_ID, ifa::TS_TRANSFER)), vec![]);
             let out = apply_op_id_binding(&cd, &v).unwrap();
             assert_eq!(
                 extract_bytes32(&out, FUNDS_OUT_BURN_ID_OFFSET).unwrap(),
@@ -1493,15 +1520,18 @@ mod tests {
             );
         }
 
-        /// Active on every flow: a Transfer (pools) last transition is written too.
+        /// Fail closed when no validated OpId was extracted (e.g. a non-Transfer
+        /// last transition): the enclave must refuse rather than fall back to a
+        /// listener- or flat-parser-supplied burnId.
         #[test]
-        fn writes_burn_id_for_transfer_transition() {
+        fn rejects_when_validated_op_id_missing() {
             let cd = mock_funds_out([0xEE; 32], &[]);
-            let v = validated(Some(transition(OP_ID, ifa::TS_TRANSFER)), vec![]);
-            let out = apply_op_id_binding(&cd, &v).unwrap();
-            assert_eq!(
-                extract_bytes32(&out, FUNDS_OUT_BURN_ID_OFFSET).unwrap(),
-                id(OP_ID)
+            let mut v = validated(Some(transition(OP_ID, ifa::TS_TRANSFER)), vec![]);
+            v.last_transfer_op_id = None;
+            let err = apply_op_id_binding(&cd, &v).unwrap_err();
+            assert!(
+                err.to_string().contains("validated OpId of the release transition"),
+                "got: {err}"
             );
         }
 
@@ -1555,11 +1585,14 @@ mod tests {
             assert_eq!(&out[36..68], &u256(123_456));
         }
 
-        /// An OpId that isn't 32-byte hex can't be transformed — fail closed.
+        /// A mint OpId that isn't 32-byte hex can not be transformed - fail
+        /// closed. (The burnId now comes from the pre-validated
+        /// `last_transfer_op_id` bytes, so the only string-decoded OpIds left
+        /// are the `fundsInIds` mint set.)
         #[test]
         fn rejects_non_hex_op_id() {
             let cd = mock_funds_out([0xEE; 32], &[]);
-            let v = validated(Some(transition("not-hex", ifa::TS_BURN)), vec![]);
+            let v = validated(Some(transition(OP_ID, ifa::TS_TRANSFER)), vec!["not-hex".into()]);
             let err = apply_op_id_binding(&cd, &v).unwrap_err();
             assert!(
                 err.to_string().contains("hex-decodable")
@@ -1576,14 +1609,14 @@ mod tests {
             assert!(err.to_string().contains("too short"), "got: {err}");
         }
 
-        /// No transition to bind against → hard error.
+        /// No validated release OpId to bind against -> hard error.
         #[test]
         fn rejects_no_transition() {
             let cd = mock_funds_out([0xEE; 32], &[]);
             let v = validated(None, vec![]);
             let err = apply_op_id_binding(&cd, &v).unwrap_err();
             assert!(
-                err.to_string().contains("at least one transition"),
+                err.to_string().contains("validated OpId of the release transition"),
                 "got: {err}"
             );
         }

--- a/enclave/src/validation/evm_crosscheck.rs
+++ b/enclave/src/validation/evm_crosscheck.rs
@@ -409,7 +409,7 @@ pub fn validate_funds_out_transfer(
     // single-use `consumedBurnIds[burnId]` guard is only sound if `burnId`
     // canonically identifies the RGB operation being released against;
     // otherwise the same burn replayed under a fresh `burnId` double-releases.
-    // Require the calldata `burnId` to equal uint256(OpId) of the release
+    // Require the calldata `burnId` to equal keccak256(OpId) of the release
     // transition, where the OpId is read from the rgbstd-VALIDATED transfer
     // (`last_transfer_op_id`), not the flat parser. Compile-time gated
     // (PCR-attested) and OFF by default until bridge-utexo derives `burnId`
@@ -441,16 +441,29 @@ pub fn validate_funds_out_transfer(
     Ok(())
 }
 
+/// Canonical transform from an RGB `OpId` to the opaque `uint256` the EVM
+/// contract stores (`burnId`, `fundsInIds`, lock-side `operationId`):
+/// `keccak256(raw 32-byte OpId)`. This MUST match bridge-utexo and #97 (#63)
+/// byte-for-byte - the enclave, the orchestrator, and the contract caller all
+/// derive the on-chain id this way. Preimage is the raw 32 OpId bytes, not its
+/// ASCII-hex form.
+#[cfg(any(feature = "bind-burn-id", test))]
+fn op_id_to_calldata_id(op_id: &[u8; 32]) -> [u8; 32] {
+    use sha3::{Digest, Keccak256};
+    Keccak256::digest(op_id).into()
+}
+
 /// Bind the `fundsOut` calldata `burnId` to the RGB operation it releases
 /// against (audit M-02 / #93, #63).
 ///
-/// The canonical `burnId` is `uint256(OpId)`: the 32-byte commitment hash of
-/// the release transition, taken big-endian. `expected_op_id` is that hash,
-/// sourced by the caller from the rgbstd-VALIDATED transfer
+/// The canonical `burnId` is `keccak256(OpId)` (see [`op_id_to_calldata_id`]),
+/// where `expected_op_id` is the raw 32-byte commitment hash of the release
+/// transition, sourced by the caller from the rgbstd-VALIDATED transfer
 /// (`ValidatedConsignment::last_transfer_op_id`) - NOT from a parallel parse,
-/// so the comparison is against data `validate()` authenticated. A uint256 ABI
-/// word is the same 32 bytes big-endian, so we compare the calldata `burnId`
-/// slot to the OpId byte-for-byte (no endianness conversion).
+/// so the comparison is against data `validate()` authenticated. The contract's
+/// `burnId`/`fundsInIds` are opaque `uint256`s the backend assigns; this scheme
+/// is shared with bridge-utexo and #97 so the same burn always yields the same
+/// on-chain id.
 ///
 /// Assumes one RGB release transition maps to one `fundsOut` (the live pools
 /// model); it does not support partial releases of a single operation under
@@ -467,13 +480,14 @@ fn verify_burn_id_binding(call_data: &[u8], expected_op_id: &[u8; 32]) -> Result
     }
     let burn_id = &call_data[FUNDS_OUT_BURN_ID_OFFSET..end];
 
-    if burn_id != expected_op_id.as_slice() {
+    let expected = op_id_to_calldata_id(expected_op_id);
+    if burn_id != expected.as_slice() {
         return Err(EnclaveError::CrossCheck(format!(
-            "burnId not bound to the RGB operation: calldata burnId 0x{} != uint256(OpId) 0x{} \
+            "burnId not bound to the RGB operation: calldata burnId 0x{} != keccak256(OpId) 0x{} \
              of the release transition - refusing to sign a fundsOut that the same burn could \
              replay under a different burnId",
             hex::encode(burn_id),
-            hex::encode(expected_op_id)
+            hex::encode(expected)
         )));
     }
     Ok(())
@@ -960,10 +974,11 @@ mod tests {
             let mut amt = [0u8; 32];
             amt[24..].copy_from_slice(&amount.to_be_bytes());
             data.extend_from_slice(&amt);
-            // burnId @ offset 68 - set to the canonical test OpId so the
-            // (default-off) bind-burn-id check passes transparently when the
-            // feature is compiled in. The other 5 head slots stay zero-filled.
-            data.extend_from_slice(&TEST_OP_ID_BYTES);
+            // burnId @ offset 68 - set to keccak256(OpId), the canonical
+            // on-chain id, so the (default-off) bind-burn-id check passes
+            // transparently when the feature is compiled in. The other 5 head
+            // slots stay zero-filled.
+            data.extend_from_slice(&op_id_to_calldata_id(&TEST_OP_ID_BYTES));
             data.extend_from_slice(&[0u8; 32 * 5]);
             data
         }
@@ -1097,8 +1112,19 @@ mod tests {
         #[test]
         fn accepts_matching_burn_id() {
             let op = [0xABu8; 32];
-            let cd = calldata_with_burn_id(&op);
+            // The calldata carries keccak256(OpId), the canonical on-chain id.
+            let cd = calldata_with_burn_id(&op_id_to_calldata_id(&op));
             assert!(verify_burn_id_binding(&cd, &op).is_ok());
+        }
+
+        #[test]
+        fn rejects_raw_op_id_in_calldata() {
+            // A caller that put the raw OpId (not keccak256(OpId)) in the
+            // calldata must be rejected - this is the #93 -> #97 formula change.
+            let op = [0xABu8; 32];
+            let cd = calldata_with_burn_id(&op);
+            let err = verify_burn_id_binding(&cd, &op).unwrap_err();
+            assert!(err.to_string().contains("burnId not bound"), "got: {err}");
         }
 
         #[test]
@@ -1122,7 +1148,7 @@ mod tests {
         #[test]
         fn single_bit_flip_in_burn_id_is_rejected() {
             let op = [0x11u8; 32];
-            let mut bad = op;
+            let mut bad = op_id_to_calldata_id(&op);
             bad[31] ^= 0x01; // calldata burnId off by one bit
             let cd = calldata_with_burn_id(&bad);
             let err = verify_burn_id_binding(&cd, &op).unwrap_err();

--- a/enclave/src/validation/psbt_crosscheck.rs
+++ b/enclave/src/validation/psbt_crosscheck.rs
@@ -573,6 +573,7 @@ mod tests {
                 last_transition: Some(transfer_summary(total_output_amount)),
                 last_transfer_witness_txid: Some(psbt.unsigned_tx.compute_txid()),
                 last_transfer_witness_prevouts: Some(prevouts),
+                last_transfer_op_id: None,
                 non_mined_witness_txids: vec![],
             }
         }

--- a/enclave/src/validation/psbt_crosscheck.rs
+++ b/enclave/src/validation/psbt_crosscheck.rs
@@ -487,6 +487,7 @@ mod tests {
                 last_transition: Some(transfer_summary(total_output_amount)),
                 last_transfer_witness_txid: Some(psbt.unsigned_tx.compute_txid()),
                 last_transfer_witness_prevouts: Some(prevouts),
+                last_transfer_op_id: None,
             }
         }
 

--- a/enclave/src/validation/rgb.rs
+++ b/enclave/src/validation/rgb.rs
@@ -399,7 +399,9 @@ fn read_last_transfer_witness(
         }
         let opid_hex = known.opid.to_string();
         let bytes = hex::decode(&opid_hex).map_err(|e| {
-            EnclaveError::CrossCheck(format!("validated opid hex decode failed: {e} ({opid_hex:?})"))
+            EnclaveError::CrossCheck(format!(
+                "validated opid hex decode failed: {e} ({opid_hex:?})"
+            ))
         })?;
         let arr: [u8; 32] = bytes.try_into().map_err(|v: Vec<u8>| {
             EnclaveError::CrossCheck(format!("validated opid is not 32 bytes (got {})", v.len()))

--- a/enclave/src/validation/rgb.rs
+++ b/enclave/src/validation/rgb.rs
@@ -95,6 +95,17 @@ pub struct ValidatedConsignment {
     /// consignment carries only the witness txid (`PubWitness::Txid`), in
     /// which case the txid identity bind alone anchors every input.
     pub last_transfer_witness_prevouts: Option<Vec<bitcoin::OutPoint>>,
+    /// Authoritative OpId (32-byte commitment hash) of the consignment's
+    /// **last** transition, read from the rgbstd-**validated** `Transfer`
+    /// (`KnownTransition.opid` of the same last bundle as
+    /// `last_transfer_witness_txid`), NOT from the flat `rgb_consignment`
+    /// parser. This is the value `validate()` authenticated and anchored on
+    /// chain, so binding the EVM `fundsOut` `burnId` to it
+    /// (`bind-burn-id` / audit M-02 / #93) is a comparison against validated
+    /// consignment data, not a parallel parse. `None` only for a consignment
+    /// with no bundles (rgbstd rejects those) or a non-Transfer last
+    /// transition (the burnId binding only applies to the transfer flow).
+    pub last_transfer_op_id: Option<[u8; 32]>,
 }
 
 /// Flat summary of one RGB state transition. Mirrors
@@ -274,12 +285,13 @@ impl RgbValidator {
         // bind is only meaningful for the pools-mode send shape, and the
         // consistency check inside reads the parsed transition type to ensure
         // the txid and the transition come from the same witness.
-        let (last_transfer_witness_txid, last_transfer_witness_prevouts) = match last_transition {
-            Some(ref last) if last.transition_type == ifa::TS_TRANSFER => {
-                read_last_transfer_witness(&transfer, last.transition_type)?
-            }
-            _ => (None, None),
-        };
+        let (last_transfer_witness_txid, last_transfer_witness_prevouts, last_transfer_op_id) =
+            match last_transition {
+                Some(ref last) if last.transition_type == ifa::TS_TRANSFER => {
+                    read_last_transfer_witness(&transfer, last.transition_type)?
+                }
+                _ => (None, None, None),
+            };
 
         // 2. Create an Esplora-backed resolver.
         let builder = esplora_client::Builder::new(&self.esplora_url);
@@ -328,16 +340,27 @@ impl RgbValidator {
             last_transition,
             last_transfer_witness_txid,
             last_transfer_witness_prevouts,
+            last_transfer_op_id,
         })
     }
 }
 
+/// Binding data for the consignment's last transfer bundle:
+/// `(witness txid, witness input prevouts, validated last-transition OpId)`.
+/// All `Option` because a bundle-less transfer (rejected upstream by rgbstd)
+/// yields `(None, None, None)`. See [`read_last_transfer_witness`].
+type LastTransferBinding = (
+    Option<bitcoin::Txid>,
+    Option<Vec<bitcoin::OutPoint>>,
+    Option<[u8; 32]>,
+);
+
 /// Extract the witness-tx identity binding for the consignment's **last**
 /// transition out of the rgbstd `Transfer`: the witness txid of the bundle
-/// carrying the most recent transition, and — when that bundle embeds the
-/// full witness tx (`PubWitness::Tx`) — its Bitcoin input prevouts. Consumed
-/// by the send-RGB PSBT cross-check to bind the PSBT being signed to the
-/// consignment's `TS_TRANSFER` witness transaction.
+/// carrying the most recent transition, and - when that bundle embeds the
+/// full witness tx (`PubWitness::Tx`) - its Bitcoin input prevouts; plus the
+/// validated OpId of that transition (canonical burnId source, #93). Consumed
+/// by the send-RGB PSBT cross-check and the EVM burnId binding.
 ///
 /// Reads the **same** `transfer.bundles.iter().last()` bundle that
 /// [`read_last_transition_burned_asset`] uses, and asserts that bundle's last
@@ -353,20 +376,35 @@ impl RgbValidator {
 fn read_last_transfer_witness(
     transfer: &Transfer,
     expected_type: u16,
-) -> Result<(Option<bitcoin::Txid>, Option<Vec<bitcoin::OutPoint>>)> {
+) -> Result<LastTransferBinding> {
     let Some(last_bundle) = transfer.bundles.iter().last() else {
-        return Ok((None, None));
+        return Ok((None, None, None));
     };
 
+    // Read the authoritative OpId of the validated last transition from the
+    // same bundle. rgbstd's `OpId` is the transition's commitment hash; its
+    // `Display` is lowercase hex of the 32 bytes, so we hex-decode it back to
+    // the raw array. Sourcing it here (the validated object) rather than from
+    // the flat `rgb_consignment` parser is what makes the EVM burnId binding a
+    // check against validated data (audit M-02 / #93).
+    let mut op_id: Option<[u8; 32]> = None;
     if let Some(known) = last_bundle.bundle().known_transitions.iter().last() {
         let actual = known.transition.transition_type;
         let expected = TransitionType::with(expected_type);
         if actual != expected {
             return Err(EnclaveError::CrossCheck(format!(
                 "consignment last-bundle transition type {actual} disagrees with parsed last \
-                 transition type {expected} — refusing to bind PSBT to an ambiguous witness"
+                 transition type {expected} - refusing to bind to an ambiguous witness"
             )));
         }
+        let opid_hex = known.opid.to_string();
+        let bytes = hex::decode(&opid_hex).map_err(|e| {
+            EnclaveError::CrossCheck(format!("validated opid hex decode failed: {e} ({opid_hex:?})"))
+        })?;
+        let arr: [u8; 32] = bytes.try_into().map_err(|v: Vec<u8>| {
+            EnclaveError::CrossCheck(format!("validated opid is not 32 bytes (got {})", v.len()))
+        })?;
+        op_id = Some(arr);
     }
 
     // `witness_id()` is `bitcoin::Txid` (rgb re-exports the same bitcoin 0.32
@@ -377,7 +415,7 @@ fn read_last_transfer_witness(
         .tx()
         .map(|tx| tx.input.iter().map(|txin| txin.previous_output).collect());
 
-    Ok((Some(txid), prevouts))
+    Ok((Some(txid), prevouts, op_id))
 }
 
 /// Parse the consignment with `rgb_consignment::parse` and pull out the
@@ -663,28 +701,38 @@ mod tests {
 
         // The fixture's last transition is a Transfer (type 10000, asserted in
         // `extracts_op_ids_and_last_transition_from_transfer_fixture`).
-        let (txid, prevouts) =
+        let (txid, prevouts, op_id) =
             read_last_transfer_witness(&transfer, ifa::TS_TRANSFER).expect("extract witness");
 
         // Every validated transfer has at least one bundle, so the txid is set.
         let txid = txid.expect("transfer fixture has a witness txid");
         // It must equal the last bundle's witness id (the bundle we bind to).
-        let expected = transfer
-            .bundles
-            .iter()
-            .last()
-            .expect("fixture has bundles")
-            .witness_id();
+        let last_bundle = transfer.bundles.iter().last().expect("fixture has bundles");
+        let expected = last_bundle.witness_id();
         assert_eq!(txid, expected);
 
         // The rgb-lib sender embeds the full witness tx for a freshly-composed
         // transfer, so the prevouts (the witness tx's Bitcoin inputs) are
-        // present and non-empty — the per-input canary is available.
+        // present and non-empty - the per-input canary is available.
         let prevouts = prevouts.expect("fixture embeds the full witness tx (PubWitness::Tx)");
         assert!(
             !prevouts.is_empty(),
             "witness tx must spend at least one input"
         );
+
+        // The validated OpId (canonical burnId source, #93) must be present and
+        // equal the last bundle's last known-transition opid, read straight
+        // from the validated object - not the flat parser.
+        let op_id = op_id.expect("transfer fixture yields a validated opid");
+        let expected_opid = last_bundle
+            .bundle()
+            .known_transitions
+            .iter()
+            .last()
+            .expect("bundle has a known transition")
+            .opid
+            .to_string();
+        assert_eq!(hex::encode(op_id), expected_opid);
     }
 
     #[test]

--- a/enclave/src/validation/rgb.rs
+++ b/enclave/src/validation/rgb.rs
@@ -152,6 +152,18 @@ pub struct ValidatedConsignment {
     /// consignment carries only the witness txid (`PubWitness::Txid`), in
     /// which case the txid identity bind alone anchors every input.
     pub last_transfer_witness_prevouts: Option<Vec<bitcoin::OutPoint>>,
+    /// Authoritative OpId (32-byte commitment hash) of the consignment's
+    /// **last** transition, read from the rgbstd-**validated** `Transfer`
+    /// (`KnownTransition.opid` of the same last bundle as
+    /// `last_transfer_witness_txid`), NOT from the flat `rgb_consignment`
+    /// parser. This is the value `validate()` authenticated and anchored on
+    /// chain, so deriving the EVM `fundsOut` `burnId` from it
+    /// (`evm_crosscheck::apply_op_id_binding`, audit M-02 / #93) binds the
+    /// contract's single-use `consumedBurnIds` guard to validated consignment
+    /// data, not a parallel/unauthenticated parse. `None` only for a
+    /// consignment with no bundles (rgbstd rejects those) or a non-Transfer
+    /// last transition (the burnId binding only applies to the transfer flow).
+    pub last_transfer_op_id: Option<[u8; 32]>,
     /// Witness txids that rgbstd `validate()` classified as **not mined**
     /// (`WitnessOrd::Tentative` / `Ignored`), in **display (big-endian) byte
     /// order** - same encoding as [`Self::witness_txids`]. `validate()` already
@@ -177,10 +189,12 @@ pub struct ValidatedConsignment {
 pub struct TransitionSummary {
     /// Operation id — the 64-char lowercase hex of the 32-byte RGB OpId, as
     /// the consignment parser yields it (verified by the fixture test). The
-    /// EVM OpId cross-check compares this as a string; the staged `burnId`
+    /// EVM OpId cross-check compares this as a string; the `fundsInIds`
     /// value-binding hex-decodes it to 32 bytes
     /// (`evm_crosscheck::decode_op_id_to_bytes32`), so the hex form is
-    /// load-bearing — not baid64.
+    /// load-bearing - not baid64. (The `burnId` is bound instead from the
+    /// rgbstd-validated [`ValidatedConsignment::last_transfer_op_id`], not this
+    /// flat-parser value - audit M-02 / #93.)
     pub op_id: String,
     /// IFA-schema transition-type id; compare against [`ifa::TS_TRANSFER`]
     /// / [`ifa::TS_BURN`] / [`ifa::TS_INFLATION`] to classify the EVM
@@ -353,12 +367,13 @@ impl RgbValidator {
         // bind is only meaningful for the pools-mode send shape, and the
         // consistency check inside reads the parsed transition type to ensure
         // the txid and the transition come from the same witness.
-        let (last_transfer_witness_txid, last_transfer_witness_prevouts) = match last_transition {
-            Some(ref last) if last.transition_type == ifa::TS_TRANSFER => {
-                read_last_transfer_witness(&transfer, last.transition_type)?
-            }
-            _ => (None, None),
-        };
+        let (last_transfer_witness_txid, last_transfer_witness_prevouts, last_transfer_op_id) =
+            match last_transition {
+                Some(ref last) if last.transition_type == ifa::TS_TRANSFER => {
+                    read_last_transfer_witness(&transfer, last.transition_type)?
+                }
+                _ => (None, None, None),
+            };
 
         // 2. Create an Esplora-backed resolver.
         let builder = esplora_client::Builder::new(&self.esplora_url);
@@ -464,6 +479,7 @@ impl RgbValidator {
             last_transition,
             last_transfer_witness_txid,
             last_transfer_witness_prevouts,
+            last_transfer_op_id,
             non_mined_witness_txids,
         })
     }
@@ -485,25 +501,46 @@ impl RgbValidator {
 /// same data; binding a txid from one transition while gating on another
 /// would be a latent mismatch, so a disagreement is rejected fail-closed.
 ///
-/// Returns `(None, None)` only when the transfer has no bundles — a state
+/// Also returns the validated OpId (32-byte commitment hash) of that last
+/// transition, read from the same rgbstd bundle - the authoritative source for
+/// the EVM `fundsOut` burnId binding (audit M-02 / #93), NOT the flat parser.
+///
+/// Returns `(None, None, None)` only when the transfer has no bundles - a state
 /// rgbstd validation rejects upstream.
 fn read_last_transfer_witness(
     transfer: &Transfer,
     expected_type: u16,
-) -> Result<(Option<bitcoin::Txid>, Option<Vec<bitcoin::OutPoint>>)> {
+) -> Result<LastTransferBinding> {
     let Some(last_bundle) = transfer.bundles.iter().last() else {
-        return Ok((None, None));
+        return Ok((None, None, None));
     };
 
+    // Read the authoritative OpId of the validated last transition from the
+    // same bundle. rgbstd's `OpId` is the transition's commitment hash; its
+    // `Display` is lowercase hex of the 32 bytes, so we hex-decode it back to
+    // the raw array. Sourcing it here (the validated object) rather than from
+    // the flat `rgb_consignment` parser is what makes the EVM burnId binding a
+    // derivation from validated data (audit M-02 / #93).
+    let mut op_id: Option<[u8; 32]> = None;
     if let Some(known) = last_bundle.bundle().known_transitions.iter().last() {
         let actual = known.transition.transition_type;
         let expected = TransitionType::with(expected_type);
         if actual != expected {
             return Err(EnclaveError::CrossCheck(format!(
                 "consignment last-bundle transition type {actual} disagrees with parsed last \
-                 transition type {expected} — refusing to bind PSBT to an ambiguous witness"
+                 transition type {expected} - refusing to bind to an ambiguous witness"
             )));
         }
+        let opid_hex = known.opid.to_string();
+        let bytes = hex::decode(&opid_hex).map_err(|e| {
+            EnclaveError::CrossCheck(format!(
+                "validated opid hex decode failed: {e} ({opid_hex:?})"
+            ))
+        })?;
+        let arr: [u8; 32] = bytes.try_into().map_err(|v: Vec<u8>| {
+            EnclaveError::CrossCheck(format!("validated opid is not 32 bytes (got {})", v.len()))
+        })?;
+        op_id = Some(arr);
     }
 
     // `witness_id()` is `bitcoin::Txid` (rgb re-exports the same bitcoin 0.32
@@ -514,8 +551,18 @@ fn read_last_transfer_witness(
         .tx()
         .map(|tx| tx.input.iter().map(|txin| txin.previous_output).collect());
 
-    Ok((Some(txid), prevouts))
+    Ok((Some(txid), prevouts, op_id))
 }
+
+/// Binding data for the consignment's last transfer bundle:
+/// `(witness txid, witness input prevouts, validated last-transition OpId)`.
+/// All `Option` because a bundle-less transfer (rejected upstream by rgbstd)
+/// yields `(None, None, None)`. See [`read_last_transfer_witness`].
+type LastTransferBinding = (
+    Option<bitcoin::Txid>,
+    Option<Vec<bitcoin::OutPoint>>,
+    Option<[u8; 32]>,
+);
 
 /// Parse the consignment with `rgb_consignment::parse` and pull out the
 /// flat transition summary (every op_id + the most recent transition's
@@ -845,18 +892,14 @@ mod tests {
 
         // The fixture's last transition is a Transfer (type 10000, asserted in
         // `extracts_op_ids_and_last_transition_from_transfer_fixture`).
-        let (txid, prevouts) =
+        let (txid, prevouts, op_id) =
             read_last_transfer_witness(&transfer, ifa::TS_TRANSFER).expect("extract witness");
 
         // Every validated transfer has at least one bundle, so the txid is set.
         let txid = txid.expect("transfer fixture has a witness txid");
         // It must equal the last bundle's witness id (the bundle we bind to).
-        let expected = transfer
-            .bundles
-            .iter()
-            .last()
-            .expect("fixture has bundles")
-            .witness_id();
+        let last_bundle = transfer.bundles.iter().last().expect("fixture has bundles");
+        let expected = last_bundle.witness_id();
         assert_eq!(txid, expected);
 
         // The rgb-lib sender embeds the full witness tx for a freshly-composed
@@ -867,6 +910,20 @@ mod tests {
             !prevouts.is_empty(),
             "witness tx must spend at least one input"
         );
+
+        // The validated OpId (canonical burnId source, #93) must be present and
+        // equal the last bundle's last known-transition opid, read straight
+        // from the validated object - not the flat parser.
+        let op_id = op_id.expect("transfer fixture yields a validated opid");
+        let expected_opid = last_bundle
+            .bundle()
+            .known_transitions
+            .iter()
+            .last()
+            .expect("bundle has a known transition")
+            .opid
+            .to_string();
+        assert_eq!(hex::encode(op_id), expected_opid);
     }
 
     #[test]

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -171,19 +171,26 @@ fn build_test_multisig_psbt(our_pubkey: &bitcoin::PublicKey) -> Vec<u8> {
 
 /// Build a valid enriched SignPsbtRequest for testing.
 #[cfg(feature = "allow-seed-import")]
+// Vanilla-mode (non-bridge) PSBT request: empty `evm_tx_hash` so the handler
+// signs the PSBT on its mechanics alone. The roundtrip test exercises signing,
+// not the bridge cross-checks. A bridge-mode request (non-empty evm_tx_hash)
+// under `rgb-validation` fail-closes on a missing consignment (the send-RGB
+// binding from #79), and this synthetic multisig PSBT could never match a real
+// consignment's witness txid - so bridge mode is the wrong shape here. The
+// consignment binding has its own coverage in `psbt_crosscheck` unit tests.
 fn valid_sign_psbt_request(psbt_bytes: Vec<u8>) -> SignPsbtRequest {
     SignPsbtRequest {
-        evm_tx_hash: vec![0xCC; 32],
+        evm_tx_hash: vec![],
         operation_idx: 0,
-        evm_event_valid: true,
-        evm_event_finalized: true,
-        evm_token: vec![0x11; 20],
-        evm_amount: 100_000,
-        evm_recipient: vec![0x22; 20],
-        evm_commission: 1_000,
+        evm_event_valid: false,
+        evm_event_finalized: false,
+        evm_token: vec![],
+        evm_amount: 0,
+        evm_recipient: vec![],
+        evm_commission: 0,
         psbt_bytes,
-        psbt_output_amount: 50_000,
-        rgb_asset_id: "rgb:test".into(),
+        psbt_output_amount: 0,
+        rgb_asset_id: String::new(),
         consignment: vec![],
         consignment_hash: vec![],
     }


### PR DESCRIPTION
The contract's single-use consumedBurnIds[burnId] guard is only sound if burnId canonically identifies the RGB operation being released against. Previously the
  enclave derived burnId from the flat rgb_consignment parser's last-transition OpId — a traversal independent of the one rgbstd validate() actually
  authenticates. A consignment whose flat parse disagrees with the validated object could yield a burnId not bound to the authenticated operation (audit M-02 /
  #93, overlaps #63).

  This PR sources burnId from the rgbstd-validated Transfer. read_last_transfer_witness now also reads the OpId (32-byte commitment hash) of the validated last
  bundle's known transition and surfaces it as ValidatedConsignment::last_transfer_op_id. apply_op_id_binding derives burnId = keccak256(last_transfer_op_id) from
  that value — the operation validate() authenticated and anchored on chain — instead of the flat-parser string.

  Semantics unchanged from the existing binding: the enclave does not trust or read the listener's burnId. It overwrites the calldata slot (offset 68) and signs
  over the result; because the MultisigProxy signature commits to keccak256(callData), the returned bytes are authoritative and a compromised backend cannot steer
  the release to a different replay slot. The caller MUST submit exactly the returned bytes. Fail-closed if the validated OpId is absent (no bundles, or a
  non-Transfer last transition — the pools path already requires a TS_TRANSFER last transition via validate_funds_out_transfer, so this is defense-in-depth).

  Active on the pools fundsOut selector under the existing rgb-validation feature (no new feature gate). Default builds without rgb-validation sign calldata as
  received.

  Coordination requirement: the burnId preimage is keccak256(<raw 32-byte OpId>) (op_id_to_calldata_id). bridge-utexo must key consumedBurnIds on the identical
  derivation. This is the single line that changes if the team pins a different preimage.

  Out of scope / still open (#93 stays open): settlementData / fundsInIds are still sourced from the flat parser (mint_op_ids), not the validated object — the
  same trust class as this fix, on the fundsIn side. The EVM→RGB consumed-set (durable on-chain state) is tracked separately.

  Tests: unit tests for apply_op_id_binding (validated-OpId source, fail-closed when the validated OpId is missing, mint-OpId hex-decode failures);
  read_last_transfer_witness asserts the returned OpId equals the validated last bundle's known-transition opid; the test_signing roundtrip switched to vanilla
  (non-bridge) mode, since a synthetic multisig PSBT can't match a real consignment's witness txid and would fail-close under the send-RGB binding (#79) — the
  consignment binding keeps its coverage in the psbt_crosscheck unit tests.