### PR TITLE
fix(enclave): require spv for rgb-validation; refuse fundsOut without SPV (#61)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
       # feature combos) is hosted in a private repo and fetched over
       # SSH. Load a read-only deploy key registered on
       # UTEXO-Protocol/rgb-consignment-parser into the agent so cargo's
-      # `git fetch` can authenticate. Default-feature jobs don't pull
-      # the dep and run without this; every job below that enables
-      # `rgb-validation` or `spv` requires it.
+      # `git fetch` can authenticate. The default feature set now includes
+      # `spv` (which pulls `rgb-validation`), so every build below needs this
+      # key except the explicit `--no-default-features` minimal build.
       - name: Set up SSH for private RGB deps
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -52,6 +52,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+      # The default feature set is now `spv` (which pulls `rgb-validation`), so
+      # the default build/clippy/test below exercise the production signing
+      # path — the SPV-anchored fundsOut flow shipped in the EIF.
       - name: Build (default features)
         run: cargo build --workspace
 
@@ -64,18 +67,28 @@ jobs:
         run: cargo test --workspace
 
       # Production build profile: vsock + rgb-validation + spv. Catches any
-      # regression on the actual feature combination shipped in the EIF.
+      # regression on the actual feature combination shipped in the EIF (the
+      # default above omits vsock, which needs a Linux/vsock host).
       - name: Build (production combo)
         run: cargo build -p utexo-bridge-enclave --features vsock,rgb-validation,spv
 
       - name: Clippy (production combo)
         run: cargo clippy -p utexo-bridge-enclave --features vsock,rgb-validation,spv --all-targets -- -D warnings
 
-      # SPV path coverage. Cannot use vsock here (Linux runner without
-      # vsock support); spv pulls in rgb-validation transitively, which is
-      # what the SPV unit + integration tests exercise.
-      - name: Test (--features spv)
-        run: cargo test -p utexo-bridge-enclave --features spv
+      # Minimal build: no features at all (`--no-default-features` drops the
+      # now-default `spv`). Keeps the no-SPV path compiling and exercises the
+      # M-01 / #61 guard that a no-spv build refuses to sign `fundsOut`
+      # (test_no_spv_build_refuses_funds_out_even_without_merkle_proofs). Does
+      # not need the RGB deploy key — without `rgb-validation` the private dep
+      # is not pulled.
+      - name: Build (minimal — no default features)
+        run: cargo build -p utexo-bridge-enclave --no-default-features
+
+      - name: Clippy (minimal — no default features)
+        run: cargo clippy -p utexo-bridge-enclave --no-default-features --all-targets -- -D warnings
+
+      - name: Test (minimal — no default features)
+        run: cargo test -p utexo-bridge-enclave --no-default-features
 
   # Assert the dev-only features `compile_error!` in a release build, so a
   # misconfigured Dockerfile / CI matrix can never ship one. Each feature is
@@ -131,3 +144,54 @@ jobs:
             exit 1
           fi
           echo "OK: release build correctly rejected '${{ matrix.feature }}' via the compile_error guard"
+
+  # Assert that enabling `rgb-validation` without `spv` fails to compile via the
+  # `compile_error!` in lib.rs (audit M-01 / #61). Without SPV, a consignment's
+  # witness txs are anchored only through the host-controlled Esplora resolver,
+  # so the enclave must never be built that way. Runs separately from `ci`
+  # because the build is expected to fail. Unlike `release-guards` this is not
+  # release-specific — the combination is unsafe in every profile.
+  feature-guards:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust 1.89
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.89"
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
+
+      # `--features rgb-validation` pulls the private `rgb-consignment` dep, which
+      # cargo fetches/builds before it reaches our crate's `compile_error!`, so
+      # the deploy key is required here just like the `ci` job above.
+      - name: Set up SSH for private RGB deps
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.RGB_CONSIGNMENT_PARSER_DEPLOY_KEY }}
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-feature-guards-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-feature-guards-
+
+      - name: Assert rgb-validation without spv is rejected
+        run: |
+          if cargo build -p utexo-bridge-enclave --no-default-features --features rgb-validation 2>build.log; then
+            echo "::error::build unexpectedly SUCCEEDED with rgb-validation but no spv — the compile_error guard is missing or not firing"
+            exit 1
+          fi
+          if ! grep -q "rgb-validation requires spv" build.log; then
+            echo "::error::build failed, but not via the expected compile_error guard (rgb-validation requires spv)"
+            cat build.log
+            exit 1
+          fi
+          echo "OK: rgb-validation-without-spv correctly rejected via the compile_error guard"

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -88,19 +88,30 @@ aws-nitro-enclaves-nsm-api = "0.4"
 prost-build = "0.14.3"
 
 [features]
-default = []
+# Production posture: a plain `cargo build` produces the SPV path (which pulls
+# in `rgb-validation`), so the default binary is the one shipped in the EIF. A
+# minimal build is still available via `--no-default-features` and is covered
+# explicitly in CI.
+default = ["spv"]
 vsock = []
 # DANGER: allows importing a raw seed over the wire. Testing only.
 allow-seed-import = []
 # Skips cross-check validation on signing requests. Development/testing only.
 dev-mode = []
-# In-enclave RGB consignment validation via rgbstd + Esplora.
+# In-enclave RGB consignment validation via rgbstd + Esplora. REQUIRES `spv`
+# (enforced by a `compile_error!` in lib.rs — audit M-01 / #61): without SPV the
+# only anchor for a consignment's witness txs is the host-controlled Esplora
+# resolver, so a malicious host could have the enclave sign a release against a
+# fabricated Bitcoin anchor. Kept as a separate feature (rather than adding
+# `spv` to this list) to avoid a feature cycle with `spv` below.
 rgb-validation = ["rgb-ops", "rgb-consignment", "rgb-schemas"]
 # Bitcoin SPV verification of consignment witness txids before signing EVM
 # transactions. Implies `rgb-validation` because SPV needs the consignment
 # parsed to extract witness txids. When the feature is OFF, handle_sign_evm
-# additionally REJECTS any request that carries non-empty merkle_proofs —
-# fail-closed against build mismatches between listener and enclave.
+# refuses to sign ANY `fundsOut` release — regardless of whether the request
+# carries merkle_proofs — and additionally rejects any request that does carry
+# merkle_proofs it cannot verify (fail-closed against listener/enclave build
+# mismatches).
 spv = ["rgb-validation"]
 # Mock attestation path: skip NSM / COSE / cert-chain checks and use raw CBOR docs.
 # Testing only — never enable in production builds.

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -41,6 +41,22 @@ dev_feature_release_guard!(
      it skips all signing cross-checks."
 );
 
+// `rgb-validation` validates a consignment by asking a resolver whether its
+// witness txs are mined. Without `spv` that resolver is the host-controlled
+// Esplora endpoint, so a malicious host can answer "mined at sufficient depth"
+// for a fabricated witness tx and the enclave would sign a `fundsOut` release
+// against a non-existent Bitcoin anchor (audit M-01 / #61). `spv` re-anchors
+// every witness tx against the enclave's own PoW-verified header chain, so a
+// build that can validate consignments MUST also carry SPV. Unlike the
+// dev-feature guards above, this combination is unsafe in every profile — so it
+// is not release-gated and must never compile.
+#[cfg(all(feature = "rgb-validation", not(feature = "spv")))]
+compile_error!(
+    "rgb-validation requires spv: without spv, consignment anchoring trusts only \
+     the host-controlled Esplora resolver — build with `--features spv` (which \
+     pulls in rgb-validation)"
+);
+
 pub mod attestation;
 pub mod cloning;
 pub mod config;

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -391,18 +391,41 @@ fn handle_get_attested_public_key(
 }
 
 fn handle_sign_evm(ctx: &ServerContext, req: SignEvmRequest) -> Result<EnclaveResponse> {
-    // Fail-closed against build mismatch: if the listener built with SPV on
-    // and we built without it, the request will carry `merkle_proofs[]`
-    // that we cannot verify. Refuse loudly rather than sign as if SPV
-    // hadn't been requested.
+    // Fail-closed without SPV (audit M-01 / #61). A build without `spv` can
+    // only anchor a consignment's witness txs through the host-controlled
+    // Esplora resolver, so a malicious host could claim a fabricated witness
+    // tx is mined at sufficient depth and the enclave would sign a `fundsOut`
+    // release against a non-existent Bitcoin anchor. Refuse every `fundsOut`
+    // here regardless of whether the request carries merkle_proofs — an empty
+    // `merkle_proofs[]` must not slip through. The `compile_error!` in lib.rs
+    // guarantees this branch only exists when `rgb-validation` is also off, so
+    // there is no in-enclave validation to fall back on.
     #[cfg(not(feature = "spv"))]
-    if !req.merkle_proofs.is_empty() {
-        return Err(EnclaveError::Spv(
-            "enclave was not built with --features spv but request carries \
-             merkle_proofs; refusing to sign without verification (rebuild \
-             with `--features spv,rgb-validation` to enable SPV)"
-                .into(),
-        ));
+    {
+        let is_funds_out = req.call_data.len() >= 4
+            && req.call_data[..4] == crate::validation::evm_crosscheck::FUNDS_OUT_SELECTOR_POOLS;
+        if is_funds_out {
+            return Err(EnclaveError::Spv(
+                "enclave was not built with --features spv: refusing to sign a \
+                 fundsOut release whose RGB anchoring cannot be SPV-verified \
+                 against the enclave's own header chain (rebuild with \
+                 `--features spv`)"
+                    .into(),
+            ));
+        }
+        // Defence-in-depth against a listener/enclave build mismatch: the
+        // listener built with SPV on and sent `merkle_proofs[]` we cannot
+        // verify. Refuse loudly rather than sign as if SPV hadn't been asked
+        // for. (Reached only for non-`fundsOut` calldata; `fundsOut` already
+        // returned above.)
+        if !req.merkle_proofs.is_empty() {
+            return Err(EnclaveError::Spv(
+                "enclave was not built with --features spv but request carries \
+                 merkle_proofs; refusing to sign without verification (rebuild \
+                 with `--features spv`)"
+                    .into(),
+            ));
+        }
     }
 
     // In-enclave RGB consignment validation (when feature enabled and bytes present).

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -362,13 +362,17 @@ fn test_sign_evm_rejects_unconfigured_bridge_config() {
 // were removed rather than ported — they can't run without a configured
 // in-enclave validator, which the harness doesn't wire.
 
-/// Default-build coverage: `--features rgb-validation` is required to
-/// sign fundsOut at all. The cross-check fails fast with a message
-/// that names the missing feature, so a misconfigured deployment fails
-/// loud instead of silently signing against unvalidated bytes.
-#[cfg(not(feature = "rgb-validation"))]
+/// M-01 / #61: a build without `spv` must refuse to sign any `fundsOut`,
+/// even when the request carries no merkle_proofs. Without SPV the enclave can
+/// only anchor a consignment's witness txs through the host-controlled Esplora
+/// resolver, so a fabricated anchor would otherwise be signed against. The
+/// earlier guard only fired when `merkle_proofs[]` was non-empty, letting an
+/// empty-proofs `fundsOut` slip through — this asserts that gap is closed.
+/// (`not(spv)` ⇔ `not(rgb-validation)` for any build that compiles, since
+/// lib.rs's `compile_error!` forbids rgb-validation without spv.)
+#[cfg(not(feature = "spv"))]
 #[test]
-fn test_sign_evm_rejects_funds_out_in_default_build() {
+fn test_no_spv_build_refuses_funds_out_even_without_merkle_proofs() {
     let port = common::start_test_server();
 
     let init_req = EnclaveRequest {
@@ -379,8 +383,15 @@ fn test_sign_evm_rejects_funds_out_in_default_build() {
     };
     common::send_request(port, &init_req);
 
+    // A fundsOut request carrying no merkle_proofs — exactly the shape that
+    // previously bypassed the no-spv guard.
+    let req = valid_sign_evm_request(1000, 50);
+    assert!(
+        req.merkle_proofs.is_empty(),
+        "test precondition: the request must carry no merkle_proofs"
+    );
     let sign_req = EnclaveRequest {
-        request: Some(Request::SignEvm(valid_sign_evm_request(1000, 50))),
+        request: Some(Request::SignEvm(req)),
     };
     let resp = common::send_request(port, &sign_req);
 
@@ -388,8 +399,8 @@ fn test_sign_evm_rejects_funds_out_in_default_build() {
         Some(Response::Error(e)) => {
             assert_eq!(e.code, 3);
             assert!(
-                e.message.contains("rgb-validation"),
-                "expected feature-gate rejection, got: {}",
+                e.message.contains("--features spv"),
+                "expected an SPV-feature refusal, got: {}",
                 e.message
             );
         }

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -169,21 +169,27 @@ fn build_test_multisig_psbt(our_pubkey: &bitcoin::PublicKey) -> Vec<u8> {
     psbt.serialize()
 }
 
-/// Build a valid enriched SignPsbtRequest for testing.
+/// Build a vanilla (create_utxo-style) `SignPsbtRequest` for the roundtrip
+/// signing test: an empty `evm_tx_hash` means no bridge enrichment, so it skips
+/// the send-RGB consignment binding — which, under `rgb-validation` (now in the
+/// default feature set), requires a validated consignment the test harness
+/// can't supply (`rgb_validator` is `None`). The roundtrip test only exercises
+/// the signing primitive, so vanilla mode is sufficient and keeps it valid in
+/// both the default (spv/rgb-validation) and minimal builds.
 #[cfg(feature = "allow-seed-import")]
 fn valid_sign_psbt_request(psbt_bytes: Vec<u8>) -> SignPsbtRequest {
     SignPsbtRequest {
-        evm_tx_hash: vec![0xCC; 32],
+        evm_tx_hash: vec![],
         operation_idx: 0,
-        evm_event_valid: true,
-        evm_event_finalized: true,
-        evm_token: vec![0x11; 20],
-        evm_amount: 100_000,
-        evm_recipient: vec![0x22; 20],
-        evm_commission: 1_000,
+        evm_event_valid: false,
+        evm_event_finalized: false,
+        evm_token: vec![],
+        evm_amount: 0,
+        evm_recipient: vec![],
+        evm_commission: 0,
         psbt_bytes,
-        psbt_output_amount: 50_000,
-        rgb_asset_id: "rgb:test".into(),
+        psbt_output_amount: 0,
+        rgb_asset_id: String::new(),
         consignment: vec![],
         consignment_hash: vec![],
     }


### PR DESCRIPTION
## What

Closes audit finding **M-01** (#61). A build with `--features rgb-validation` but no `spv` validated RGB consignments using only the host-controlled Esplora resolver for anchoring. A malicious host could answer "mined at sufficient depth" for a fabricated witness tx, and the enclave would sign a `fundsOut` release against a non-existent Bitcoin anchor. The pre-existing guard rejected a no-spv build only when the request carried non-empty `merkle_proofs`; an empty `merkle_proofs` slipped through.

## Changes

- **`enclave/Cargo.toml`** — `default = []` → `default = ["spv"]`, so a plain `cargo build` produces the production (SPV-anchored) path. `rgb-validation` and `spv` stay separate features to avoid a feature cycle; the guard below enforces the dependency.
- **`enclave/src/lib.rs`** — `compile_error!` when `rgb-validation` is enabled without `spv`. Unlike the dev-feature guards this is **not** release-gated — the combination is unsafe in every profile, so it never compiles.
- **`enclave/src/server.rs`** — widened the `#[cfg(not(feature = "spv"))]` guard in `handle_sign_evm` so a no-spv build refuses **any** `fundsOut` (matched by `FUNDS_OUT_SELECTOR_POOLS`), regardless of `merkle_proofs`. The build-mismatch rejection for non-`fundsOut` requests carrying proofs is retained.
- **`enclave/tests/test_signing.rs`** — `test_no_spv_build_refuses_funds_out_even_without_merkle_proofs` asserts an empty-proofs `fundsOut` is refused on a no-spv build.
- **`.github/workflows/ci.yml`** — default build/clippy/test now exercise the spv path; replaced the redundant `--features spv` step with an explicit minimal (`--no-default-features`) build/clippy/test trio; added a `feature-guards` job asserting `--no-default-features --features rgb-validation` fails with the compile_error.

## Acceptance

- ✅ `cargo build` (default) compiles the spv path
- ✅ `--no-default-features --features rgb-validation` fails to compile (`rgb-validation requires spv`)
- ✅ the no-spv path refuses `fundsOut` regardless of `merkle_proofs`
- ✅ CI covers both the default (spv) and minimal (no-features) builds, plus the compile-guard

## Verification (local)

`cargo fmt`; default + minimal `clippy -D warnings` clean; default test suite (16 + 5) and the minimal suite (incl. the new test) pass; the compile-guard fires with the expected message; the `rgb-validation`-without-`spv` build fails as expected.

## Notes

- Guardrail + default-build safety change, not a prod-behavior change: `Dockerfile.enclave` already builds `vsock,rgb-validation,spv`.
- The open feature-graph PR also edits the `[features]` block (it inserts a feature after `spv`); this PR edits `default` and the comments above `spv`, so the merge should be clean. That feature implies `rgb-validation`, so once both land it transitively requires `spv` too — the intended posture.
