### PR TITLE
fix(cloning): record replay-guard nonce after auth checks (audit W-13)

### DIFF
--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -361,6 +361,12 @@ fn handle_get_attested_public_key(
         EnclaveError::InvalidRequest(format!("nonce must be 32 bytes, got {}", req.nonce.len()))
     })?;
 
+    // NOTE (audit W-13): this endpoint attests over a *caller-supplied* nonce,
+    // so it can act as an oracle that mints valid attestations for arbitrary
+    // nonces. That is safe for replay accounting: the cloning handlers record a
+    // nonce only after a fully-authenticated handshake (see `handle_get_clone` /
+    // `handle_set_clone`), so an oracle-minted nonce carries no replay-guard
+    // weight on its own and cannot be used to exhaust the guard.
     let keys = ctx.state.get_keys()?;
     let public_keys = build_public_keys_response(keys, &ctx.bridge_config);
 
@@ -1049,27 +1055,20 @@ fn handle_get_clone(state: &EnclaveState, req: GetCloneRequest) -> Result<Enclav
 
     // 2. Verify the requester attestation chain + PCRs. `None` for the
     //    expected nonce: we have not seen the requester's nonce before,
-    //    so freshness is enforced by the replay guard immediately after.
+    //    so freshness is enforced by the replay guard once the binding and
+    //    authenticity checks below have passed.
     let expected_pcrs = attestation::get_own_pcrs()?;
     let verified =
         attestation::verify_peer_attestation(&req.requester_attestation, &expected_pcrs, None)?;
 
-    // 3. Replay-check the nonce pulled from the verified document.
-    let nonce_array: [u8; 32] = verified
-        .nonce
-        .as_slice()
-        .try_into()
-        .map_err(|_| EnclaveError::Attestation("attestation nonce has wrong length".into()))?;
-    state.replay_guard.check_and_record(nonce_array)?;
-
-    // 4. Pubkey binding: the attestation's `public_key` field must equal
+    // 3. Pubkey binding: the attestation's `public_key` field must equal
     //    the one the parent put on the wire. Otherwise the parent could
     //    have swapped it for a key it controls.
     if verified.enclave_pubkey.as_slice() != req_encryption_pk {
         return Err(EnclaveError::PubkeyMismatch);
     }
 
-    // 5. Digest binding: the attestation's `user_data` must equal the
+    // 4. Digest binding: the attestation's `user_data` must equal the
     //    digest on the wire — NSM-signed, so parent-proof.
     let user_data = verified.user_data.as_deref().ok_or_else(|| {
         EnclaveError::Attestation("requester attestation missing user_data (cloning digest)".into())
@@ -1078,7 +1077,7 @@ fn handle_get_clone(state: &EnclaveState, req: GetCloneRequest) -> Result<Enclav
         return Err(EnclaveError::DigestMismatch);
     }
 
-    // 6. Digest authenticity: HMAC(donor_secret, encryption_pubkey) must
+    // 5. Digest authenticity: HMAC(donor_secret, encryption_pubkey) must
     //    match. Proves the requester was issued by the same operator.
     state.with_donor_cloning_secret(|secret| {
         if !cloning::verify_cloning_digest(secret, &req_encryption_pk, &req_digest) {
@@ -1086,6 +1085,21 @@ fn handle_get_clone(state: &EnclaveState, req: GetCloneRequest) -> Result<Enclav
         }
         Ok(())
     })?;
+
+    // 6. Replay-check + record the nonce from the verified document. This
+    //    runs only *after* the pubkey, digest and donor-secret checks above
+    //    have passed, so a rejected (unauthenticated) handshake never
+    //    consumes replay-guard capacity. Combined with the count-cap removal
+    //    (#80), this closes the secret-less cloning-availability DoS in which
+    //    an attacker mints attestations over arbitrary nonces via
+    //    `get_attested_public_key` and burns them on doomed handshakes
+    //    (audit W-13).
+    let nonce_array: [u8; 32] = verified
+        .nonce
+        .as_slice()
+        .try_into()
+        .map_err(|_| EnclaveError::Attestation("attestation nonce has wrong length".into()))?;
+    state.replay_guard.check_and_record(nonce_array)?;
 
     // 7. Seal the seed under a fresh donor ephemeral keypair.
     let (encrypted_seed, donor_pubkey) =
@@ -1122,18 +1136,12 @@ fn handle_set_clone(state: &EnclaveState, req: SetCloneRequest) -> Result<Enclav
         ))
     })?;
 
-    // 1. Verify donor attestation chain + PCRs (no nonce match — we
-    //    enforce freshness via the replay guard).
+    // 1. Verify donor attestation chain + PCRs (no nonce match — freshness
+    //    is enforced by the replay guard once the binding and seed/identity
+    //    checks below have passed).
     let expected_pcrs = attestation::get_own_pcrs()?;
     let verified =
         attestation::verify_peer_attestation(&req.donor_attestation, &expected_pcrs, None)?;
-
-    let nonce_array: [u8; 32] = verified
-        .nonce
-        .as_slice()
-        .try_into()
-        .map_err(|_| EnclaveError::Attestation("attestation nonce has wrong length".into()))?;
-    state.replay_guard.check_and_record(nonce_array)?;
 
     // 2. Pubkey binding: the donor's pubkey on the wire must equal the
     //    one inside their signed attestation.
@@ -1158,6 +1166,16 @@ fn handle_set_clone(state: &EnclaveState, req: SetCloneRequest) -> Result<Enclav
         cluster_public_key = session.cluster_public_key;
         Ok(km)
     })?;
+
+    // 4. Replay-check + record the donor nonce only *after* the pubkey
+    //    binding and the seed/identity checks above have passed, so a
+    //    rejected handshake never consumes replay-guard capacity (audit W-13).
+    let nonce_array: [u8; 32] = verified
+        .nonce
+        .as_slice()
+        .try_into()
+        .map_err(|_| EnclaveError::Attestation("attestation nonce has wrong length".into()))?;
+    state.replay_guard.check_and_record(nonce_array)?;
 
     tracing::info!(
         cluster_pk = %hex::encode(cluster_public_key),

--- a/enclave/tests/test_clone.rs
+++ b/enclave/tests/test_clone.rs
@@ -269,6 +269,40 @@ fn clone_rejects_duplicate_requester_attestation_nonce_on_donor() {
 }
 
 #[test]
+fn clone_rejected_handshake_does_not_consume_replay_nonce() {
+    // audit W-13: the donor must record a handshake nonce only AFTER the
+    // pubkey/digest/donor-secret checks pass. A rejected (unauthenticated)
+    // handshake must not consume replay-guard capacity — otherwise anyone able
+    // to mint attestations over arbitrary nonces (the get_attested_public_key
+    // oracle) could exhaust the guard without ever knowing the cloning secret.
+    let (donor_port, donor_keys) = start_donor();
+    let requester_port = start_requester();
+
+    let init = initiate_cloning(requester_port, CLONING_SECRET, &donor_keys.evm_address);
+
+    // Tamper the cloning digest so the handshake is rejected at the digest
+    // binding — which runs *after* the point where the nonce used to be
+    // recorded.
+    let mut tampered = init.clone();
+    tampered.cloning_digest[0] ^= 0xff;
+    let err = request_get_clone(donor_port, &donor_keys.evm_address, &tampered)
+        .expect_err("tampered cloning_digest must be rejected");
+    assert!(
+        !err.message.contains("replay"),
+        "should fail on the digest binding, not the replay guard: {}",
+        err.message
+    );
+
+    // The rejected attempt must NOT have recorded its nonce: a subsequent
+    // valid handshake reusing the same attestation (same nonce) still
+    // succeeds. Pre-fix this failed on the replay guard because the doomed
+    // attempt consumed the nonce first.
+    request_get_clone(donor_port, &donor_keys.evm_address, &init).expect(
+        "valid handshake reusing the same nonce must still succeed after a rejected attempt",
+    );
+}
+
+#[test]
 fn cannot_initialize_after_entering_cloning() {
     let requester_port = start_requester();
     // Start a clone session using a throwaway donor address.


### PR DESCRIPTION
Closes audit finding **W-13** (part of the unfiled-warnings umbrella #123).

## Problem
`handle_get_clone` and `handle_set_clone` called `replay_guard.check_and_record(nonce)` **before** the pubkey / digest / donor-secret and seed/identity checks. Because `handle_get_attested_public_key` mints a valid NSM attestation over **any** caller-supplied nonce (and `verify_peer_attestation(..., None)` only checks nonce *presence*), any caller able to reach the cloning RPC could:

1. mint attestations over many distinct nonces via the oracle, then
2. feed each into `get_clone`/`set_clone`, which recorded the nonce and *then* failed the later binding/secret checks,

exhausting replay-guard capacity on doomed handshakes **without knowing the cloning secret**. The count-cap half of this (W-12) was already fixed by #80 (TTL + oldest-first eviction); this is the companion record-before-auth + oracle half.

## Fix
- Move `check_and_record` **below** the pubkey/digest/donor-secret checks in `handle_get_clone` (recorded just before sealing the seed) and below the pubkey binding + `complete_cloning` seed/identity checks in `handle_set_clone`. A rejected handshake now never consumes replay capacity.
- Document on `handle_get_attested_public_key` why the arbitrary-nonce oracle is benign under this ordering (an oracle-minted nonce carries no replay-guard weight until a fully-authenticated handshake uses it).

Replay protection for *valid* handshakes is unchanged: a duplicate valid handshake still records-then-rejects, and single-threaded/serialized `check_and_record` still runs before the seed is sealed.

## Test
- New `clone_rejected_handshake_does_not_consume_replay_nonce`: a handshake rejected at the digest binding does **not** record its nonce, so a subsequent valid handshake reusing the same attestation (same nonce) still succeeds. Pre-fix this failed on the replay guard.
- Existing `clone_rejects_duplicate_requester_attestation_nonce_on_donor` (valid-replay rejection) and the happy path still pass. `cargo test --features mock-attestation,allow-seed-import --test test_clone` → 7/7 green.

## Notes
- Base is **`dev-ng`**. Touches only the cloning handlers (`handle_get_clone` / `handle_set_clone` / `handle_get_attested_public_key`) — no overlap with the in-flight signing PRs (#122/#102/#101/#125/#126), so it merges independently.
- `cargo fmt` clean; default-feature build clean.
