### PR TITLE
fix(crosscheck): fail-closed fundsOut selector guard + audit doc clarifications

### DIFF
--- a/enclave/src/main.rs
+++ b/enclave/src/main.rs
@@ -78,6 +78,9 @@ fn main() {
 
     // Start vsock-to-TCP forwarder for Esplora access (production only).
     // The host must run: vsock-proxy <ESPLORA_VSOCK_PORT> <esplora-host> <esplora-port>
+    // Untrusted, host-controlled egress boundary (audit I-01): data fetched
+    // through it is evidence verified by SPV + rgbstd validation, never
+    // trusted input. See `vsock_forwarder`'s module-level TRUST BOUNDARY note.
     #[cfg(all(feature = "vsock", target_os = "linux"))]
     {
         let vsock_port: u32 = std::env::var("ESPLORA_VSOCK_PORT")

--- a/enclave/src/networks/evm/crosscheck.rs
+++ b/enclave/src/networks/evm/crosscheck.rs
@@ -58,6 +58,28 @@ pub fn assert_witnesses_confirmed(validated: &ValidatedConsignment) -> Result<()
     Ok(())
 }
 
+/// Fail-closed selector guard for the selector-specific `fundsOut` validator
+/// [`validate_funds_out_transfer`].
+///
+/// It is only meaningful for the `fundsOut` selector
+/// ([`FUNDS_OUT_SELECTOR_POOLS`]), which the caller
+/// (`server::apply_funds_out_binding`) has already whitelisted before invoking
+/// it. It previously returned `Ok(())` for any other selector, so a future
+/// refactor that called it directly - skipping that whitelist - would get a
+/// *silent success* for an unsupported selector (audit I-03 / Oxorio I-10:
+/// caller-ordering instead of failing closed). Reject instead: a
+/// selector-specific validator handed the wrong selector is a programming
+/// error, so fail closed rather than pass.
+fn ensure_funds_out_selector(call_data: &[u8], validator: &str) -> Result<()> {
+    if call_data.len() < 4 || call_data[..4] != FUNDS_OUT_SELECTOR_POOLS {
+        return Err(EnclaveError::CrossCheck(format!(
+            "{validator} called with a non-fundsOut selector - selector-specific validators must \
+             only run after the fundsOut whitelist in apply_funds_out_binding"
+        )));
+    }
+    Ok(())
+}
+
 /// Pools-side amount cross-check for the `fundsOut` transfer flow. Binds the
 /// calldata `amount` to the consignment's actual asset value:
 ///
@@ -66,16 +88,15 @@ pub fn assert_witnesses_confirmed(validated: &ValidatedConsignment) -> Result<()
 ///   2. The transition's `total_output_amount` must cover the EVM-side release
 ///      `amount`.
 ///
-/// A no-op for any non-`fundsOut` selector.
+/// Fails closed (does not no-op) if handed anything but the `fundsOut`
+/// selector - see [`ensure_funds_out_selector`] (audit I-03).
 pub fn validate_funds_out_transfer(
     call_data: &[u8],
     validated: &ValidatedConsignment,
 ) -> Result<()> {
     use crate::networks::rgb::validation::ifa;
 
-    if call_data.len() < 4 || call_data[..4] != FUNDS_OUT_SELECTOR_POOLS {
-        return Ok(());
-    }
+    ensure_funds_out_selector(call_data, "validate_funds_out_transfer")?;
 
     let last = validated.last_transition.as_ref().ok_or_else(|| {
         EnclaveError::CrossCheck(

--- a/enclave/src/networks/rgb/mod.rs
+++ b/enclave/src/networks/rgb/mod.rs
@@ -149,6 +149,11 @@ pub fn validate_destination_anchor(
                 .into(),
         ));
     }
+    // Wire-tamper detection, mirroring the EVM path's defence-in-depth check.
+    // INTEGRITY, NOT AUTHORIZATION (audit I-02 / Oxorio I-09): the listener
+    // controls both `consignment` and `consignment_hash`, so a match only
+    // proves the wire copy is intact - authorization is the full rgbstd
+    // validation + witness-txid bind below, never this hash.
     if destination.consignment_hash.is_empty() {
         return Err(EnclaveError::CrossCheck(
             "consignment present but consignment_hash is missing".into(),

--- a/enclave/src/networks/rgb/validation.rs
+++ b/enclave/src/networks/rgb/validation.rs
@@ -119,6 +119,16 @@ fn validate_source_payload(source: &RgbSource) -> Result<()> {
                 .into(),
         ));
     }
+    // Hash integrity check between listener-supplied bytes and the pre-computed
+    // keccak. This is INTEGRITY, NOT AUTHORIZATION (audit I-02 / Oxorio I-09):
+    // the listener controls BOTH `consignment` and `consignment_hash`, so a
+    // match only proves the wire copy was not corrupted in transit - it says
+    // nothing about whether the consignment authorizes this release.
+    // Authorization comes solely from the independent in-enclave RGB validation
+    // (`validate_consignment` below, `rgbstd::Transfer::validate` against an
+    // Esplora resolver), SPV anchoring, and the binding of validated facts
+    // (contract_id / op_id / amount). Keep this as defence-in-depth tamper
+    // detection; never read a hash match as proof of intent.
     if source.consignment_hash.is_empty() {
         return Err(EnclaveError::CrossCheck(
             "consignment present but consignment_hash is missing".into(),

--- a/enclave/src/vsock_forwarder.rs
+++ b/enclave/src/vsock_forwarder.rs
@@ -1,6 +1,20 @@
 //! TCP-to-vsock forwarder for reaching external services (e.g., Esplora) from
 //! inside a Nitro enclave. Listens on localhost TCP and forwards each connection
 //! to the parent instance via vsock, where `vsock-proxy` relays to the real endpoint.
+//!
+//! TRUST BOUNDARY (audit I-01 / Oxorio I-03, I-08): everything reachable
+//! through this forwarder is HOST-CONTROLLED and UNTRUSTED. The host runs the
+//! `vsock-proxy` on the far end and can drop, delay, reorder, or forge any
+//! bytes it returns. Data fetched over it (Esplora tx / merkle proof / chain
+//! tip) is EVIDENCE TO BE VERIFIED - by in-enclave SPV proof checking and
+//! rgbstd consignment validation - never trusted input. The listener binds
+//! only to loopback (`127.0.0.1`, not externally reachable), but it is a
+//! GENERIC egress primitive: any code inside the enclave process that can open
+//! a loopback socket can tunnel host-bound traffic through it. A future
+//! hardening (issue #87) would replace it with a typed Esplora client private
+//! to the RGB resolver path that only issues the specific calls the resolver
+//! makes (fetch tx / merkle proof / tip), so arbitrary traffic cannot be
+//! tunneled.
 
 use std::io;
 use std::net::TcpListener;
@@ -12,6 +26,10 @@ const PARENT_CID: u32 = 3;
 
 /// Start a background forwarder thread that bridges `127.0.0.1:{local_port}`
 /// to vsock CID 3 (parent instance), port `vsock_port`.
+///
+/// See the module-level TRUST BOUNDARY note: this is an untrusted,
+/// host-controlled egress path. Anything fetched through it must be verified
+/// (SPV + rgbstd validation), never trusted as input (audit I-01).
 ///
 /// The forwarder is fire-and-forget — it logs errors but never crashes the enclave.
 pub fn start_forwarder(local_port: u16, vsock_port: u32) -> io::Result<()> {


### PR DESCRIPTION
- validate_funds_out_* reject wrong selector instead of silent Ok (#89, I-03)
- document consignment_hash as integrity-only, not authorization (#88, I-02)
- document vsock forwarder as untrusted host egress boundary (#87, I-01)