### PR TITLE
parent adapter: fix EVM→RGB signing (invoice recipient + EVM_GAS_TX routing)

### DIFF
--- a/parent/src/grpc_server.rs
+++ b/parent/src/grpc_server.rs
@@ -257,147 +257,139 @@ impl ParentService for ParentAdapterService {
         let data_type = DataType::try_from(common.data_type).unwrap_or(DataType::Transaction);
         let signer_network_id = common.dst_network_id;
 
-        // EVM_GAS_TX carries a pre-hashed 32-byte digest in EvmData.call_data
-        // and is signed with the enclave's dedicated gas-tx key. It has no
-        // source proof, so route it to SignRawDigest before requiring one.
-        if data_type == DataType::EvmGasTx {
-            let digest = match inner.data {
-                Some(sign_request::Data::EvmData(payload)) => payload.call_data,
-                _ => {
-                    return Err(Status::invalid_argument(
-                        "EVM_GAS_TX sign requires EvmData with the digest in call_data",
-                    ))
-                }
-            };
-            tracing::info!(
-                dst_network_id = signer_network_id,
-                digest_len = digest.len(),
-                "gRPC Sign: EVM gas tx raw digest"
-            );
-            let enclave_req = EnclaveRequest {
-                request: Some(enclave_request::Request::SignRawDigest(
-                    enclave_proto::SignRawDigestRequest { digest },
-                )),
-            };
-            let resp = self.send_to_enclave(enclave_req).await?;
-            return match resp.response {
-                Some(enclave_response::Response::RawDigestSig(r)) => {
-                    Ok(Response::new(SignatureResponse {
-                        signer_network_id,
-                        signature: r.signature,
-                        identifier: None,
-                    }))
-                }
-                Some(enclave_response::Response::Error(e)) => {
-                    Err(Self::enclave_error_to_status(&e))
-                }
-                other => Err(Status::internal(format!(
-                    "unexpected enclave response for SignRawDigest: {:?}",
-                    other
-                ))),
-            };
-        }
+        match data_type {
+            DataType::Transaction => {
+                let source = Self::source_proof(&inner)?;
+                let amount = source.amount;
 
-        let source = Self::source_proof(&inner)?;
-        let amount = source.amount;
-        let data = inner.data;
+                let destination_network = match inner.data {
+                    Some(sign_request::Data::EvmData(payload)) => {
+                        if !self.evm_network_ids.contains(&common.dst_network_id) {
+                            return Err(Status::invalid_argument(format!(
+                                "EVM payload destination network {} is not configured as EVM",
+                                common.dst_network_id
+                            )));
+                        }
+                        tracing::info!(
+                            src_network_id = common.src_network_id,
+                            dst_network_id = common.dst_network_id,
+                            calldata_len = payload.call_data.len(),
+                            nonce = payload.nonce,
+                            deadline = payload.deadline,
+                            "gRPC Sign: EVM transaction"
+                        );
 
-        let destination_network = match data_type {
-            DataType::Transaction => match data {
-                Some(sign_request::Data::EvmData(payload)) => {
-                    if !self.evm_network_ids.contains(&common.dst_network_id) {
-                        return Err(Status::invalid_argument(format!(
-                            "EVM payload destination network {} is not configured as EVM",
-                            common.dst_network_id
-                        )));
+                        Self::enclave_destination_network(sign_request::Data::EvmData(payload))
                     }
-                    tracing::info!(
-                        src_network_id = common.src_network_id,
-                        dst_network_id = common.dst_network_id,
-                        calldata_len = payload.call_data.len(),
-                        nonce = payload.nonce,
-                        deadline = payload.deadline,
-                        "gRPC Sign: EVM transaction"
-                    );
+                    Some(sign_request::Data::RgbData(payload)) => {
+                        if self.evm_network_ids.contains(&common.dst_network_id) {
+                            return Err(Status::invalid_argument(format!(
+                                "RGB payload destination network {} is configured as EVM",
+                                common.dst_network_id
+                            )));
+                        }
+                        tracing::info!(
+                            src_network_id = common.src_network_id,
+                            dst_network_id = common.dst_network_id,
+                            psbt_len = payload.psbt_bytes.len(),
+                            operation_idx = payload.operation_idx,
+                            "gRPC Sign: RGB transaction"
+                        );
 
-                    Self::enclave_destination_network(sign_request::Data::EvmData(payload))
-                }
-                Some(sign_request::Data::RgbData(payload)) => {
-                    if self.evm_network_ids.contains(&common.dst_network_id) {
-                        return Err(Status::invalid_argument(format!(
-                            "RGB payload destination network {} is configured as EVM",
-                            common.dst_network_id
-                        )));
+                        Self::enclave_destination_network(sign_request::Data::RgbData(payload))
                     }
-                    tracing::info!(
-                        src_network_id = common.src_network_id,
-                        dst_network_id = common.dst_network_id,
-                        psbt_len = payload.psbt_bytes.len(),
-                        operation_idx = payload.operation_idx,
-                        "gRPC Sign: RGB transaction"
-                    );
+                    None => return Err(Status::invalid_argument("SignRequest.data is missing")),
+                };
 
-                    Self::enclave_destination_network(sign_request::Data::RgbData(payload))
+                let source_network = Self::enclave_source_network(source)?;
+                Self::validate_cross_network_route(&source_network, &destination_network)?;
+
+                let enclave_req = EnclaveRequest {
+                    request: Some(enclave_request::Request::Sign(enclave_proto::SignRequest {
+                        amount,
+                        source_network: Some(source_network),
+                        destination_network: Some(destination_network),
+                    })),
+                };
+
+                let start = std::time::Instant::now();
+                let resp = self.send_to_enclave(enclave_req).await?;
+                tracing::debug!(
+                    elapsed_ms = start.elapsed().as_millis() as u64,
+                    "enclave round-trip"
+                );
+
+                match resp.response {
+                    Some(enclave_response::Response::SignedPsbt(r)) => {
+                        Ok(Response::new(SignatureResponse {
+                            signer_network_id,
+                            signature: r.signed_psbt,
+                            identifier: None,
+                        }))
+                    }
+                    Some(enclave_response::Response::EvmSignature(r)) => {
+                        Ok(Response::new(SignatureResponse {
+                            signer_network_id,
+                            signature: r.signature,
+                            identifier: None,
+                        }))
+                    }
+                    Some(enclave_response::Response::Error(e)) => {
+                        Err(Self::enclave_error_to_status(&e))
+                    }
+                    other => Err(Status::internal(format!(
+                        "unexpected enclave response for Sign: {:?}",
+                        other
+                    ))),
                 }
-                None => return Err(Status::invalid_argument("SignRequest.data is missing")),
-            },
+            }
             DataType::EvmGasTx => {
-                return Err(Status::invalid_argument(
-                    "EVM_GAS_TX signing is not supported by parent.SignRequest: no raw digest field",
-                ));
+                // EVM_GAS_TX carries a pre-hashed 32-byte digest in EvmData.call_data
+                // and is signed with the enclave's dedicated gas-tx key. It has no
+                // source proof, so it is routed to SignRawDigest rather than the
+                // source/destination Sign path.
+                let digest = match inner.data {
+                    Some(sign_request::Data::EvmData(payload)) => payload.call_data,
+                    _ => {
+                        return Err(Status::invalid_argument(
+                            "EVM_GAS_TX sign requires EvmData with the digest in call_data",
+                        ))
+                    }
+                };
+                tracing::info!(
+                    dst_network_id = signer_network_id,
+                    digest_len = digest.len(),
+                    "gRPC Sign: EVM gas tx raw digest"
+                );
+                let enclave_req = EnclaveRequest {
+                    request: Some(enclave_request::Request::SignRawDigest(
+                        enclave_proto::SignRawDigestRequest { digest },
+                    )),
+                };
+                let resp = self.send_to_enclave(enclave_req).await?;
+                match resp.response {
+                    Some(enclave_response::Response::RawDigestSig(r)) => {
+                        Ok(Response::new(SignatureResponse {
+                            signer_network_id,
+                            signature: r.signature,
+                            identifier: None,
+                        }))
+                    }
+                    Some(enclave_response::Response::Error(e)) => {
+                        Err(Self::enclave_error_to_status(&e))
+                    }
+                    other => Err(Status::internal(format!(
+                        "unexpected enclave response for SignRawDigest: {:?}",
+                        other
+                    ))),
+                }
             }
             other => {
                 tracing::warn!(?other, "unsupported data_type in Sign request");
-                return Err(Status::invalid_argument(format!(
+                Err(Status::invalid_argument(format!(
                     "unsupported data_type: {other:?}"
-                )));
+                )))
             }
-        };
-        let source_network = Self::enclave_source_network(source)?;
-        Self::validate_cross_network_route(&source_network, &destination_network)?;
-
-        let enclave_req = EnclaveRequest {
-            request: Some(enclave_request::Request::Sign(enclave_proto::SignRequest {
-                amount,
-                source_network: Some(source_network),
-                destination_network: Some(destination_network),
-            })),
-        };
-
-        let start = std::time::Instant::now();
-        let resp = self.send_to_enclave(enclave_req).await?;
-        tracing::debug!(
-            elapsed_ms = start.elapsed().as_millis() as u64,
-            "enclave round-trip"
-        );
-
-        match resp.response {
-            Some(enclave_response::Response::SignedPsbt(r)) => {
-                Ok(Response::new(SignatureResponse {
-                    signer_network_id,
-                    signature: r.signed_psbt,
-                    identifier: None,
-                }))
-            }
-            Some(enclave_response::Response::EvmSignature(r)) => {
-                Ok(Response::new(SignatureResponse {
-                    signer_network_id,
-                    signature: r.signature,
-                    identifier: None,
-                }))
-            }
-            Some(enclave_response::Response::RawDigestSig(r)) => {
-                Ok(Response::new(SignatureResponse {
-                    signer_network_id,
-                    signature: r.signature,
-                    identifier: None,
-                }))
-            }
-            Some(enclave_response::Response::Error(e)) => Err(Self::enclave_error_to_status(&e)),
-            other => Err(Status::internal(format!(
-                "unexpected enclave response for Sign: {:?}",
-                other
-            ))),
         }
     }
 

--- a/parent/src/grpc_server.rs
+++ b/parent/src/grpc_server.rs
@@ -129,6 +129,18 @@ impl ParentAdapterService {
             .map_err(|e| Status::invalid_argument(format!("{field} must be hex bytes: {e}")))
     }
 
+    /// Decode a field that is hex for EVM addresses but an opaque string for
+    /// other networks — EVM→RGB FundsIn events carry the RGB invoice
+    /// (`utxob:…`) in SourceProof.recipient. Non-hex values pass through as
+    /// their raw UTF-8 bytes so the enclave sees what the listener saw.
+    fn decode_hex_or_raw_field(value: String) -> Vec<u8> {
+        let hex = value.strip_prefix("0x").unwrap_or(&value);
+        match hex::decode(hex) {
+            Ok(bytes) => bytes,
+            Err(_) => value.into_bytes(),
+        }
+    }
+
     fn enclave_merkle_proof(
         proof: grpc_proto::MerkleProofEntry,
     ) -> enclave_proto::MerkleProofEntry {
@@ -150,7 +162,7 @@ impl ParentAdapterService {
                     event_valid: true,
                     event_finalized: source.finalized,
                     token: Self::decode_hex_field("SourceProof.token", source.token)?,
-                    recipient: Self::decode_hex_field("SourceProof.recipient", source.recipient)?,
+                    recipient: Self::decode_hex_or_raw_field(source.recipient),
                     commission: source.commission,
                 }),
             ),
@@ -244,6 +256,48 @@ impl ParentService for ParentAdapterService {
         let common = Self::common_sign_request(&inner)?;
         let data_type = DataType::try_from(common.data_type).unwrap_or(DataType::Transaction);
         let signer_network_id = common.dst_network_id;
+
+        // EVM_GAS_TX carries a pre-hashed 32-byte digest in EvmData.call_data
+        // and is signed with the enclave's dedicated gas-tx key. It has no
+        // source proof, so route it to SignRawDigest before requiring one.
+        if data_type == DataType::EvmGasTx {
+            let digest = match inner.data {
+                Some(sign_request::Data::EvmData(payload)) => payload.call_data,
+                _ => {
+                    return Err(Status::invalid_argument(
+                        "EVM_GAS_TX sign requires EvmData with the digest in call_data",
+                    ))
+                }
+            };
+            tracing::info!(
+                dst_network_id = signer_network_id,
+                digest_len = digest.len(),
+                "gRPC Sign: EVM gas tx raw digest"
+            );
+            let enclave_req = EnclaveRequest {
+                request: Some(enclave_request::Request::SignRawDigest(
+                    enclave_proto::SignRawDigestRequest { digest },
+                )),
+            };
+            let resp = self.send_to_enclave(enclave_req).await?;
+            return match resp.response {
+                Some(enclave_response::Response::RawDigestSig(r)) => {
+                    Ok(Response::new(SignatureResponse {
+                        signer_network_id,
+                        signature: r.signature,
+                        identifier: None,
+                    }))
+                }
+                Some(enclave_response::Response::Error(e)) => {
+                    Err(Self::enclave_error_to_status(&e))
+                }
+                other => Err(Status::internal(format!(
+                    "unexpected enclave response for SignRawDigest: {:?}",
+                    other
+                ))),
+            };
+        }
+
         let source = Self::source_proof(&inner)?;
         let amount = source.amount;
         let data = inner.data;


### PR DESCRIPTION
Two adapter-level blockers found while retesting the refactoring train:

## 1. `SourceProof.recipient must be hex bytes` kills every EVM→RGB funds-out
EVM→RGB FundsIn events carry the RGB invoice (`utxob:…`) in
`SourceProof.recipient`; the unconditional hex decode (introduced in 438d04a)
rejected it before signing. The enclave doesn't parse this field, so non-hex
values now pass through as raw UTF-8 bytes (`decode_hex_or_raw_field`),
hex stays hex for real addresses.

## 2. `data_type=EVM_GAS_TX` was unroutable
`sign()` required a source proof before the data_type match, so gas-tx digests
died with `SignRequest.source is missing` (the intended "not supported" error
was unreachable). Both sides already implement the source-less path
(`SignRawDigestRequest` / `RawDigestSig`, gas-tx key) — this change just routes
EVM_GAS_TX to it before requiring a source.

## Verified
Live on the test stand: transfer 105 (EVM→RGB) finished E2E; transfer 106
(RGB→EVM) produced valid 2-of-3 mint signatures that recover to the registered
enclave signers.