### PR TITLE
per-field semantic size caps and discarded validate() status 

### DIFF
--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -433,6 +433,15 @@ fn handle_sign_evm(ctx: &ServerContext, req: SignEvmRequest) -> Result<EnclaveRe
                 &req.rgb_asset_id,
                 &ctx.bridge_config.rgb_asset_id,
             )?;
+            // Defense-in-depth recency check (audit 4th I-03 / #95). The
+            // RGB->EVM fundsOut direction settles an already-confirmed
+            // transfer, so every witness tx must be mined. rgbstd's
+            // validation status (otherwise discarded) is surfaced as
+            // `non_mined_witness_txids`; reject here so confirmation does
+            // not rest on the SPV header chain alone. Skipped under dev-mode
+            // alongside the other cross-checks.
+            #[cfg(not(feature = "dev-mode"))]
+            crate::validation::evm_crosscheck::assert_witnesses_confirmed(&v)?;
             Some(v)
         } else {
             tracing::warn!("RGB validator not configured, skipping in-enclave validation");

--- a/enclave/src/validation/evm_crosscheck.rs
+++ b/enclave/src/validation/evm_crosscheck.rs
@@ -36,6 +36,15 @@ pub const FUNDS_OUT_SELECTOR_POOLS: [u8; 4] = [0xcc, 0xdd, 0xb7, 0x68];
 /// yet; it lands in the mint/burn epic, dispatched by contract address.
 const FUNDS_OUT_SELECTORS: &[[u8; 4]] = &[FUNDS_OUT_SELECTOR_POOLS];
 
+/// Upper bound on `fundsOut` calldata length. The fixed ABI head is
+/// 4 + 9*32 = 292 bytes; the dynamic tails (srcAddr, proof, settlementData)
+/// add at most a few hundred bytes for the live transfer flow. 64 KiB is far
+/// above any legitimate fundsOut encoding yet rejects a multi-megabyte
+/// calldata (bounded only by the 4 MB framing limit today) before any
+/// byte-level extraction or signing work runs (audit I-06 / #90). Compile-time
+/// so the posture is PCR-attested, not host-tunable.
+pub const MAX_FUNDS_OUT_CALL_DATA_LEN: usize = 64 * 1024;
+
 /// Byte offset of `amount` in the `fundsOut` calldata. After the 4-byte
 /// selector and the 32-byte `recipient` head slot, `amount` (uint256)
 /// sits at byte 36..68. Shared by the transfer and (future) burn paths
@@ -68,6 +77,16 @@ pub fn validate_evm_request(req: &SignEvmRequest, bridge_config: &BridgeConfig) 
         return Err(EnclaveError::CrossCheck(format!(
             "call_data too short: need at least 4 bytes for selector, got {}",
             req.call_data.len()
+        )));
+    }
+    // Semantic upper bound on calldata, well below the generic 4 MB frame, so
+    // a maximally packed request is rejected before any offset extraction or
+    // signing (audit I-06 / #90).
+    if req.call_data.len() > MAX_FUNDS_OUT_CALL_DATA_LEN {
+        return Err(EnclaveError::CrossCheck(format!(
+            "call_data too large: {} bytes (max {})",
+            req.call_data.len(),
+            MAX_FUNDS_OUT_CALL_DATA_LEN
         )));
     }
     let selector: [u8; 4] = req.call_data[..4]
@@ -282,6 +301,37 @@ pub fn bind_asset_identity(
         return Err(EnclaveError::CrossCheck(format!(
             "contract_id mismatch: consignment has {} but request declares {}",
             validated_contract_id, declared_rgb_asset_id
+        )));
+    }
+    Ok(())
+}
+
+/// Defense-in-depth recency check for the RGB->EVM `fundsOut` direction
+/// (audit 4th I-03 / #95).
+///
+/// In this direction the consignment describes a transfer that is already
+/// settled on Bitcoin, so every witness transaction anchoring it must be
+/// mined. rgbstd's `validate()` already hard-rejects `Archived`/unresolvable
+/// witnesses, but accepts `Tentative`/`Ignored` ones (legitimate for the
+/// unbroadcast send-RGB PSBT flow, never for a confirmed unlock). The SPV
+/// stage independently checks inclusion + depth; this check refuses to sign
+/// if rgbstd itself classified any witness as not-mined, so confirmation is
+/// not load-bearing on the in-enclave header chain alone.
+///
+/// `validated.non_mined_witness_txids` is in display byte order.
+#[cfg(feature = "rgb-validation")]
+pub fn assert_witnesses_confirmed(validated: &ValidatedConsignment) -> Result<()> {
+    if !validated.non_mined_witness_txids.is_empty() {
+        let list: Vec<String> = validated
+            .non_mined_witness_txids
+            .iter()
+            .map(hex::encode)
+            .collect();
+        return Err(EnclaveError::CrossCheck(format!(
+            "fundsOut requires every consignment witness tx to be mined, but rgbstd classified \
+             {} witness(es) as not-yet-confirmed (tentative/ignored): {} - refusing to sign",
+            list.len(),
+            list.join(", ")
         )));
     }
     Ok(())
@@ -683,6 +733,39 @@ mod tests {
         );
     }
 
+    #[test]
+    fn rejects_calldata_over_size_cap() {
+        // A maximally packed calldata must be rejected up-front (audit I-06 /
+        // #90), before selector dispatch or any offset extraction. Start from
+        // a valid fundsOut request and pad the tail past the cap.
+        let mut req = valid_evm_request();
+        req.call_data
+            .resize(super::MAX_FUNDS_OUT_CALL_DATA_LEN + 1, 0u8);
+        let err = validate_evm_request(&req, &unconfigured()).unwrap_err();
+        assert!(
+            err.to_string().contains("call_data too large"),
+            "expected too-large rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn accepts_calldata_at_size_cap() {
+        // Exactly at the cap is allowed; the selector head is preserved so
+        // dispatch still recognizes the fundsOut shape.
+        let mut req = valid_evm_request();
+        req.call_data
+            .resize(super::MAX_FUNDS_OUT_CALL_DATA_LEN, 0u8);
+        req.call_data[..4].copy_from_slice(&FUNDS_OUT_SELECTOR_POOLS);
+        // Under default (no rgb-validation) the call still fails later for
+        // requiring rgb-validation; assert only that it is NOT the size error.
+        if let Err(e) = validate_evm_request(&req, &unconfigured()) {
+            assert!(
+                !e.to_string().contains("call_data too large"),
+                "calldata exactly at the cap must not trip the size check, got: {e}"
+            );
+        }
+    }
+
     // =========================================================================
     // Mint/burn fundsOut tests — `validate_funds_out_burn`
     // =========================================================================
@@ -723,6 +806,7 @@ mod tests {
                 last_transition: Some(transition),
                 last_transfer_witness_txid: None,
                 last_transfer_witness_prevouts: None,
+                non_mined_witness_txids: vec![],
             }
         }
 
@@ -815,6 +899,7 @@ mod tests {
                 last_transition: None,
                 last_transfer_witness_txid: None,
                 last_transfer_witness_prevouts: None,
+                non_mined_witness_txids: vec![],
             };
             let err = validate_funds_out_burn(&req, &validated).unwrap_err();
             assert!(
@@ -855,6 +940,7 @@ mod tests {
                 last_transition: Some(transition),
                 last_transfer_witness_txid: None,
                 last_transfer_witness_prevouts: None,
+                non_mined_witness_txids: vec![],
             }
         }
 
@@ -912,6 +998,27 @@ mod tests {
         }
 
         #[test]
+        fn witnesses_confirmed_passes_when_all_mined() {
+            // No non-mined witnesses surfaced -> the recency guard is a no-op
+            // (audit 4th I-03 / #95).
+            let validated = validated_with_last(transfer_transition(1000));
+            assert!(super::super::assert_witnesses_confirmed(&validated).is_ok());
+        }
+
+        #[test]
+        fn witnesses_confirmed_rejects_non_mined() {
+            // A tentative/ignored witness in the RGB->EVM direction is an
+            // anomaly: the unlock settles an already-confirmed transfer.
+            let mut validated = validated_with_last(transfer_transition(1000));
+            validated.non_mined_witness_txids = vec![[0xABu8; 32]];
+            let err = super::super::assert_witnesses_confirmed(&validated).unwrap_err();
+            assert!(
+                err.to_string().contains("mined"),
+                "expected not-mined rejection, got: {err}"
+            );
+        }
+
+        #[test]
         fn passes_when_total_output_exceeds_calldata_amount() {
             let req = req_with_calldata(mock_pools_calldata(1000));
             let validated = validated_with_last(transfer_transition(2000));
@@ -960,6 +1067,7 @@ mod tests {
                 last_transition: None,
                 last_transfer_witness_txid: None,
                 last_transfer_witness_prevouts: None,
+                non_mined_witness_txids: vec![],
             };
             let err = validate_funds_out_transfer(&req, &validated).unwrap_err();
             assert!(

--- a/enclave/src/validation/psbt_crosscheck.rs
+++ b/enclave/src/validation/psbt_crosscheck.rs
@@ -572,6 +572,7 @@ mod tests {
                 last_transition: Some(transfer_summary(total_output_amount)),
                 last_transfer_witness_txid: Some(psbt.unsigned_tx.compute_txid()),
                 last_transfer_witness_prevouts: Some(prevouts),
+                non_mined_witness_txids: vec![],
             }
         }
 

--- a/enclave/src/validation/rgb.rs
+++ b/enclave/src/validation/rgb.rs
@@ -16,6 +16,7 @@ use rgbstd::indexers::esplora_blocking::esplora_client;
 use rgbstd::indexers::AnyResolver;
 use rgbstd::schema::{MetaType, TransitionType};
 use rgbstd::validation::ValidationConfig;
+use rgbstd::vm::WitnessOrd;
 use rgbstd::ChainNet;
 
 use crate::error::{EnclaveError, Result};
@@ -144,6 +145,22 @@ pub struct ValidatedConsignment {
     /// consignment carries only the witness txid (`PubWitness::Txid`), in
     /// which case the txid identity bind alone anchors every input.
     pub last_transfer_witness_prevouts: Option<Vec<bitcoin::OutPoint>>,
+    /// Witness txids that rgbstd `validate()` classified as **not mined**
+    /// (`WitnessOrd::Tentative` / `Ignored`), in **display (big-endian) byte
+    /// order** - same encoding as [`Self::witness_txids`]. `validate()` already
+    /// hard-rejects `Archived`/unresolvable witnesses, so only these softer
+    /// not-yet-confirmed states reach here, and only because this set is built
+    /// from the rgbstd status that was previously discarded (audit 4th
+    /// I-03 / #95).
+    ///
+    /// A non-empty set is **expected** for the send-RGB (EVM-lock -> RGB-send)
+    /// PSBT path: that witness tx is freshly composed and unbroadcast, so it is
+    /// legitimately `Tentative`. It is an **anomaly** for the RGB->EVM
+    /// `fundsOut` direction, where the witness is already confirmed on-chain
+    /// and SPV-verified - the SignEvm path rejects any non-mined witness as
+    /// defense-in-depth atop the SPV depth check (see
+    /// [`crate::validation::evm_crosscheck::assert_witnesses_confirmed`]).
+    pub non_mined_witness_txids: Vec<[u8; 32]>,
 }
 
 /// Flat summary of one RGB state transition. Mirrors
@@ -363,7 +380,7 @@ impl RgbValidator {
 
         // 4. Run full RGB validation (makes blocking HTTP calls to Esplora).
         tracing::debug!(%contract_id, "calling rgbstd validate (this may block on Esplora)");
-        let _valid = transfer.validate(&resolver, &config).map_err(|e| {
+        let valid = transfer.validate(&resolver, &config).map_err(|e| {
             tracing::warn!(
                 %contract_id,
                 elapsed_ms = start.elapsed().as_millis() as u64,
@@ -372,10 +389,54 @@ impl RgbValidator {
             EnclaveError::CrossCheck(format!("RGB consignment validation failed: {e}"))
         })?;
 
+        // 4b. Inspect the validation status instead of discarding it (audit 4th
+        // I-03 / #95). A hard failure already came back as Err above; what
+        // reaches here is `Ok` with a status that may still carry warnings and
+        // a per-witness ordinal map. Without `safe_height` set, rgbstd's
+        // `validity()` is `Valid` even when witnesses are not mined, so the
+        // only signal of a not-yet-confirmed witness is `tx_ord_map` - we read
+        // it out rather than trust `validity()` alone.
+        //
+        // We deliberately do NOT set `ValidationConfig.safe_height`: doing so
+        // would flag recency against the *Esplora resolver's* tip, which is
+        // host-controlled and untrusted. Recency for the RGB->EVM direction is
+        // enforced authoritatively by the in-enclave SPV header chain
+        // (`SPV_MIN_CONFIRMATIONS`); surfacing the witness ordinals here lets
+        // that direction reject non-mined witnesses as defense-in-depth.
+        let status = valid.validation_status();
+        let mut non_mined: BTreeSet<[u8; 32]> = BTreeSet::new();
+        for (txid, ord) in status.tx_ord_map.iter() {
+            if !matches!(ord, WitnessOrd::Mined(_)) {
+                // `txid` is `bitcoin::Txid`; its Display is display-order hex,
+                // matching the `witness_txids` encoding decoded above.
+                let display_hex = txid.to_string();
+                let bytes = hex::decode(&display_hex).map_err(|e| {
+                    EnclaveError::CrossCheck(format!(
+                        "witness ordinal txid hex decode failed: {e} (got {display_hex:?})"
+                    ))
+                })?;
+                let arr: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
+                    EnclaveError::CrossCheck(format!(
+                        "witness ordinal txid is not 32 bytes (got {} bytes from {display_hex:?})",
+                        bytes.len()
+                    ))
+                })?;
+                tracing::warn!(%contract_id, txid = %display_hex, witness_ord = %ord, "consignment witness tx is not mined");
+                non_mined.insert(arr);
+            }
+        }
+        for warning in &status.warnings {
+            tracing::warn!(%contract_id, "RGB validation warning: {warning}");
+        }
+        let non_mined_witness_txids: Vec<[u8; 32]> = non_mined.into_iter().collect();
+
         tracing::info!(
             %contract_id,
             %chain_net,
+            validity = %status.validity(),
             witness_txids_count = witness_txids.len(),
+            non_mined_count = non_mined_witness_txids.len(),
+            warnings = status.warnings.len(),
             transitions_count,
             elapsed_ms = start.elapsed().as_millis() as u64,
             "RGB consignment validated successfully"
@@ -389,6 +450,7 @@ impl RgbValidator {
             last_transition,
             last_transfer_witness_txid,
             last_transfer_witness_prevouts,
+            non_mined_witness_txids,
         })
     }
 }

--- a/enclave/src/validation/spv_crosscheck.rs
+++ b/enclave/src/validation/spv_crosscheck.rs
@@ -60,6 +60,16 @@ pub const SPV_MAX_TIP_AGE_SECS: u64 = 2 * 60 * 60;
 /// `time = far_future` to defeat the staleness check.
 pub const SPV_MAX_TIP_FUTURE_SECS: u64 = 2 * 60 * 60;
 
+/// Maximum number of sibling hashes allowed in a single Merkle path. A path
+/// of depth d authenticates a block of up to 2^d transactions; even a 4 MB
+/// block packed with minimum-size transactions holds well under 2^17, so 32
+/// (over four billion leaves) never false-rejects a real proof while bounding
+/// the per-proof hashing a hostile listener can demand. Rejected up-front in
+/// `validate_spv_proofs`, before any Merkle hashing runs, so a maximally
+/// packed request is cheap to reject (audit I-06 / #90). Compile-time, like
+/// the other SPV limits: PCR-attested posture, not host-tunable.
+pub const MAX_MERKLE_PATH_DEPTH: usize = 32;
+
 /// Verify a complete set of SPV proofs against the chain.
 ///
 /// `expected_txids` is the witness-txid set extracted from the validated
@@ -83,6 +93,16 @@ pub fn validate_spv_proofs(
                 proof.txid.len()
             ))
         })?;
+        // Bound Merkle path depth before any hashing runs. A path longer
+        // than any real block could contain is either a bug or an attempt
+        // to maximize the per-proof verification loop (audit I-06 / #90).
+        if proof.merkle_path.len() > MAX_MERKLE_PATH_DEPTH {
+            return Err(EnclaveError::Spv(format!(
+                "merkle_proofs[{i}].merkle_path too deep: {} siblings (max {})",
+                proof.merkle_path.len(),
+                MAX_MERKLE_PATH_DEPTH
+            )));
+        }
         if !proof_set.insert(txid) {
             return Err(EnclaveError::Spv(format!(
                 "duplicate merkle proof for txid {}",
@@ -672,6 +692,27 @@ mod tests {
         let err = validate_spv_proofs(&chain, &[txid_display], &[bad_proof], SPV_MIN_CONFIRMATIONS)
             .unwrap_err();
         assert!(err.to_string().contains("must be 32 bytes"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_overdeep_merkle_path() {
+        // A path deeper than any real block could produce is rejected before
+        // any Merkle hashing runs (audit I-06 / #90). Siblings are well-formed
+        // 32-byte hashes so the only failing predicate is the depth cap.
+        let target = synth_headers(1).into_iter().next().unwrap();
+        let chain = chain_burying(target, 5);
+        let (txid_display, _proof) = single_tx_proof(chain.header_at(1).unwrap(), 1);
+
+        let bad_proof = MerkleProofEntry {
+            txid: txid_display.to_vec(),
+            block_height: 1,
+            tx_position: 0,
+            merkle_path: vec![vec![0u8; 32]; MAX_MERKLE_PATH_DEPTH + 1],
+        };
+
+        let err = validate_spv_proofs(&chain, &[txid_display], &[bad_proof], SPV_MIN_CONFIRMATIONS)
+            .unwrap_err();
+        assert!(err.to_string().contains("too deep"), "got: {err}");
     }
 
     #[test]


### PR DESCRIPTION
### Batch: #90 (I-06 size caps) + #95 (4th I-03 validate() status)

####  #90 — per-field semantic size caps
  - MAX_MERKLE_PATH_DEPTH = 32 — rejected before any Merkle hashing in validate_spv_proofs. 32 siblings = 2³² leaves, far above any real block (~2¹⁷), so no false
  rejects.
  - MAX_FUNDS_OUT_CALL_DATA_LEN = 64 KiB — rejected in validate_evm_request right after the selector floor, before offset extraction. (fundsInIds lives inside ABI
  call_data, so this covers it.)
  - Both compile-time → PCR-attested, not host-tunable.

#### #95 — stop discarding the rgbstd validation status
  - validate_consignment now binds the status (was _valid) and surfaces non_mined_witness_txids.
  - Note: without safe_height, validity() is always Valid even with non-mined witnesses — the real signal is tx_ord_map. Archived/unresolvable are already
  hard-rejected by rgbstd; only Tentative/Ignored reach Ok.
  - Deliberately not setting safe_height (would judge recency against the untrusted Esplora tip); recency stays with in-enclave SPV depth.
  - Tentative is expected for the send-RGB PSBT path, so the mined-ness rejection (assert_witnesses_confirmed, defense-in-depth atop SPV) lives only in
  handle_sign_evm, not in shared validate_consignment.

  **Verify**: default + --features spv build & clippy clean; tests 170 / 247, 0 fail; 5 new tests.
  
  **Deferred**: end-to-end Tentative/Ignored fixture test needs an Esplora mock.