### PR TITLE
fix(psbt): close SignPsbt vanilla-mode bypass; add explicit plain-BTC path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 [[package]]
 name = "federated-signer-proto"
 version = "0.1.0"
-source = "git+ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git?rev=f61dcb76595c69af914107a74852ad013afed9df#f61dcb76595c69af914107a74852ad013afed9df"
+source = "git+ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git?rev=aafbbdd243c96354d1ee1147eee4b8be7d861416#aafbbdd243c96354d1ee1147eee4b8be7d861416"
 dependencies = [
  "bytes",
  "prost",

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 # Protobuf
 prost = "0.14.3"
-federated-signer-proto = { git = "ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git", rev = "f61dcb76595c69af914107a74852ad013afed9df", package = "federated-signer-proto" }
+federated-signer-proto = { git = "ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git", rev = "aafbbdd243c96354d1ee1147eee4b8be7d861416", package = "federated-signer-proto" }
 
 # Crypto — ECDSA on secp256k1 (EVM address derivation + signing later)
 k256 = { version = "0.13", features = ["ecdsa"] }

--- a/enclave/src/config.rs
+++ b/enclave/src/config.rs
@@ -21,7 +21,7 @@
 use crate::error::{EnclaveError, Result};
 
 /// Bridge config pinned at enclave boot from env. See module docs.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct BridgeConfig {
     pub chain_id: u64,
     pub bridge_contract: [u8; 20],
@@ -43,6 +43,21 @@ pub struct BridgeConfig {
     /// the enclave's committed identity. It can be added to the bundle in a
     /// follow-up if external verifiability of the gas-tx policy is wanted.
     pub gas_tx_allowed_to: Option<[u8; 20]>,
+    /// Operator-pinned output allowlist for the **plain-BTC** signing path
+    /// (`SignBtc`, env `BTC_ALLOWED_SCRIPTS`): the set of output
+    /// `script_pubkey` byte-strings the enclave will co-sign a plain-BTC PSBT
+    /// toward (e.g. the bridge's own change/UTXO-management scripts). Empty =
+    /// unset; a production (`rgb-validation`) build refuses plain-BTC signing
+    /// when unset. Like the gas-tx destination pin (`GAS_TX_ALLOWED_TO`), this
+    /// is an operational signing-policy pin, NOT part of `is_configured()` or
+    /// the attested identity bundle — see the C-01 systemic follow-up for
+    /// attesting it.
+    pub btc_allowed_scripts: Vec<Vec<u8>>,
+    /// Operator-pinned cap (sats) on the **total** output value of a plain-BTC
+    /// PSBT (`BTC_MAX_TOTAL_SATS`). `0` = unset; a production build refuses
+    /// plain-BTC signing when unset. Bounds the blast radius of the plain-BTC
+    /// path independently of the destination allowlist.
+    pub btc_max_total_sats: u64,
 }
 
 impl BridgeConfig {
@@ -67,11 +82,31 @@ impl BridgeConfig {
             .ok()
             .and_then(|s| parse_eth_address(&s).ok());
 
+        // Plain-BTC output allowlist: comma-separated hex `script_pubkey`s.
+        // Each entry is parsed independently; malformed/empty entries are
+        // dropped rather than poisoning the whole list.
+        let btc_allowed_scripts = std::env::var("BTC_ALLOWED_SCRIPTS")
+            .ok()
+            .map(|s| {
+                s.split(',')
+                    .filter_map(|part| hex::decode(part.trim()).ok())
+                    .filter(|bytes| !bytes.is_empty())
+                    .collect::<Vec<Vec<u8>>>()
+            })
+            .unwrap_or_default();
+
+        let btc_max_total_sats = std::env::var("BTC_MAX_TOTAL_SATS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(0);
+
         Self {
             chain_id,
             bridge_contract,
             rgb_asset_id,
             gas_tx_allowed_to,
+            btc_allowed_scripts,
+            btc_max_total_sats,
         }
     }
 
@@ -159,7 +194,7 @@ mod tests {
             chain_id: 0,
             bridge_contract: [0u8; 20],
             rgb_asset_id: String::new(),
-            gas_tx_allowed_to: None,
+            ..Default::default()
         };
         assert!(!c.is_configured());
         assert!(!c.is_partially_configured());
@@ -172,6 +207,7 @@ mod tests {
             bridge_contract: [1u8; 20],
             rgb_asset_id: "rgb:asset".into(),
             gas_tx_allowed_to: None,
+            ..Default::default()
         };
         assert!(c.is_configured());
         assert!(!c.is_partially_configured());
@@ -186,7 +222,7 @@ mod tests {
             chain_id: 1,
             bridge_contract: [0u8; 20],
             rgb_asset_id: "rgb:asset".into(),
-            gas_tx_allowed_to: None,
+            ..Default::default()
         };
         assert!(!c.is_configured());
         assert!(c.is_partially_configured());
@@ -199,6 +235,7 @@ mod tests {
             bridge_contract: [1u8; 20],
             rgb_asset_id: "rgb:asset".into(),
             gas_tx_allowed_to: None,
+            ..Default::default()
         };
         assert!(!c.is_configured());
         assert!(c.is_partially_configured());

--- a/enclave/src/keys.rs
+++ b/enclave/src/keys.rs
@@ -31,7 +31,7 @@ pub struct KeyInfo {
 }
 
 /// Which BIP-86 account to derive from.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AccountType {
     Vanilla,
     Colored,
@@ -333,6 +333,27 @@ impl KeyManager {
     /// Auto-detects taproot (Schnorr, BIP-340) vs SegWit v0 P2WSH (ECDSA) per input.
     /// Returns the modified PSBT bytes and count of inputs signed.
     pub fn sign_psbt(&self, psbt_bytes: &[u8]) -> Result<(Vec<u8>, usize)> {
+        self.sign_psbt_scoped(psbt_bytes, None)
+    }
+
+    /// Sign PSBT inputs matching our keys, optionally restricted to a single
+    /// BIP-86 account.
+    ///
+    /// `allowed_account`:
+    ///   * `None` — sign every input we can (taproot any account + legacy
+    ///     P2WSH). Used by the consignment-bound bridge path (`SignPsbt`),
+    ///     where the consignment, not the account, is the authorization.
+    ///   * `Some(account)` — sign ONLY taproot inputs resolving to `account`,
+    ///     and skip the legacy P2WSH path entirely. The plain-BTC path
+    ///     (`SignBtc`) passes `Some(Vanilla)` so it can never co-sign a
+    ///     Colored (RGB-allocated) input — those move only via the
+    ///     consignment-bound path. This is the structural guard that keeps the
+    ///     M-01 fix from being reopened on the plain-BTC sibling path.
+    pub fn sign_psbt_scoped(
+        &self,
+        psbt_bytes: &[u8],
+        allowed_account: Option<AccountType>,
+    ) -> Result<(Vec<u8>, usize)> {
         let secp = Secp256k1::new();
 
         let mut psbt = Psbt::deserialize(psbt_bytes)
@@ -341,11 +362,17 @@ impl KeyManager {
         let mut signed_count = 0usize;
 
         // === Taproot signing (BIP-86 / BIP-340 Schnorr) ===
-        let taproot_jobs = crate::networks::rgb::signing::taproot::find_taproot_sign_jobs(
+        let mut taproot_jobs = crate::networks::rgb::signing::taproot::find_taproot_sign_jobs(
             &psbt,
             &self.master_fingerprint,
             self,
         );
+        if let Some(account) = allowed_account {
+            // Plain-BTC path: refuse any input that resolves to a different
+            // account (e.g. Colored/RGB). Dropping the job means the input is
+            // left unsigned.
+            taproot_jobs.retain(|job| job.account_type == account);
+        }
         if !taproot_jobs.is_empty() {
             signed_count += crate::networks::rgb::signing::taproot::sign_taproot_inputs(
                 &mut psbt,
@@ -355,6 +382,11 @@ impl KeyManager {
         }
 
         // === Legacy SegWit v0 P2WSH signing (ECDSA) ===
+        // Skipped entirely on an account-scoped call: the legacy single key is
+        // not BIP-86-account-derived, so it has no place on the plain-BTC path.
+        if allowed_account.is_some() {
+            return Ok((psbt.serialize(), signed_count));
+        }
         let secret_key = SecretKey::from_slice(self.btc_secret.expose_secret())
             .map_err(|e| EnclaveError::Signing(format!("btc key: {e}")))?;
         let our_pubkey = secret_key.public_key(&secp);

--- a/enclave/src/networks/evm/gas_tx.rs
+++ b/enclave/src/networks/evm/gas_tx.rs
@@ -409,6 +409,7 @@ mod tests {
             bridge_contract: [0xBB; 20],
             rgb_asset_id: "rgb:test".into(),
             gas_tx_allowed_to: Some(ALLOWED_TO),
+            ..Default::default()
         }
     }
 

--- a/enclave/src/networks/evm/validation.rs
+++ b/enclave/src/networks/evm/validation.rs
@@ -238,6 +238,7 @@ mod tests {
             bridge_contract: [0xAA; ADDRESS_LEN],
             rgb_asset_id: "ignored-by-evm-validation".into(),
             gas_tx_allowed_to: None,
+            ..Default::default()
         }
     }
 

--- a/enclave/src/networks/rgb/btc_crosscheck.rs
+++ b/enclave/src/networks/rgb/btc_crosscheck.rs
@@ -1,0 +1,370 @@
+//! Plain-BTC (`SignBtc`) signing cross-check.
+//!
+//! This is the authorization gate for the *plain-BTC* signing path — the ops
+//! the bridge legitimately performs that carry no RGB consignment and no EVM
+//! correlation (e.g. `create_utxo` UTXO management, plain BTC withdrawals).
+//! It exists as a request type distinct from `SignPsbt` (the bridge/RGB-send
+//! path) precisely so plain-BTC ops can no longer be reached by *omitting*
+//! the bridge fields on a bridge request — the M-01/#69 anti-pattern.
+//!
+//! Funds-safety on this path is layered:
+//!
+//!   * **Account scope (enforced in the signer, not here):** the handler signs
+//!     a plain-BTC PSBT via `EnclaveState::sign_psbt_scoped(.., Some(Vanilla))`,
+//!     so the enclave will only co-sign inputs that resolve to the **Vanilla**
+//!     (plain-BTC) BIP-86 account and never a **Colored** (RGB-allocated) input.
+//!     Plain-BTC ops (`create_utxo`, `sendBtc`) spend only vanilla-account
+//!     UTXOs, while RGB-allocated value lives in the colored account and moves
+//!     only via the consignment-bound `SignPsbt` path. That scoping is what
+//!     keeps the M-01 fix from being reopened on this sibling path; this
+//!     validator adds the operator-pinned destination + amount policy on top:
+//!   * **Output allowlist** (`BTC_ALLOWED_SCRIPTS`): every output's
+//!     `script_pubkey` must be one the operator pinned (e.g. the bridge's own
+//!     change / UTXO-management scripts). A listener cannot redirect funds to
+//!     an address the operator did not pre-authorize.
+//!   * **Amount cap** (`BTC_MAX_TOTAL_SATS`): the **total input value spent**
+//!     must not exceed the pinned cap. Capping *value spent* (not output value)
+//!     bounds the real blast radius — including value routed to miner fees — so
+//!     a host can't burn bridge funds by under-paying the outputs.
+//!
+//! Scope note: a *static* pinned allowlist cannot express a withdrawal to an
+//! arbitrary user address (`sendBtc`); this path serves self-pay / UTXO-
+//! management (`create_utxo`) where destinations are bridge-controlled and
+//! pinnable. Dynamic-destination withdrawals are out of scope for #69.
+//!
+//! Fail-closed posture (mirrors `evm_crosscheck`): a production build
+//! (`rgb-validation`) refuses to sign on this path when the allowlist/cap are
+//! unconfigured. Default / `cfg(test)` builds, which are never production
+//! (production is `--features vsock,rgb-validation,spv`), fall back to a
+//! permissive dev path when nothing is pinned so local tooling keeps working.
+//! `dev-mode` skips this function entirely (the handler is
+//! `cfg(not(dev-mode))`). The witness_utxo requirement below runs in ALL builds
+//! (it is needed to bound value, not a tunable policy).
+
+use crate::config::BridgeConfig;
+use crate::error::{EnclaveError, Result};
+use crate::proto::SignBtcRequest;
+
+/// Validate a plain-BTC `SignBtcRequest` before signing: the operator-pinned
+/// output allowlist + value-spent cap. (Account scoping — never sign a Colored
+/// input — is enforced separately in the signer; see the module docs.) Returns
+/// `Ok(())` when authorized, a `CrossCheck` error otherwise.
+pub fn validate_btc_request(req: &SignBtcRequest, cfg: &BridgeConfig) -> Result<()> {
+    // 0. Shape whitelist (shared with the bridge path).
+    let psbt = crate::networks::rgb::psbt_validation::parse_psbt_shape(&req.psbt_bytes)?;
+
+    // 1. Sum the value spent (for the cap). Every input must carry its
+    //    witness_utxo — the bridge populates it on every segwit input it spends,
+    //    and without it we cannot bound the value, so refuse fail-closed.
+    let mut total_in_sat: u64 = 0;
+    for (i, input) in psbt.inputs.iter().enumerate() {
+        let Some(witness_utxo) = input.witness_utxo.as_ref() else {
+            return Err(EnclaveError::CrossCheck(format!(
+                "plain-BTC input {i} is missing witness_utxo — cannot bound the value spent; \
+                 refusing (the bridge populates witness_utxo on every segwit input it spends)"
+            )));
+        };
+        total_in_sat = total_in_sat
+            .checked_add(witness_utxo.value.to_sat())
+            .ok_or_else(|| {
+                EnclaveError::CrossCheck("plain-BTC total input value overflow".into())
+            })?;
+    }
+
+    // 2. A usable pin requires BOTH an allowlist and a cap. A half-pin is
+    //    treated as unconfigured (fail-closed in production) rather than
+    //    enforcing one dimension while silently ignoring the other.
+    let pinned = !cfg.btc_allowed_scripts.is_empty() && cfg.btc_max_total_sats != 0;
+
+    if !pinned {
+        // Production (rgb-validation, not test) must not sign plain BTC without
+        // an enclave-verifiable policy — otherwise a misprovisioned-but-running
+        // enclave silently degrades to "sign any output the host asks for".
+        #[cfg(all(feature = "rgb-validation", not(test)))]
+        {
+            return Err(EnclaveError::CrossCheck(
+                "plain-BTC signing requires BTC_ALLOWED_SCRIPTS and BTC_MAX_TOTAL_SATS to be \
+                 pinned — refusing to sign without an enclave-verifiable output allowlist + \
+                 amount cap"
+                    .into(),
+            ));
+        }
+        // Default / test builds: nothing pinned, no operator policy to enforce
+        // (the input guard above still ran). Dev path only.
+        #[cfg(not(all(feature = "rgb-validation", not(test))))]
+        {
+            tracing::warn!(
+                "plain-BTC signing: no BTC_ALLOWED_SCRIPTS / BTC_MAX_TOTAL_SATS pinned \
+                 (non-production build) — skipping output/amount policy"
+            );
+            return Ok(());
+        }
+    }
+
+    // 3. Reject an empty output set — every input value would go to fees, which
+    //    the output allowlist would not catch. The cap below bounds value spent,
+    //    but a no-output PSBT is never a legitimate plain-BTC op.
+    if psbt.unsigned_tx.output.is_empty() {
+        return Err(EnclaveError::CrossCheck(
+            "plain-BTC PSBT has no outputs — refusing (would route all input value to fees)".into(),
+        ));
+    }
+
+    // 4. Output allowlist. Authorization is anchored to the unsigned tx's
+    //    outputs, which the segwit sighash commits to — the same bytes the
+    //    signature will cover.
+    for (i, out) in psbt.unsigned_tx.output.iter().enumerate() {
+        let spk = out.script_pubkey.as_bytes();
+        let allowed = cfg
+            .btc_allowed_scripts
+            .iter()
+            .any(|allowed_spk| allowed_spk.as_slice() == spk);
+        if !allowed {
+            return Err(EnclaveError::CrossCheck(format!(
+                "plain-BTC output {i} pays a non-allowlisted script_pubkey ({}) — refusing to \
+                 sign toward a destination the operator did not pin",
+                hex::encode(spk)
+            )));
+        }
+    }
+
+    // 5. Amount cap on VALUE SPENT (sum of input values), bounding the blast
+    //    radius including any value routed to fees.
+    if total_in_sat > cfg.btc_max_total_sats {
+        return Err(EnclaveError::CrossCheck(format!(
+            "plain-BTC total input value {total_in_sat} sats exceeds pinned cap {} sats",
+            cfg.btc_max_total_sats
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::hashes::Hash;
+    use bitcoin::psbt::Psbt;
+    use bitcoin::{
+        Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, WPubkeyHash, Witness,
+    };
+
+    /// A P2WPKH script_pubkey seeded deterministically — a NON-P2WSH script,
+    /// stands in for a bridge-controlled plain output/input script.
+    fn script_for(seed: u8) -> ScriptBuf {
+        ScriptBuf::new_p2wpkh(&WPubkeyHash::from_byte_array([seed; 20]))
+    }
+
+    /// Build a PSBT from `inputs` (witness_utxo script + value sats, per input)
+    /// and `outputs` (script + value sats). Every input gets its witness_utxo
+    /// populated so the validator can classify and value it.
+    fn psbt(inputs: &[(ScriptBuf, u64)], outputs: &[(ScriptBuf, u64)]) -> Vec<u8> {
+        psbt_inner(inputs, outputs, true)
+    }
+
+    /// Like [`psbt`] but leaves witness_utxo unset on every input (for the
+    /// missing-witness_utxo guard test).
+    fn psbt_without_witness_utxo(
+        inputs: &[(ScriptBuf, u64)],
+        outputs: &[(ScriptBuf, u64)],
+    ) -> Vec<u8> {
+        psbt_inner(inputs, outputs, false)
+    }
+
+    fn psbt_inner(
+        inputs: &[(ScriptBuf, u64)],
+        outputs: &[(ScriptBuf, u64)],
+        set_witness_utxo: bool,
+    ) -> Vec<u8> {
+        let unsigned_tx = Transaction {
+            version: bitcoin::transaction::Version(2),
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: (0..inputs.len().max(1))
+                .map(|i| TxIn {
+                    previous_output: OutPoint {
+                        txid: Txid::from_raw_hash(bitcoin::hashes::sha256d::Hash::from_byte_array(
+                            [i as u8; 32],
+                        )),
+                        vout: 0,
+                    },
+                    script_sig: ScriptBuf::new(),
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
+                })
+                .collect(),
+            output: outputs
+                .iter()
+                .map(|(spk, sat)| TxOut {
+                    value: Amount::from_sat(*sat),
+                    script_pubkey: spk.clone(),
+                })
+                .collect(),
+        };
+        let mut p = Psbt::from_unsigned_tx(unsigned_tx).expect("from_unsigned_tx");
+        if set_witness_utxo {
+            for (i, (spk, sat)) in inputs.iter().enumerate() {
+                p.inputs[i].witness_utxo = Some(TxOut {
+                    value: Amount::from_sat(*sat),
+                    script_pubkey: spk.clone(),
+                });
+            }
+        }
+        p.serialize()
+    }
+
+    fn cfg_pinned(allowed: &[ScriptBuf], cap: u64) -> BridgeConfig {
+        BridgeConfig {
+            btc_allowed_scripts: allowed.iter().map(|s| s.as_bytes().to_vec()).collect(),
+            btc_max_total_sats: cap,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn rejects_empty_psbt() {
+        let cfg = cfg_pinned(&[script_for(0x11)], 100_000);
+        let req = SignBtcRequest { psbt_bytes: vec![] };
+        let err = validate_btc_request(&req, &cfg).unwrap_err();
+        assert!(err.to_string().contains("psbt_bytes is empty"));
+    }
+
+    // --- witness_utxo required (needed to bound value spent) ---
+
+    #[test]
+    fn rejects_missing_witness_utxo() {
+        let allowed = script_for(0x11);
+        let cfg = cfg_pinned(std::slice::from_ref(&allowed), 100_000);
+        let req = SignBtcRequest {
+            psbt_bytes: psbt_without_witness_utxo(
+                &[(script_for(0x11), 50_000)],
+                &[(allowed, 40_000)],
+            ),
+        };
+        let err = validate_btc_request(&req, &cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("missing witness_utxo"),
+            "got: {err}"
+        );
+    }
+
+    // --- Output allowlist + value-spent cap (pinned policy) ---
+
+    #[test]
+    fn accepts_allowlisted_output_under_cap() {
+        let allowed = script_for(0x11);
+        let cfg = cfg_pinned(std::slice::from_ref(&allowed), 100_000);
+        let req = SignBtcRequest {
+            psbt_bytes: psbt(&[(script_for(0x11), 60_000)], &[(allowed, 50_000)]),
+        };
+        assert!(validate_btc_request(&req, &cfg).is_ok());
+    }
+
+    #[test]
+    fn accepts_input_value_at_exact_cap() {
+        let allowed = script_for(0x11);
+        let cfg = cfg_pinned(std::slice::from_ref(&allowed), 100_000);
+        let req = SignBtcRequest {
+            // input value 100_000 == cap; outputs allowlisted
+            psbt_bytes: psbt(&[(script_for(0x11), 100_000)], &[(allowed, 99_000)]),
+        };
+        assert!(validate_btc_request(&req, &cfg).is_ok());
+    }
+
+    #[test]
+    fn rejects_output_not_in_allowlist() {
+        let allowed = script_for(0x11);
+        let cfg = cfg_pinned(&[allowed], 100_000);
+        let req = SignBtcRequest {
+            // input fine, but pays 0x99 which is not pinned
+            psbt_bytes: psbt(&[(script_for(0x11), 50_000)], &[(script_for(0x99), 10_000)]),
+        };
+        let err = validate_btc_request(&req, &cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("non-allowlisted script_pubkey"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_one_bad_output_among_allowed() {
+        let a = script_for(0x11);
+        let cfg = cfg_pinned(std::slice::from_ref(&a), 100_000);
+        let req = SignBtcRequest {
+            psbt_bytes: psbt(
+                &[(script_for(0x11), 50_000)],
+                &[(a, 10_000), (script_for(0x99), 10_000)],
+            ),
+        };
+        let err = validate_btc_request(&req, &cfg).unwrap_err();
+        assert!(err.to_string().contains("non-allowlisted"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_empty_output_set() {
+        let allowed = script_for(0x11);
+        let cfg = cfg_pinned(std::slice::from_ref(&allowed), 100_000);
+        let req = SignBtcRequest {
+            psbt_bytes: psbt(&[(script_for(0x11), 50_000)], &[]),
+        };
+        let err = validate_btc_request(&req, &cfg).unwrap_err();
+        assert!(err.to_string().contains("no outputs"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_input_value_over_cap() {
+        let allowed = script_for(0x11);
+        let cfg = cfg_pinned(std::slice::from_ref(&allowed), 100_000);
+        let req = SignBtcRequest {
+            // input value 100_001 > cap; output allowlisted (so we reach the cap)
+            psbt_bytes: psbt(&[(script_for(0x11), 100_001)], &[(allowed, 50_000)]),
+        };
+        let err = validate_btc_request(&req, &cfg).unwrap_err();
+        assert!(err.to_string().contains("exceeds pinned cap"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_summed_input_value_over_cap() {
+        let allowed = script_for(0x11);
+        let cfg = cfg_pinned(std::slice::from_ref(&allowed), 100_000);
+        let req = SignBtcRequest {
+            // two inputs, 70_000 + 50_000 = 120_000 > cap
+            psbt_bytes: psbt(
+                &[(script_for(0x11), 70_000), (script_for(0x11), 50_000)],
+                &[(allowed, 100_000)],
+            ),
+        };
+        let err = validate_btc_request(&req, &cfg).unwrap_err();
+        assert!(err.to_string().contains("exceeds pinned cap"), "got: {err}");
+    }
+
+    /// In a production build, an unpinned policy fails closed (after the input
+    /// guard passes). In default / test builds it falls back to the dev path.
+    #[test]
+    fn unpinned_policy_behaviour_matches_build_profile() {
+        let cfg = BridgeConfig::default(); // nothing pinned
+        let req = SignBtcRequest {
+            psbt_bytes: psbt(&[(script_for(0x11), 1_000)], &[(script_for(0x99), 900)]),
+        };
+        let result = validate_btc_request(&req, &cfg);
+        #[cfg(all(feature = "rgb-validation", not(test)))]
+        assert!(result.is_err());
+        // Unit tests are always cfg(test): the dev fallback returns Ok.
+        #[cfg(not(all(feature = "rgb-validation", not(test))))]
+        assert!(result.is_ok());
+    }
+
+    /// A half-pin (allowlist but no cap, or vice-versa) is treated as
+    /// unconfigured — never "enforce one dimension, ignore the other".
+    #[test]
+    fn half_pin_is_treated_as_unconfigured() {
+        let allowed = script_for(0x11);
+        // allowlist set, cap == 0 (unset)
+        let cfg = cfg_pinned(std::slice::from_ref(&allowed), 0);
+        let req = SignBtcRequest {
+            psbt_bytes: psbt(&[(script_for(0x11), 50_000)], &[(allowed, 40_000)]),
+        };
+        // In test builds the unconfigured path returns Ok (dev fallback);
+        // the point of the test is that it does NOT enforce the partial pin.
+        assert!(validate_btc_request(&req, &cfg).is_ok());
+    }
+}

--- a/enclave/src/networks/rgb/mod.rs
+++ b/enclave/src/networks/rgb/mod.rs
@@ -1,3 +1,4 @@
+pub mod btc_crosscheck;
 pub mod psbt_validation;
 pub mod signing;
 pub mod spv;

--- a/enclave/src/networks/rgb/psbt_validation.rs
+++ b/enclave/src/networks/rgb/psbt_validation.rs
@@ -37,21 +37,22 @@ pub fn psbt_operation_key(
     h.finalize().into()
 }
 
-/// Validate the serialized PSBT shape owned by an RGB destination.
-pub fn validate_psbt_bytes(psbt_bytes: &[u8]) -> Result<()> {
-    // Shape whitelist: refuse payloads that aren't even a legitimate PSBT before any other
-    //    predicate runs. Catches three classes of garbage up-front:
-    //
-    //      (a) empty bytes (handler tried to sign nothing),
-    //      (b) bytes that don't conform to BIP-174 (random/truncated/
-    //          tampered),
-    //      (c) PSBTs with no inputs — there's literally nothing to sign,
-    //          and the unsigned-tx-must-be-non-empty rule is implicit in
-    //          BIP-174's signing semantics.
-    //
-    //    The existing PSBT signer would have failed later on these too,
-    //    but with a much noisier downstream error. Failing here gives the
-    //    caller a single clear reason.
+/// Shape whitelist for a raw PSBT: refuse payloads that aren't even a legitimate
+/// PSBT before any other predicate runs. Catches three classes of garbage
+/// up-front:
+///
+///   (a) empty bytes (handler tried to sign nothing),
+///   (b) bytes that don't conform to BIP-174 (random/truncated/tampered),
+///   (c) PSBTs with no inputs — there's literally nothing to sign, and the
+///       unsigned-tx-must-be-non-empty rule is implicit in BIP-174's signing
+///       semantics.
+///
+/// The signer would fail later on these too, but with a much noisier downstream
+/// error; failing here gives the caller a single clear reason. Returns the
+/// parsed PSBT so callers that need it (the plain-BTC `SignBtc` path) don't
+/// re-parse. Shared by the bridge/RGB `SignPsbt` path ([`validate_psbt_bytes`])
+/// and the plain-BTC `SignBtc` path ([`crate::networks::rgb::btc_crosscheck`]).
+pub(crate) fn parse_psbt_shape(psbt_bytes: &[u8]) -> Result<Psbt> {
     if psbt_bytes.is_empty() {
         return Err(EnclaveError::CrossCheck("psbt_bytes is empty".into()));
     }
@@ -63,7 +64,12 @@ pub fn validate_psbt_bytes(psbt_bytes: &[u8]) -> Result<()> {
         ));
     }
 
-    Ok(())
+    Ok(psbt)
+}
+
+/// Validate the serialized PSBT shape owned by an RGB destination.
+pub fn validate_psbt_bytes(psbt_bytes: &[u8]) -> Result<()> {
+    parse_psbt_shape(psbt_bytes).map(|_| ())
 }
 
 /// Bind a PSBT to the RGB consignment it claims to finalize.

--- a/enclave/src/networks/rgb/signing/taproot.rs
+++ b/enclave/src/networks/rgb/signing/taproot.rs
@@ -545,4 +545,118 @@ mod tests {
         let jobs = find_taproot_sign_jobs(&psbt, km.master_fingerprint(), &km);
         assert!(jobs.is_empty());
     }
+
+    // === Account-scoped signing (plain-BTC path guard, M-01/#69) ===
+
+    fn our_xonly_colored(km: &KeyManager) -> XOnlyPublicKey {
+        let secp = Secp256k1::new();
+        let sk = km
+            .derive_btc_child(
+                AccountType::Colored,
+                &[
+                    ChildNumber::Normal { index: 0 },
+                    ChildNumber::Normal { index: 0 },
+                ],
+            )
+            .unwrap();
+        XOnlyPublicKey::from_keypair(&Keypair::from_secret_key(&secp, &sk)).0
+    }
+
+    fn our_colored_full_path() -> DerivationPath {
+        DerivationPath::from(vec![
+            ChildNumber::from_hardened_idx(86).unwrap(),
+            ChildNumber::from_hardened_idx(827167).unwrap(), // RGB coin type → Colored
+            ChildNumber::from_hardened_idx(0).unwrap(),
+            ChildNumber::Normal { index: 0 },
+            ChildNumber::Normal { index: 0 },
+        ])
+    }
+
+    /// Like [`build_legit_taproot_psbt`] but the leaf + tap_key_origins use the
+    /// COLORED (RGB) account key/path, so the resolved job is `AccountType::Colored`.
+    fn build_colored_taproot_psbt(km: &KeyManager) -> Psbt {
+        let secp = Secp256k1::new();
+        let our = our_xonly_colored(km);
+        let leaf_script = multi_a_2_of_3(&[our, xonly_from_byte(0xA1), xonly_from_byte(0xA2)]);
+        let leaf_hash = TapLeafHash::from_script(&leaf_script, LeafVersion::TapScript);
+
+        let internal_key = XOnlyPublicKey::from_slice(&NUMS_INTERNAL).unwrap();
+        let spend_info = TaprootBuilder::new()
+            .add_leaf(0, leaf_script.clone())
+            .unwrap()
+            .finalize(&secp, internal_key)
+            .unwrap();
+        let script_pubkey = ScriptBuf::new_p2tr(&secp, internal_key, spend_info.merkle_root());
+        let control_block = spend_info
+            .control_block(&(leaf_script.clone(), LeafVersion::TapScript))
+            .unwrap();
+
+        let unsigned_tx = Transaction {
+            version: bitcoin::transaction::Version(2),
+            lock_time: bitcoin::blockdata::locktime::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([0xBB; 32]),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::MAX,
+                witness: bitcoin::Witness::default(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(50_000),
+                script_pubkey: ScriptBuf::new_p2tr_tweaked(spend_info.output_key()),
+            }],
+        };
+        let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).unwrap();
+        psbt.inputs[0].witness_utxo = Some(TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey,
+        });
+        psbt.inputs[0].tap_internal_key = Some(internal_key);
+        psbt.inputs[0]
+            .tap_scripts
+            .insert(control_block, (leaf_script, LeafVersion::TapScript));
+        psbt.inputs[0].tap_key_origins.insert(
+            our,
+            (
+                vec![leaf_hash],
+                (*km.master_fingerprint(), our_colored_full_path()),
+            ),
+        );
+        psbt
+    }
+
+    #[test]
+    fn scoped_vanilla_signs_a_vanilla_input() {
+        let km = KeyManager::from_seed([0x42u8; 64], Network::Testnet).unwrap();
+        let (psbt, _, _, _, _) = build_legit_taproot_psbt(&km);
+        let bytes = psbt.serialize();
+        let (_, signed) = km
+            .sign_psbt_scoped(&bytes, Some(AccountType::Vanilla))
+            .unwrap();
+        assert_eq!(
+            signed, 1,
+            "vanilla-scoped signing must sign a vanilla input"
+        );
+    }
+
+    #[test]
+    fn scoped_vanilla_refuses_a_colored_input() {
+        let km = KeyManager::from_seed([0x42u8; 64], Network::Testnet).unwrap();
+        let bytes = build_colored_taproot_psbt(&km).serialize();
+
+        // Unscoped: the colored input IS signable (sanity check the fixture).
+        let (_, unscoped) = km.sign_psbt_scoped(&bytes, None).unwrap();
+        assert_eq!(unscoped, 1, "fixture: colored input should sign unscoped");
+
+        // Vanilla-scoped: the colored (RGB-allocated) input must NOT be signed.
+        let (_, scoped) = km
+            .sign_psbt_scoped(&bytes, Some(AccountType::Vanilla))
+            .unwrap();
+        assert_eq!(
+            scoped, 0,
+            "plain-BTC (vanilla-scoped) signing must refuse a colored input"
+        );
+    }
 }

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -137,6 +137,10 @@ fn dispatch(request: EnclaveRequest, ctx: &ServerContext) -> EnclaveResponse {
             handle_get_public_key(ctx, req)
         }
         Some(Request::Sign(req)) => handle_sign(ctx, req),
+        Some(Request::SignBtc(req)) => {
+            tracing::info!("request: SignBtc");
+            handle_sign_btc(ctx, req)
+        }
         Some(Request::SignRawMessage(req)) => {
             tracing::info!("request: SignRawMessage");
             handle_sign_raw_message(&ctx.state, req)
@@ -608,6 +612,50 @@ fn handle_sign_psbt(ctx: &ServerContext, req: RgbDestination) -> Result<EnclaveR
     }
 
     tracing::info!(inputs_signed, "PSBT signed");
+
+    Ok(EnclaveResponse {
+        response: Some(Response::SignedPsbt(SignedPsbtResponse {
+            signed_psbt,
+            inputs_signed: inputs_signed as u32,
+        })),
+    })
+}
+
+/// Sign a plain-BTC PSBT (create_utxo / plain withdrawals). Distinct from
+/// [`handle_sign_psbt`]: this path carries no RGB consignment and no EVM event.
+/// The enclave authorizes it solely against the operator-pinned output
+/// allowlist + amount cap ([`crate::networks::rgb::btc_crosscheck`]); a
+/// production (rgb-validation) build refuses to sign when that policy is
+/// unconfigured. Routing plain-BTC ops through their own request type is the
+/// structural half of the M-01/#69 fix — the bridge `SignPsbt` (RgbDestination)
+/// path can no longer be reached by omitting its fields.
+fn handle_sign_btc(ctx: &ServerContext, req: SignBtcRequest) -> Result<EnclaveResponse> {
+    // Pinned output allowlist + amount cap (skipped only in dev-mode).
+    #[cfg(not(feature = "dev-mode"))]
+    crate::networks::rgb::btc_crosscheck::validate_btc_request(&req, &ctx.bridge_config)?;
+
+    // Sign restricted to the VANILLA (plain-BTC) account: the enclave will not
+    // co-sign a Colored (RGB-allocated) input on this path, so it is
+    // structurally impossible for plain-BTC signing to move federation/RGB
+    // funds — those move only via the consignment-bound SignPsbt path. createUtxos
+    // and sendBtc spend only vanilla-account UTXOs, so this never blocks a
+    // legitimate plain-BTC op.
+    let (signed_psbt, inputs_signed) = ctx
+        .state
+        .sign_psbt_scoped(&req.psbt_bytes, Some(crate::keys::AccountType::Vanilla))?;
+
+    // Mirror the bridge path's W-03 guard: a 0-input signing is a no-op and
+    // must not be returned as a successful signature in production.
+    #[cfg(not(feature = "dev-mode"))]
+    if inputs_signed == 0 {
+        return Err(EnclaveError::Signing(
+            "sign_btc signed 0 inputs: no PSBT input belongs to this enclave — refusing to \
+             return a no-op as a successful signing response"
+                .into(),
+        ));
+    }
+
+    tracing::info!(inputs_signed, "plain-BTC PSBT signed");
 
     Ok(EnclaveResponse {
         response: Some(Response::SignedPsbt(SignedPsbtResponse {

--- a/enclave/src/state.rs
+++ b/enclave/src/state.rs
@@ -441,6 +441,18 @@ impl EnclaveState {
         self.with_active(|km| km.sign_psbt(psbt_bytes))
     }
 
+    /// Sign a PSBT restricted to a single BIP-86 account (see
+    /// [`crate::keys::KeyManager::sign_psbt_scoped`]). The plain-BTC path uses
+    /// this with `Some(AccountType::Vanilla)` so it can never co-sign a Colored
+    /// (RGB-allocated) input.
+    pub fn sign_psbt_scoped(
+        &self,
+        psbt_bytes: &[u8],
+        allowed_account: Option<crate::keys::AccountType>,
+    ) -> Result<(Vec<u8>, usize)> {
+        self.with_active(|km| km.sign_psbt_scoped(psbt_bytes, allowed_account))
+    }
+
     fn lock_phase(&self) -> Result<std::sync::MutexGuard<'_, Phase>> {
         self.inner
             .lock()

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -32,7 +32,20 @@ fn pinned_bridge_config() -> BridgeConfig {
         chain_id: 1,
         bridge_contract: [0xAA; 20],
         rgb_asset_id: "rgb:test".into(),
-        gas_tx_allowed_to: None,
+        ..Default::default()
+    }
+}
+
+/// Pinned `BridgeConfig` for the plain-BTC (`SignBtc`) path: pins a single
+/// allowed output `script_pubkey` and a total-output cap, so the plain-BTC
+/// cross-check has a concrete allowlist to enforce. Mirrors how #81's
+/// `gas_pinned_config()` pins the gas-tx destination.
+#[allow(dead_code)]
+fn btc_pinned_config(allowed_script: Vec<u8>, max_total_sats: u64) -> BridgeConfig {
+    BridgeConfig {
+        btc_allowed_scripts: vec![allowed_script],
+        btc_max_total_sats: max_total_sats,
+        ..Default::default()
     }
 }
 
@@ -129,6 +142,58 @@ fn minimal_valid_psbt_bytes() -> Vec<u8> {
     Psbt::from_unsigned_tx(unsigned_tx)
         .expect("from_unsigned_tx")
         .serialize()
+}
+
+/// Build a one-input, one-output PSBT for the plain-BTC (`SignBtc`) tests. The
+/// input carries a populated `witness_utxo` (`input_spk`/`input_sats`) so the
+/// validator can classify (P2WSH vs not) and bound it; the output pays
+/// `output_spk` for `output_sats`. The signer won't actually sign it (no
+/// matchable keys), so use it for tests expecting a cross-check rejection or a
+/// 0-input signed response.
+#[allow(dead_code)]
+fn btc_psbt(
+    input_spk: bitcoin::ScriptBuf,
+    input_sats: u64,
+    output_spk: bitcoin::ScriptBuf,
+    output_sats: u64,
+) -> Vec<u8> {
+    use bitcoin::hashes::Hash;
+    use bitcoin::psbt::Psbt;
+    use bitcoin::{Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness};
+
+    let unsigned_tx = Transaction {
+        version: bitcoin::transaction::Version(2),
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: Txid::from_raw_hash(bitcoin::hashes::sha256d::Hash::from_byte_array(
+                    [0u8; 32],
+                )),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(output_sats),
+            script_pubkey: output_spk,
+        }],
+    };
+    let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).expect("from_unsigned_tx");
+    psbt.inputs[0].witness_utxo = Some(TxOut {
+        value: Amount::from_sat(input_sats),
+        script_pubkey: input_spk,
+    });
+    psbt.serialize()
+}
+
+/// A deterministic P2WPKH script_pubkey — a bridge-controlled plain
+/// output/input script for the plain-BTC tests.
+#[allow(dead_code)]
+fn btc_test_script(seed: u8) -> bitcoin::ScriptBuf {
+    use bitcoin::hashes::Hash;
+    bitcoin::ScriptBuf::new_p2wpkh(&bitcoin::WPubkeyHash::from_byte_array([seed; 20]))
 }
 
 /// Build a minimal 2-of-3 multisig PSBT for testing with a known pubkey.
@@ -368,7 +433,7 @@ fn test_sign_evm_rejects_unconfigured_bridge_config() {
         chain_id: 0,
         bridge_contract: [0u8; 20],
         rgb_asset_id: String::new(),
-        gas_tx_allowed_to: None,
+        ..Default::default()
     };
     let port = common::start_test_server_with_config(|_| {}, unconfigured);
 
@@ -582,9 +647,13 @@ fn test_sign_psbt_rejects_amount_mismatch() {
 }
 
 // =============================================================================
-// Vanilla PSBT signing tests (create_utxo — no EVM cross-checks)
+// M-01/#69: bridge SignPsbt no longer has a vanilla bypass
 // =============================================================================
 
+// In a production (rgb-validation) build, a SignPsbt with no consignment is
+// rejected fail-closed — the empty-`evm_tx_hash` "vanilla mode" that used to
+// skip every bridge predicate is gone. This is the core M-01 regression gate.
+#[cfg(feature = "rgb-validation")]
 #[test]
 #[cfg(not(feature = "dev-mode"))]
 fn test_sign_psbt_rejects_missing_evm_source_hash() {
@@ -621,6 +690,211 @@ fn test_sign_psbt_rejects_missing_evm_source_hash() {
             );
         }
         other => panic!("unexpected response: {:?}", other),
+    }
+}
+
+// =============================================================================
+// Plain-BTC signing (SignBtc): structural input guard + pinned allowlist + cap
+// =============================================================================
+
+fn init_server(port: u16) {
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+            mnemonic: String::new(),
+        })),
+    };
+    common::send_request(port, &init_req);
+}
+
+#[test]
+fn test_sign_btc_before_init() {
+    let allowed = btc_test_script(0x11);
+    let port = common::start_test_server_with_config(
+        |_| {},
+        btc_pinned_config(allowed.as_bytes().to_vec(), 100_000),
+    );
+
+    // Valid policy (non-P2WSH input, under cap, allowlisted output) so the only
+    // reason to fail is the uninitialized key.
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignBtc(SignBtcRequest {
+            psbt_bytes: btc_psbt(btc_test_script(0x11), 60_000, allowed, 50_000),
+        })),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    assert!(
+        matches!(&resp.response, Some(Response::Error(_))),
+        "SignBtc before init should return error"
+    );
+}
+
+// The structural M-01 guard for the plain-BTC path — the enclave refuses to
+// co-sign a Colored (RGB-allocated) input under SignBtc's vanilla-only signing
+// scope — is exercised at the unit level in
+// `signing::taproot::tests::scoped_vanilla_refuses_a_colored_input` (it needs a
+// known seed + a colored-account tapscript, which the integration harness's
+// random init key can't construct). The integration tests below cover the
+// operator-pinned destination/amount policy layer.
+
+#[test]
+fn test_sign_btc_rejects_non_allowlisted_output() {
+    let allowed = btc_test_script(0x11);
+    let port = common::start_test_server_with_config(
+        |_| {},
+        btc_pinned_config(allowed.as_bytes().to_vec(), 100_000),
+    );
+    init_server(port);
+
+    // Input is fine, but pays an address the operator did NOT pin.
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignBtc(SignBtcRequest {
+            psbt_bytes: btc_psbt(btc_test_script(0x11), 60_000, btc_test_script(0x99), 10_000),
+        })),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    match &resp.response {
+        Some(Response::Error(e)) => {
+            assert_eq!(e.code, 3);
+            assert!(
+                e.message.contains("non-allowlisted"),
+                "expected allowlist rejection, got: {}",
+                e.message
+            );
+        }
+        other => panic!("expected ErrorResponse, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_sign_btc_rejects_input_value_over_cap() {
+    let allowed = btc_test_script(0x11);
+    let port = common::start_test_server_with_config(
+        |_| {},
+        btc_pinned_config(allowed.as_bytes().to_vec(), 100_000),
+    );
+    init_server(port);
+
+    // Allowlisted destination, but the input value spent exceeds the cap.
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignBtc(SignBtcRequest {
+            psbt_bytes: btc_psbt(btc_test_script(0x11), 200_000, allowed, 50_000),
+        })),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    match &resp.response {
+        Some(Response::Error(e)) => {
+            assert_eq!(e.code, 3);
+            assert!(
+                e.message.contains("exceeds pinned cap"),
+                "expected cap rejection, got: {}",
+                e.message
+            );
+        }
+        other => panic!("expected ErrorResponse, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_sign_btc_accepts_allowlisted_under_cap() {
+    let allowed = btc_test_script(0x11);
+    let port = common::start_test_server_with_config(
+        |_| {},
+        btc_pinned_config(allowed.as_bytes().to_vec(), 100_000),
+    );
+    init_server(port);
+
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignBtc(SignBtcRequest {
+            psbt_bytes: btc_psbt(btc_test_script(0x11), 60_000, allowed, 50_000),
+        })),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    // Passes policy; the test seed matches no input. With the inputs_signed==0
+    // guard this returns a (non-cross-check) Signing error rather than a code-3
+    // policy rejection — assert only that policy did not reject it.
+    match &resp.response {
+        Some(Response::SignedPsbt(_)) => {}
+        Some(Response::Error(e)) => assert_ne!(
+            e.code, 3,
+            "allowlisted output under cap should pass policy, got: {}",
+            e.message
+        ),
+        other => panic!("unexpected response: {:?}", other),
+    }
+}
+
+// A production (rgb-validation) build refuses plain-BTC signing when the
+// allowlist/cap are unconfigured — fail-closed, mirroring the EVM path.
+#[cfg(feature = "rgb-validation")]
+#[test]
+fn test_sign_btc_unconfigured_fails_closed_under_rgb_validation() {
+    // Unconfigured BridgeConfig (no BTC_ALLOWED_SCRIPTS / BTC_MAX_TOTAL_SATS).
+    let port = common::start_test_server_with_config(|_| {}, BridgeConfig::default());
+    init_server(port);
+
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignBtc(SignBtcRequest {
+            // Non-P2WSH input (passes the structural guard) so the failure is
+            // specifically the unconfigured-policy fail-closed.
+            psbt_bytes: btc_psbt(btc_test_script(0x11), 10_000, btc_test_script(0x11), 9_000),
+        })),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    match &resp.response {
+        Some(Response::Error(e)) => {
+            assert_eq!(e.code, 3);
+            assert!(
+                e.message.contains("requires BTC_ALLOWED_SCRIPTS"),
+                "expected fail-closed-unconfigured rejection, got: {}",
+                e.message
+            );
+        }
+        other => panic!(
+            "unconfigured plain-BTC signing must fail closed under rgb-validation, got: {:?}",
+            other
+        ),
+    }
+}
+
+// A production build also refuses plain-BTC signing under a HALF-pin (allowlist
+// set but cap unset, or vice-versa) — the half-pin is treated as unconfigured.
+#[cfg(feature = "rgb-validation")]
+#[test]
+fn test_sign_btc_half_pin_fails_closed_under_rgb_validation() {
+    let allowed = btc_test_script(0x11);
+    // allowlist set, cap == 0 (unset) → half-pin → unconfigured
+    let port = common::start_test_server_with_config(
+        |_| {},
+        btc_pinned_config(allowed.as_bytes().to_vec(), 0),
+    );
+    init_server(port);
+
+    let sign_req = EnclaveRequest {
+        request: Some(Request::SignBtc(SignBtcRequest {
+            psbt_bytes: btc_psbt(btc_test_script(0x11), 10_000, allowed, 9_000),
+        })),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    match &resp.response {
+        Some(Response::Error(e)) => {
+            assert_eq!(e.code, 3);
+            assert!(
+                e.message.contains("requires BTC_ALLOWED_SCRIPTS"),
+                "expected half-pin fail-closed rejection, got: {}",
+                e.message
+            );
+        }
+        other => panic!(
+            "half-pin plain-BTC signing must fail closed under rgb-validation, got: {:?}",
+            other
+        ),
     }
 }
 
@@ -958,6 +1232,188 @@ fn test_proxy_federation_returns_not_ready() {
                 "federation proxy should return NOT_READY (code 2)"
             );
             assert!(e.message.contains("federation proxy"));
+        }
+        other => panic!("expected ErrorResponse, got {:?}", other),
+    }
+}
+
+// =============================================================================
+// EVM gas-tx (SignRawDigest) shape-allowlist tests (audit TEE-XC-09)
+// =============================================================================
+//
+// These run through the real handler, so the production fail-closed gate in
+// `validation::evm_gas_tx` is active (the integration crate builds the lib
+// without cfg(test)). They cover the accept path and the two drain vectors.
+
+/// Minimal RLP encoder for building gas-tx fixtures.
+fn rlp_str(bytes: &[u8]) -> Vec<u8> {
+    if bytes.len() == 1 && bytes[0] < 0x80 {
+        return vec![bytes[0]];
+    }
+    let mut out = Vec::new();
+    if bytes.len() <= 55 {
+        out.push(0x80 + bytes.len() as u8);
+    } else {
+        let lb: Vec<u8> = bytes
+            .len()
+            .to_be_bytes()
+            .iter()
+            .copied()
+            .skip_while(|&b| b == 0)
+            .collect();
+        out.push(0xb7 + lb.len() as u8);
+        out.extend_from_slice(&lb);
+    }
+    out.extend_from_slice(bytes);
+    out
+}
+
+fn rlp_scalar(v: u64) -> Vec<u8> {
+    let trimmed: Vec<u8> = v
+        .to_be_bytes()
+        .iter()
+        .copied()
+        .skip_while(|&b| b == 0)
+        .collect();
+    rlp_str(&trimmed)
+}
+
+fn rlp_list(items: &[Vec<u8>]) -> Vec<u8> {
+    let mut payload = Vec::new();
+    for it in items {
+        payload.extend_from_slice(it);
+    }
+    let mut out = Vec::new();
+    if payload.len() <= 55 {
+        out.push(0xc0 + payload.len() as u8);
+    } else {
+        let lb: Vec<u8> = payload
+            .len()
+            .to_be_bytes()
+            .iter()
+            .copied()
+            .skip_while(|&b| b == 0)
+            .collect();
+        out.push(0xf7 + lb.len() as u8);
+        out.extend_from_slice(&lb);
+    }
+    out.extend_from_slice(&payload);
+    out
+}
+
+/// Unsigned EIP-1559 preimage: `0x02 || rlp([chainId, nonce, maxPrio, maxFee, gas, to, value, data, accessList])`.
+fn eip1559_unsigned(chain_id: u64, to: &[u8; 20], value: u64) -> Vec<u8> {
+    let body = rlp_list(&[
+        rlp_scalar(chain_id),
+        rlp_scalar(7),
+        rlp_scalar(1),
+        rlp_scalar(100),
+        rlp_scalar(21_000),
+        rlp_str(to),
+        rlp_scalar(value),
+        rlp_str(&[]),
+        rlp_list(&[]),
+    ]);
+    let mut out = vec![0x02];
+    out.extend_from_slice(&body);
+    out
+}
+
+/// `BridgeConfig` with the gas-tx destination pinned (chain_id 1, to 0xAA…).
+fn gas_pinned_config() -> BridgeConfig {
+    BridgeConfig {
+        chain_id: 1,
+        bridge_contract: [0xBB; 20],
+        rgb_asset_id: "rgb:test".into(),
+        gas_tx_allowed_to: Some([0xAA; 20]),
+        ..Default::default()
+    }
+}
+
+fn init(port: u16) {
+    common::send_request(
+        port,
+        &EnclaveRequest {
+            request: Some(Request::InitializeKey(InitializeKeyRequest {
+                seed: vec![],
+                mnemonic: String::new(),
+            })),
+        },
+    );
+}
+
+#[test]
+fn test_gas_tx_signs_pinned_destination() {
+    let port = common::start_test_server_with_config(|_| {}, gas_pinned_config());
+    init(port);
+
+    let tx = eip1559_unsigned(1, &[0xAA; 20], 0);
+    let resp = common::send_request(
+        port,
+        &EnclaveRequest {
+            request: Some(Request::SignRawDigest(SignRawDigestRequest {
+                digest: vec![],
+                unsigned_tx: tx,
+            })),
+        },
+    );
+
+    match &resp.response {
+        Some(Response::RawDigestSig(r)) => assert_eq!(r.signature.len(), 65),
+        other => panic!("expected RawDigestSignatureResponse, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_gas_tx_rejects_opaque_digest() {
+    let port = common::start_test_server_with_config(|_| {}, gas_pinned_config());
+    init(port);
+
+    // Legacy opaque-digest request (no preimage) must be refused.
+    let resp = common::send_request(
+        port,
+        &EnclaveRequest {
+            request: Some(Request::SignRawDigest(SignRawDigestRequest {
+                digest: vec![0x11; 32],
+                unsigned_tx: vec![],
+            })),
+        },
+    );
+
+    match &resp.response {
+        Some(Response::Error(e)) => {
+            assert_eq!(e.code, 3);
+            assert!(
+                e.message.contains("unsigned transaction preimage"),
+                "got: {}",
+                e.message
+            );
+        }
+        other => panic!("expected ErrorResponse, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_gas_tx_rejects_drain_to_attacker() {
+    let port = common::start_test_server_with_config(|_| {}, gas_pinned_config());
+    init(port);
+
+    // Well-formed tx, but to an attacker address — the drain #68 closes.
+    let tx = eip1559_unsigned(1, &[0xEE; 20], 0);
+    let resp = common::send_request(
+        port,
+        &EnclaveRequest {
+            request: Some(Request::SignRawDigest(SignRawDigestRequest {
+                digest: vec![],
+                unsigned_tx: tx,
+            })),
+        },
+    );
+
+    match &resp.response {
+        Some(Response::Error(e)) => {
+            assert_eq!(e.code, 3);
+            assert!(e.message.contains("destination"), "got: {}", e.message);
         }
         other => panic!("expected ErrorResponse, got {:?}", other),
     }

--- a/parent/Cargo.toml
+++ b/parent/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/bin/attest_verify.rs"
 prost = "0.14"
 tonic = "0.14"
 tokio = { version = "1", features = ["full"] }
-federated-signer-proto = { git = "ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git", rev = "f61dcb76595c69af914107a74852ad013afed9df", package = "federated-signer-proto" }
+federated-signer-proto = { git = "ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git", rev = "aafbbdd243c96354d1ee1147eee4b8be7d861416", package = "federated-signer-proto" }
 
 clap = { version = "4", features = ["derive"] }
 

--- a/parent/src/grpc_server.rs
+++ b/parent/src/grpc_server.rs
@@ -215,6 +215,11 @@ impl ParentAdapterService {
                     },
                 )
             }
+            // Plain BTC is not a cross-network destination — it is dispatched
+            // via `data_type=BTC_UTXO` to the SignBtc path, never here.
+            sign_request::Data::BtcData(_) => unreachable!(
+                "BtcData is handled by the BTC_UTXO dispatch, not enclave_destination_network"
+            ),
         }
     }
 
@@ -246,7 +251,12 @@ impl ParentAdapterService {
 #[tonic::async_trait]
 impl ParentService for ParentAdapterService {
     /// Sign converts the structured ParentService request into the enclave
-    /// wire `SignRequest`
+    /// wire `SignRequest`.
+    ///
+    /// Dispatches on `data_type`:
+    ///   TRANSACTION → source/destination cross-network Sign (bridge / RGB-send / EVM)
+    ///   EVM_GAS_TX  → unsigned gas-tx preimage → SignRawDigest
+    ///   BTC_UTXO    → plain-BTC PSBT → SignBtc (vanilla BIP-86 path, audit #69/M-01)
     async fn sign(
         &self,
         request: Request<grpc_proto::SignRequest>,
@@ -297,6 +307,12 @@ impl ParentService for ParentAdapterService {
                         );
 
                         Self::enclave_destination_network(sign_request::Data::RgbData(payload))
+                    }
+                    Some(sign_request::Data::BtcData(_)) => {
+                        return Err(Status::invalid_argument(
+                            "TRANSACTION data_type must not carry BtcData; \
+                             use data_type=BTC_UTXO for plain-BTC signing",
+                        ))
                     }
                     None => return Err(Status::invalid_argument("SignRequest.data is missing")),
                 };
@@ -397,6 +413,54 @@ impl ParentService for ParentAdapterService {
                     }
                     other => Err(Status::internal(format!(
                         "unexpected enclave response for SignRawDigest: {:?}",
+                        other
+                    ))),
+                }
+            }
+            DataType::BtcUtxo => {
+                // Plain-BTC signing (audit #69/M-01): a distinct request that
+                // never carries a source proof or consignment. The Listener
+                // sends the PSBT in `EnrichedBtcPayload.psbt_bytes`; the enclave
+                // signs it with the vanilla BIP-86 account under a strict output
+                // allowlist + input-value cap.
+                let payload = match inner.data {
+                    Some(sign_request::Data::BtcData(payload)) => payload,
+                    _ => {
+                        return Err(Status::invalid_argument(
+                            "BTC_UTXO sign requires BtcData with the PSBT in psbt_bytes",
+                        ))
+                    }
+                };
+
+                tracing::info!(
+                    dst_network_id = signer_network_id,
+                    psbt_len = payload.psbt_bytes.len(),
+                    "gRPC Sign: plain BTC (data_type=BTC_UTXO)"
+                );
+
+                let enclave_req = EnclaveRequest {
+                    request: Some(enclave_request::Request::SignBtc(
+                        enclave_proto::SignBtcRequest {
+                            psbt_bytes: payload.psbt_bytes,
+                        },
+                    )),
+                };
+
+                let resp = self.send_to_enclave(enclave_req).await?;
+                match resp.response {
+                    Some(enclave_response::Response::SignedPsbt(r)) => {
+                        Ok(Response::new(SignatureResponse {
+                            signer_network_id,
+                            signature: r.signed_psbt,
+                            identifier: None,
+                            call_data: Vec::new(),
+                        }))
+                    }
+                    Some(enclave_response::Response::Error(e)) => {
+                        Err(Self::enclave_error_to_status(&e))
+                    }
+                    other => Err(Status::internal(format!(
+                        "unexpected enclave response for SignBtc: {:?}",
                         other
                     ))),
                 }

--- a/parent/tests/test_grpc_bridge.rs
+++ b/parent/tests/test_grpc_bridge.rs
@@ -94,6 +94,14 @@ fn start_mock_enclave() -> u16 {
                         },
                     }
                 }
+                Some(enclave_request::Request::SignBtc(_)) => EnclaveResponse {
+                    response: Some(enclave_response::Response::SignedPsbt(
+                        enclave_proto::SignedPsbtResponse {
+                            signed_psbt: vec![0xBC; 80],
+                            inputs_signed: 1,
+                        },
+                    )),
+                },
                 Some(enclave_request::Request::InitializeKey(_)) => EnclaveResponse {
                     response: Some(enclave_response::Response::InitializeKey(
                         enclave_proto::InitializeKeyResponse {
@@ -463,6 +471,56 @@ async fn grpc_sign_psbt_roundtrip() {
         !resp.signature.is_empty(),
         "signed PSBT should not be empty"
     );
+}
+
+#[tokio::test]
+async fn grpc_sign_btc_roundtrip() {
+    // BTC_UTXO routes the EnrichedBtcPayload to a SignBtcRequest and returns a
+    // signed PSBT — the plain-BTC path is distinct from TRANSACTION/SignPsbt.
+    let enclave_port = start_mock_enclave();
+    let grpc_port = start_grpc_server(enclave_port).await;
+
+    let mut client = ParentServiceClient::connect(format!("http://127.0.0.1:{grpc_port}"))
+        .await
+        .unwrap();
+
+    let payload = enriched::EnrichedBtcPayload {
+        psbt_bytes: vec![0x70, 0x73, 0x62, 0x74, 0xFF],
+    };
+
+    let req = SignRequest {
+        common: Some(common(0, 0, DataType::BtcUtxo)),
+        source: None,
+        data: Some(sign_request::Data::BtcData(payload)),
+    };
+
+    let resp = client.sign(req).await.unwrap().into_inner();
+    assert_eq!(
+        resp.signature,
+        vec![0xBC; 80],
+        "BTC_UTXO should route to SignBtc and return its signed PSBT"
+    );
+}
+
+#[tokio::test]
+async fn grpc_btc_utxo_rejects_missing_payload() {
+    // BTC_UTXO with no BtcData in the oneof must be rejected at the boundary,
+    // not forwarded to the enclave.
+    let enclave_port = start_mock_enclave();
+    let grpc_port = start_grpc_server(enclave_port).await;
+
+    let mut client = ParentServiceClient::connect(format!("http://127.0.0.1:{grpc_port}"))
+        .await
+        .unwrap();
+
+    let req = SignRequest {
+        common: Some(common(0, 0, DataType::BtcUtxo)),
+        source: None,
+        data: None,
+    };
+
+    let status = client.sign(req).await.unwrap_err();
+    assert_eq!(status.code(), tonic::Code::InvalidArgument);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What & why

Closes the `SignPsbt` **vanilla-mode bypass**: the signing flow no longer infers its mode from an empty `evm_tx_hash`.

- The vanilla-mode early-return in `validate_psbt_request` is removed. The consignment binding now runs **unconditionally** under `rgb-validation`, so an RGB-send is authorized by a validated consignment (decoupled from `evm_tx_hash`). A `SignPsbt` that carries no consignment now **fails closed** instead of co-signing any bridge-owned input.
- Plain-BTC operations (`create_utxo`, plain withdrawals) move to a distinct, explicit request type: `DataType::BTC_UTXO` → `EnrichedBtcPayload` → `SignBtcRequest` → `handle_sign_btc`. They are authorized against an operator-pinned output allowlist (`BTC_ALLOWED_SCRIPTS`) and a total-input-value cap (`BTC_MAX_TOTAL_SATS`), fail-closed when unconfigured under `rgb-validation`.
- Plain-BTC signing is scoped to the **vanilla** BIP-86 account, so it can never co-sign a colored (RGB-allocated) input — those move only via the consignment-bound path.

## Audit finding addressed

This implements the remediation for a finding in the final external security audit report (dated 2026-06-22):

> **"`SignPsbt` vanilla mode bypasses EVM-to-RGB authorization when `evm_tx_hash` is empty"** — *MAJOR*
>
> "an empty `evm_tx_hash` switches `SignPsbt` into vanilla mode … it skips every bridge authorization predicate … a compromised listener can intentionally omit `evm_tx_hash` and ask the enclave to sign a PSBT outside the EVM-to-RGB authorization path."
>
> "It escalates to CRITICAL if `SignPsbt` is reachable in production for bridge-controlled UTXOs without a tightly controlled operational `create_utxo` flow."

The report also lists this as a manifestation of its lead **CRITICAL** finding, *"the enclave infers security mode from empty fields and feature flags."* This PR implements that finding's PSBT-path recommendation (distinct request type + enclave-checked output allowlist + amount cap + fail-closed); the systemic attested `SigningPolicy` startup gate is tracked as a separate follow-up.

## Key changes

- `validation/psbt_crosscheck.rs` — drop the vanilla early-return; EVM fields become optional enrichment checks.
- `server.rs` — `psbt_consignment_crosscheck` runs unconditionally under `rgb-validation`; new `handle_sign_btc` + dispatch arm.
- `validation/btc_crosscheck.rs` (new) — plain-BTC output allowlist + value-spent cap, fail-closed when unconfigured.
- `keys.rs` / `state.rs` — `sign_psbt_scoped(.., Some(Vanilla))` for the plain-BTC path.
- `config.rs` — `btc_allowed_scripts` / `btc_max_total_sats` pins.
- proto (`signer.proto`, `enriched-payload.proto`, `enclave.proto`) + `parent/grpc_server.rs` — `BTC_UTXO` / `EnrichedBtcPayload` / `SignBtcRequest` wiring.

## Compatibility & follow-ups

- **Coordinated listener migration required.** The listener must send a consignment for RGB-send/mint and use `BTC_UTXO` for plain-BTC ops. An un-migrated listener fails closed by design (it is rejected, never silently signed).
- Mint (`TS_INFLATION`) via `SignPsbt` fail-closed-rejects (not a `Transfer`) — left to the mint/burn epic.
- The systemic attested `SigningPolicy` / startup-config gate (lead CRITICAL finding) is a separate follow-up.

## Verification

`cargo fmt --check`, `clippy -D warnings` (default + `spv`), `test` (default + `spv`), and the release production build (`vsock,rgb-validation,spv`) all pass. New regression coverage includes: `SignPsbt` requires a consignment under `rgb-validation`; the plain-BTC allowlist / cap / empty-output / unconfigured / half-pin fail-closed paths; and `sign_psbt_scoped` refusing a colored input on the vanilla-scoped path.

Closes #69.
