### PR TITLE
#60 helios integration

### DIFF
--- a/.github/workflows/build-eif.yml
+++ b/.github/workflows/build-eif.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Rust (for nitro-cli build)
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.89"
+          toolchain: "1.96"
           targets: x86_64-unknown-linux-musl
 
       - name: System deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,16 @@ jobs:
       - name: Test (--features evm-rpc)
         run: cargo test -p utexo-bridge-enclave --features evm-rpc
 
+      # Trustless Helios path (#77) - EXPERIMENTAL, default-OFF, NOT in the
+      # shipped EIF. Compile + clippy only: a live light-client sync needs real
+      # execution + consensus RPCs, unavailable in CI (the predicate itself is
+      # already covered by the evm-rpc FakeProvider tests). Heavy build: a second
+      # alloy major, revm, BLS, and vendored OpenSSL.
+      - name: Build (--features helios)
+        run: cargo build -p utexo-bridge-enclave --features vsock,helios
+      - name: Clippy (--features helios)
+        run: cargo clippy -p utexo-bridge-enclave --features vsock,helios --all-targets -- -D warnings
+
   # Assert the dev-only features `compile_error!` in a release build, so a
   # misconfigured Dockerfile / CI matrix can never ship one. Each feature is
   # built individually with `--release`; the build MUST fail, and fail via

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,13 +171,16 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
 
-      # `--features rgb-validation` pulls the private `rgb-consignment` dep, which
-      # cargo fetches/builds before it reaches our crate's `compile_error!`, so
-      # the deploy key is required here just like the `ci` job above.
+      # `--features rgb-validation` pulls the private `rgb-consignment` dep, and
+      # cargo also resolves the private `federated-signer-proto` git dep from the
+      # lockfile, both fetched before it reaches our crate's `compile_error!`, so
+      # both deploy keys are required here just like the `ci` job above.
       - name: Set up SSH for private RGB deps
         uses: webfactory/ssh-agent@v0.9.0
         with:
-          ssh-private-key: ${{ secrets.RGB_CONSIGNMENT_PARSER_DEPLOY_KEY }}
+          ssh-private-key: |
+            ${{ secrets.RGB_CONSIGNMENT_PARSER_DEPLOY_KEY }}
+            ${{ secrets.FEDERATED_SIGNER_PROTO_DEPLOY_KEY }}
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust 1.89
+      - name: Install Rust 1.96
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.89"
+          toolchain: "1.96"
           components: rustfmt, clippy
 
       - name: Install system dependencies
@@ -109,10 +109,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust 1.89
+      - name: Install Rust 1.96
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.89"
+          toolchain: "1.96"
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
@@ -150,3 +150,54 @@ jobs:
             exit 1
           fi
           echo "OK: release build correctly rejected '${{ matrix.feature }}' via the compile_error guard"
+
+  # Assert that enabling `rgb-validation` without `spv` fails to compile via the
+  # `compile_error!` in lib.rs (audit M-01 / #61). Without SPV, a consignment's
+  # witness txs are anchored only through the host-controlled Esplora resolver,
+  # so the enclave must never be built that way. Runs separately from `ci`
+  # because the build is expected to fail. Unlike `release-guards` this is not
+  # release-specific — the combination is unsafe in every profile.
+  feature-guards:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust 1.96
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.96"
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
+
+      # `--features rgb-validation` pulls the private `rgb-consignment` dep, which
+      # cargo fetches/builds before it reaches our crate's `compile_error!`, so
+      # the deploy key is required here just like the `ci` job above.
+      - name: Set up SSH for private RGB deps
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.RGB_CONSIGNMENT_PARSER_DEPLOY_KEY }}
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-feature-guards-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-feature-guards-
+
+      - name: Assert rgb-validation without spv is rejected
+        run: |
+          if cargo build -p utexo-bridge-enclave --no-default-features --features rgb-validation 2>build.log; then
+            echo "::error::build unexpectedly SUCCEEDED with rgb-validation but no spv — the compile_error guard is missing or not firing"
+            exit 1
+          fi
+          if ! grep -q "rgb-validation requires spv" build.log; then
+            echo "::error::build failed, but not via the expected compile_error guard (rgb-validation requires spv)"
+            cat build.log
+            exit 1
+          fi
+          echo "OK: rgb-validation-without-spv correctly rejected via the compile_error guard"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,19 +65,24 @@ jobs:
       - name: Test (default features)
         run: cargo test --workspace
 
-      # Production build profile: vsock + rgb-validation + spv. Catches any
-      # regression on the actual feature combination shipped in the EIF.
+      # Production build profile: vsock + rgb-validation + spv + evm-rpc.
+      # Catches any regression on the actual feature combination shipped in the EIF.
       - name: Build (production combo)
-        run: cargo build -p utexo-bridge-enclave --features vsock,rgb-validation,spv
+        run: cargo build -p utexo-bridge-enclave --features vsock,rgb-validation,spv,evm-rpc
 
       - name: Clippy (production combo)
-        run: cargo clippy -p utexo-bridge-enclave --features vsock,rgb-validation,spv --all-targets -- -D warnings
+        run: cargo clippy -p utexo-bridge-enclave --features vsock,rgb-validation,spv,evm-rpc --all-targets -- -D warnings
 
       # SPV path coverage. Cannot use vsock here (Linux runner without
       # vsock support); spv pulls in rgb-validation transitively, which is
       # what the SPV unit + integration tests exercise.
       - name: Test (--features spv)
         run: cargo test -p utexo-bridge-enclave --features spv
+
+      # In-enclave EVM FundsIn verification (#60). The predicate + decoding
+      # tests use a FakeProvider, so no real RPC is needed in CI.
+      - name: Test (--features evm-rpc)
+        run: cargo test -p utexo-bridge-enclave --features evm-rpc
 
   # Assert the dev-only features `compile_error!` in a release build, so a
   # misconfigured Dockerfile / CI matrix can never ship one. Each feature is

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,168 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "alloy"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9677ab3454c237abe6307805bea17a7912b3a516b606c7b4d3d948b9fede137"
+dependencies = [
+ "alloy-consensus",
+ "alloy-core",
+ "alloy-eips",
+ "alloy-network",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "alloy-transport",
+ "alloy-transport-http",
+ "alloy-trie",
+]
+
+[[package]]
+name = "alloy-chains"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b5cc30538e90795a57647bef8d8864aad6e8d86190617009b4ef8d8b647b49a"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "phf",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ff0c4adba2abdcd9fb5829ae5f4394c06f8585ed283a9ba79aa33763c802e1"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-trie",
+ "alloy-tx-macros",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "k256",
+ "once_cell",
+ "rand 0.8.5",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cdf48932b1db3216175e19a2b476d89d53076e004850ee7983c6807ba0fde74"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-core"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ddde5968de6044d67af107ad835bc0069a7ca245870b94c5958a7d8712b184"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+]
+
+[[package]]
+name = "alloy-eip2124"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eip2930"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eip7928"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea4c0453065b9206acc0f869a258dc8dcbbd595e144b4446f2c493a24a814d1f"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2",
+]
+
+[[package]]
 name = "alloy-json-abi"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +193,60 @@ dependencies = [
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4691c60de5d628533752cd07e102d17c47874c06c04c91af33960fd94c484f4"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "http",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-network"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d912bb639bf4ac31e83095afe9e907c8b9774ce0c405966228368309fcfc45f"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "derive_more",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d875a11bd98595f57f73890f2e36f4a1cca0fa670623e59c9fb08b2389979c36"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
 ]
 
 [[package]]
@@ -46,7 +262,7 @@ dependencies = [
  "derive_more",
  "foldhash 0.2.0",
  "hashbrown 0.17.1",
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -62,13 +278,161 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7d526d184d392a8fbcf4293e457789b307bb70646e4f8b902989a246529450"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "alloy-sol-types",
+ "alloy-transport",
+ "alloy-transport-http",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "either",
+ "futures",
+ "futures-utils-wasm",
+ "lru",
+ "parking_lot",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
 name = "alloy-rlp"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
 dependencies = [
+ "alloy-rlp-derive",
  "arrayvec",
  "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d4311c03125e8a18296504560b9de3d75ecbd0dcda7f71e6cf2a196d57e6fba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "755447dc13a04c6fa6db8dedb5d32ab5edfa4dd7aa34487ff192a3d873e0e8cf"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-transport",
+ "alloy-transport-http",
+ "futures",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96deb317fe224e98a8ae17a7ed7ea63478867385bf50b7abd53642b24cfd811a"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911a513723ef0b90c3b072f65eebf54d6ebc8b651d06734e252d024bd89b88ac"
+dependencies = [
+ "alloy-consensus-any",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1bd19904581ee2075b61faabab1a4cefa8b96d8f2c85343adeae8ecf615e2b"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-sol-types",
+ "itertools 0.14.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e97b3e0b9f816b25083045dcfa69431bd059a078e828e4d82d296d1949b96c"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6913d06ccc0d9c6ab67e2f82e2fbe292706da1f91442f30cded2d04b56bf0d58"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "either",
+ "elliptic-curve",
+ "k256",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -94,7 +458,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -139,6 +503,73 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
  "serde",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999adfe5c91035c6bf4c4210e0eb8d0caed79d76fbf5e1b70d78721f6097ac04"
+dependencies = [
+ "alloy-json-rpc",
+ "auto_impl",
+ "base64",
+ "derive_more",
+ "futures",
+ "futures-utils-wasm",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e79a2c1793afc61eed9ca0963da370a988b27d2bbfa67c78013e262d47424c4"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "itertools 0.14.0",
+ "reqwest",
+ "serde_json",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more",
+ "nybbles",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "406bc1183f6843e0aba09f7b3365e828b597213d60793ba5cb41befc863e3a78"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -478,6 +909,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +977,29 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
 
 [[package]]
 name = "aws-nitro-enclaves-nsm-api"
@@ -775,10 +1251,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "blst"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
+name = "borsh"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "bumpalo"
@@ -808,12 +1329,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "c-kzg"
+version = "2.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -957,10 +1495,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "const-hex"
@@ -1017,6 +1574,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,6 +1606,27 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -1115,6 +1703,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1773,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1204,10 +1850,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
@@ -1219,6 +1882,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
+ "serdect",
  "signature",
  "spki",
 ]
@@ -1240,6 +1904,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -1258,6 +1925,7 @@ dependencies = [
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -1295,7 +1963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1433,10 +2101,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-channel"
@@ -1445,6 +2143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1452,6 +2151,34 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "futures-sink"
@@ -1471,11 +2198,22 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
+
+[[package]]
+name = "futures-utils-wasm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
 name = "generic-array"
@@ -1530,6 +2268,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1552,7 +2296,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1578,6 +2322,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1590,6 +2346,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1607,6 +2368,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1725,6 +2492,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls 0.23.41",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,13 +2525,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1782,10 +2567,119 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "impl-codec"
@@ -1809,6 +2703,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
@@ -1827,6 +2732,12 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1868,6 +2779,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,6 +2857,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
+ "serdect",
  "sha2",
  "signature",
 ]
@@ -1966,6 +2937,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,6 +2956,21 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "macro-string"
@@ -2043,8 +3035,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05015102dad0f7d61691ca347e9d9d9006685a64aefb3d79eecf62665de2153d"
 dependencies = [
  "base64",
- "rustls",
- "rustls-webpki",
+ "rustls 0.21.12",
+ "rustls-webpki 0.101.7",
  "serde",
  "serde_json",
  "webpki-roots",
@@ -2052,9 +3044,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2122,6 +3114,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,6 +3139,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "nybbles"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
+dependencies = [
+ "alloy-rlp",
+ "cfg-if",
+ "proptest",
+ "ruint",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2157,6 +3200,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "p384"
@@ -2260,9 +3309,27 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2308,6 +3375,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,6 +3390,21 @@ dependencies = [
  "opaque-debug",
  "universal-hash",
 ]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2455,6 +3543,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.41",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.41",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2490,6 +3634,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -2624,6 +3769,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.41",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2715,7 +3897,7 @@ dependencies = [
  "baid64",
  "fast32",
  "fluent-uri",
- "indexmap",
+ "indexmap 2.13.0",
  "percent-encoding",
  "rand 0.9.2",
  "rgb-consensus",
@@ -2735,7 +3917,7 @@ dependencies = [
  "chrono",
  "esplora-client",
  "getrandom 0.3.4",
- "indexmap",
+ "indexmap 2.13.0",
  "nonasync",
  "rand 0.9.2",
  "rgb-aluvm",
@@ -2793,7 +3975,7 @@ checksum = "09dfaa85981472cf64009d0bc605891917b320b4f735644c2940c2574f525354"
 dependencies = [
  "amplify",
  "baid64",
- "indexmap",
+ "indexmap 2.13.0",
  "rgb-ascii-armor",
  "rgb-strict-encoding",
  "serde",
@@ -2911,7 +4093,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2922,9 +4104,72 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
 ]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.13",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.41",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.13",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -2933,6 +4178,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -2961,6 +4218,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2986,6 +4285,7 @@ dependencies = [
  "der",
  "generic-array",
  "pkcs8",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -2995,6 +4295,18 @@ name = "secp256k1"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.5",
+ "secp256k1-sys 0.10.1",
+ "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.5",
@@ -3038,6 +4350,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3147,16 +4482,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
 ]
 
 [[package]]
@@ -3236,6 +4613,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3246,6 +4645,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -3266,6 +4668,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -3334,6 +4742,20 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "tap"
@@ -3351,7 +4773,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3404,6 +4826,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3441,9 +4912,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3458,13 +4929,23 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls 0.23.41",
+ "tokio",
 ]
 
 [[package]]
@@ -3476,6 +4957,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -3527,7 +5009,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -3541,7 +5023,7 @@ version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.3",
@@ -3610,7 +5092,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.13.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -3619,6 +5101,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3780,9 +5280,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "utexo-bridge-enclave"
 version = "0.1.0"
 dependencies = [
+ "alloy",
  "alloy-primitives",
  "alloy-sol-types",
  "attestation-verify",
@@ -3809,6 +5323,7 @@ dependencies = [
  "sha3 0.10.8",
  "subtle",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "vsock",
@@ -3838,6 +5353,12 @@ dependencies = [
  "utexo-bridge-enclave",
  "vsock",
 ]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -3874,6 +5395,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3920,6 +5451,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3971,7 +5516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3984,8 +5529,51 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver 1.0.27",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3993,6 +5581,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "windows-core"
@@ -4181,7 +5778,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -4212,7 +5809,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -4231,7 +5828,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver 1.0.27",
  "serde",
@@ -4240,6 +5837,12 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -4275,6 +5878,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4295,6 +5921,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4308,6 +5955,39 @@ name = "zeroize_derive"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +16,19 @@ checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common 0.1.6",
  "generic-array",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -22,6 +41,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -29,20 +63,44 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ab0cd8afe573d1f7dc2353698a51b1f93aec362c8211e28cfd3948c6adba39"
+dependencies = [
+ "alloy-consensus 1.8.3",
+ "alloy-contract",
+ "alloy-core",
+ "alloy-eips 1.8.3",
+ "alloy-genesis",
+ "alloy-json-rpc 1.8.3",
+ "alloy-network 1.8.3",
+ "alloy-provider 1.8.3",
+ "alloy-rpc-client 1.8.3",
+ "alloy-rpc-types 1.8.3",
+ "alloy-serde 1.8.3",
+ "alloy-signer 1.8.3",
+ "alloy-signer-local",
+ "alloy-transport 1.8.3",
+ "alloy-transport-http 1.8.3",
+ "alloy-trie",
+]
+
+[[package]]
+name = "alloy"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9677ab3454c237abe6307805bea17a7912b3a516b606c7b4d3d948b9fede137"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 2.1.1",
  "alloy-core",
- "alloy-eips",
- "alloy-network",
- "alloy-provider",
- "alloy-rpc-client",
- "alloy-rpc-types",
- "alloy-serde",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-eips 2.1.1",
+ "alloy-network 2.1.1",
+ "alloy-provider 2.1.1",
+ "alloy-rpc-client 2.1.1",
+ "alloy-rpc-types 2.1.1",
+ "alloy-serde 2.1.1",
+ "alloy-transport 2.1.1",
+ "alloy-transport-http 2.1.1",
  "alloy-trie",
 ]
 
@@ -54,7 +112,34 @@ checksum = "3b5cc30538e90795a57647bef8d8864aad6e8d86190617009b4ef8d8b647b49a"
 dependencies = [
  "alloy-primitives",
  "num_enum",
- "phf",
+ "phf 0.14.0",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
+dependencies = [
+ "alloy-eips 1.8.3",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 1.8.3",
+ "alloy-trie",
+ "alloy-tx-macros 1.8.3",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "k256",
+ "once_cell",
+ "rand 0.8.5",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -63,12 +148,12 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ff0c4adba2abdcd9fb5829ae5f4394c06f8585ed283a9ba79aa33763c802e1"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 2.1.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.1.1",
  "alloy-trie",
- "alloy-tx-macros",
+ "alloy-tx-macros 2.1.1",
  "auto_impl",
  "borsh",
  "c-kzg",
@@ -86,16 +171,53 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
+dependencies = [
+ "alloy-consensus 1.8.3",
+ "alloy-eips 1.8.3",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 1.8.3",
+ "serde",
+]
+
+[[package]]
+name = "alloy-consensus-any"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cdf48932b1db3216175e19a2b476d89d53076e004850ee7983c6807ba0fde74"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.1.1",
+ "alloy-eips 2.1.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.1.1",
  "serde",
+]
+
+[[package]]
+name = "alloy-contract"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ac9e0c34dc6bce643b182049cdfcca1b8ce7d9c260cbdd561f511873b7e26cd"
+dependencies = [
+ "alloy-consensus 1.8.3",
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-network 1.8.3",
+ "alloy-network-primitives 1.8.3",
+ "alloy-primitives",
+ "alloy-provider 1.8.3",
+ "alloy-rpc-types-eth 1.8.3",
+ "alloy-sol-types",
+ "alloy-transport 1.8.3",
+ "futures",
+ "futures-util",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -104,8 +226,27 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62ddde5968de6044d67af107ad835bc0069a7ca245870b94c5958a7d8712b184"
 dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-sol-types",
+]
+
+[[package]]
+name = "alloy-dyn-abi"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a475bb02d9cef2dbb99065c1664ab3fe1f9352e21d6d5ed3f02cdbfc06ed1abc"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "itoa",
+ "serde",
+ "serde_json",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -142,6 +283,21 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "borsh",
+ "k256",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eip7928"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -162,6 +318,31 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928 0.3.7",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 1.8.3",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "alloy-eips"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea4c0453065b9206acc0f869a258dc8dcbbd595e144b4446f2c493a24a814d1f"
@@ -169,10 +350,10 @@ dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-eip7928",
+ "alloy-eip7928 0.4.5",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.1.1",
  "auto_impl",
  "borsh",
  "c-kzg",
@@ -180,7 +361,22 @@ dependencies = [
  "either",
  "serde",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf9480307b09d22876efb67d30cadd9013134c21f3a17ec9f93fd7536d38024"
+dependencies = [
+ "alloy-eips 1.8.3",
+ "alloy-primitives",
+ "alloy-serde 1.8.3",
+ "alloy-trie",
+ "borsh",
+ "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -197,13 +393,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422d110f1c40f1f8d0e5562b0b649c35f345fccb7093d9f02729943dcd1eef71"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "http 1.4.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-json-rpc"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4691c60de5d628533752cd07e102d17c47874c06c04c91af33960fd94c484f4"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "http",
+ "http 1.4.0",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -212,20 +423,46 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7197a66d94c4de1591cdc16a9bcea5f8cccd0da81b865b49aef97b1b4016e0fa"
+dependencies = [
+ "alloy-consensus 1.8.3",
+ "alloy-consensus-any 1.8.3",
+ "alloy-eips 1.8.3",
+ "alloy-json-rpc 1.8.3",
+ "alloy-network-primitives 1.8.3",
+ "alloy-primitives",
+ "alloy-rpc-types-any 1.8.3",
+ "alloy-rpc-types-eth 1.8.3",
+ "alloy-serde 1.8.3",
+ "alloy-signer 1.8.3",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "derive_more",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-network"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d912bb639bf4ac31e83095afe9e907c8b9774ce0c405966228368309fcfc45f"
 dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-json-rpc",
- "alloy-network-primitives",
+ "alloy-consensus 2.1.1",
+ "alloy-consensus-any 2.1.1",
+ "alloy-eips 2.1.1",
+ "alloy-json-rpc 2.1.1",
+ "alloy-network-primitives 2.1.1",
  "alloy-primitives",
- "alloy-rpc-types-any",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "alloy-signer",
+ "alloy-rpc-types-any 2.1.1",
+ "alloy-rpc-types-eth 2.1.1",
+ "alloy-serde 2.1.1",
+ "alloy-signer 2.1.1",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
@@ -238,14 +475,27 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
+dependencies = [
+ "alloy-consensus 1.8.3",
+ "alloy-eips 1.8.3",
+ "alloy-primitives",
+ "alloy-serde 1.8.3",
+ "serde",
+]
+
+[[package]]
+name = "alloy-network-primitives"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d875a11bd98595f57f73890f2e36f4a1cca0fa670623e59c9fb08b2389979c36"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 2.1.1",
+ "alloy-eips 2.1.1",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 2.1.1",
  "serde",
 ]
 
@@ -261,6 +511,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "foldhash 0.2.0",
+ "getrandom 0.4.2",
  "hashbrown 0.17.1",
  "indexmap 2.13.0",
  "itoa",
@@ -271,10 +522,49 @@ dependencies = [
  "rand 0.9.2",
  "rapidhash",
  "ruint",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "secp256k1 0.31.1",
  "serde",
  "sha3 0.11.0",
+]
+
+[[package]]
+name = "alloy-provider"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6b18b929ef1d078b834c3631e9c925177f3b23ddc6fa08a722d13047205876"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus 1.8.3",
+ "alloy-eips 1.8.3",
+ "alloy-json-rpc 1.8.3",
+ "alloy-network 1.8.3",
+ "alloy-network-primitives 1.8.3",
+ "alloy-primitives",
+ "alloy-rpc-client 1.8.3",
+ "alloy-rpc-types-eth 1.8.3",
+ "alloy-signer 1.8.3",
+ "alloy-sol-types",
+ "alloy-transport 1.8.3",
+ "alloy-transport-http 1.8.3",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "either",
+ "futures",
+ "futures-utils-wasm",
+ "lru",
+ "parking_lot 0.12.5",
+ "pin-project",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -284,18 +574,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7d526d184d392a8fbcf4293e457789b307bb70646e4f8b902989a246529450"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
- "alloy-json-rpc",
- "alloy-network",
- "alloy-network-primitives",
+ "alloy-consensus 2.1.1",
+ "alloy-eips 2.1.1",
+ "alloy-json-rpc 2.1.1",
+ "alloy-network 2.1.1",
+ "alloy-network-primitives 2.1.1",
  "alloy-primitives",
- "alloy-rpc-client",
- "alloy-rpc-types-eth",
- "alloy-signer",
+ "alloy-rpc-client 2.1.1",
+ "alloy-rpc-types-eth 2.1.1",
+ "alloy-signer 2.1.1",
  "alloy-sol-types",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 2.1.1",
+ "alloy-transport-http 2.1.1",
  "async-stream",
  "async-trait",
  "auto_impl",
@@ -304,9 +594,9 @@ dependencies = [
  "futures",
  "futures-utils-wasm",
  "lru",
- "parking_lot",
+ "parking_lot 0.12.5",
  "pin-project",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -340,25 +630,62 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.1.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755447dc13a04c6fa6db8dedb5d32ab5edfa4dd7aa34487ff192a3d873e0e8cf"
+checksum = "94fcc9604042ca80bd37aa5e232ea1cd851f337e31e2babbbb345bc0b1c30de3"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 1.8.3",
  "alloy-primitives",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 1.8.3",
+ "alloy-transport-http 1.8.3",
  "futures",
  "pin-project",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "url",
  "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "755447dc13a04c6fa6db8dedb5d32ab5edfa4dd7aa34487ff192a3d873e0e8cf"
+dependencies = [
+ "alloy-json-rpc 2.1.1",
+ "alloy-primitives",
+ "alloy-transport 2.1.1",
+ "alloy-transport-http 2.1.1",
+ "futures",
+ "pin-project",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4faad925d3a669ffc15f43b3deec7fbdf2adeb28a4d6f9cf4bc661698c0f8f4b"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-beacon",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth 1.8.3",
+ "alloy-serde 1.8.3",
+ "serde",
 ]
 
 [[package]]
@@ -368,9 +695,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96deb317fe224e98a8ae17a7ed7ea63478867385bf50b7abd53642b24cfd811a"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 2.1.1",
+ "alloy-serde 2.1.1",
  "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3823026d1ed239a40f12364fac50726c8daf1b6ab8077a97212c5123910429ed"
+dependencies = [
+ "alloy-consensus-any 1.8.3",
+ "alloy-rpc-types-eth 1.8.3",
+ "alloy-serde 1.8.3",
 ]
 
 [[package]]
@@ -379,13 +717,73 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "911a513723ef0b90c3b072f65eebf54d6ebc8b651d06734e252d024bd89b88ac"
 dependencies = [
- "alloy-consensus-any",
- "alloy-network-primitives",
+ "alloy-consensus-any 2.1.1",
+ "alloy-network-primitives 2.1.1",
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 2.1.1",
+ "alloy-serde 2.1.1",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "alloy-rpc-types-beacon"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f526dbd7bb039327cfd0ccf18c8a29ffd7402616b0c7a0239512bf8417d544c7"
+dependencies = [
+ "alloy-eips 1.8.3",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "derive_more",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tree_hash",
+ "tree_hash_derive",
+]
+
+[[package]]
+name = "alloy-rpc-types-engine"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb9b97b6e7965679ad22df297dda809b11cebc13405c1b537e5cffecc95834fa"
+dependencies = [
+ "alloy-consensus 1.8.3",
+ "alloy-eips 1.8.3",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 1.8.3",
+ "derive_more",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "rand 0.8.5",
+ "serde",
+ "strum 0.27.2",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
+dependencies = [
+ "alloy-consensus 1.8.3",
+ "alloy-consensus-any 1.8.3",
+ "alloy-eips 1.8.3",
+ "alloy-network-primitives 1.8.3",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 1.8.3",
+ "alloy-sol-types",
+ "itertools 0.13.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -394,19 +792,30 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e1bd19904581ee2075b61faabab1a4cefa8b96d8f2c85343adeae8ecf615e2b"
 dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-network-primitives",
+ "alloy-consensus 2.1.1",
+ "alloy-consensus-any 2.1.1",
+ "alloy-eips 2.1.1",
+ "alloy-network-primitives 2.1.1",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 2.1.1",
  "alloy-sol-types",
  "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -422,6 +831,21 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f447aefab0f1c0649f71edc33f590992d4e122bc35fb9cdbbf67d4421ace85"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "either",
+ "elliptic-curve",
+ "k256",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-signer"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6913d06ccc0d9c6ab67e2f82e2fbe292706da1f91442f30cded2d04b56bf0d58"
@@ -432,6 +856,22 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
+dependencies = [
+ "alloy-consensus 1.8.3",
+ "alloy-network 1.8.3",
+ "alloy-primitives",
+ "alloy-signer 1.8.3",
+ "async-trait",
+ "k256",
+ "rand 0.8.5",
  "thiserror 2.0.18",
 ]
 
@@ -455,9 +895,10 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
 dependencies = [
+ "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
- "heck",
+ "heck 0.5.0",
  "indexmap 2.13.0",
  "proc-macro-error2",
  "proc-macro2",
@@ -473,12 +914,14 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
 dependencies = [
+ "alloy-json-abi",
  "const-hex",
  "dunce",
- "heck",
+ "heck 0.5.0",
  "macro-string",
  "proc-macro2",
  "quote",
+ "serde_json",
  "syn 2.0.117",
  "syn-solidity",
 ]
@@ -507,25 +950,64 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.1.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "999adfe5c91035c6bf4c4210e0eb8d0caed79d76fbf5e1b70d78721f6097ac04"
+checksum = "8098f965442a9feb620965ba4b4be5e2b320f4ec5a3fff6bfa9e1ff7ef42bed1"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 1.8.3",
  "auto_impl",
- "base64",
+ "base64 0.22.1",
  "derive_more",
  "futures",
  "futures-utils-wasm",
- "parking_lot",
+ "parking_lot 0.12.5",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "url",
  "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999adfe5c91035c6bf4c4210e0eb8d0caed79d76fbf5e1b70d78721f6097ac04"
+dependencies = [
+ "alloy-json-rpc 2.1.1",
+ "auto_impl",
+ "base64 0.22.1",
+ "derive_more",
+ "futures",
+ "futures-utils-wasm",
+ "parking_lot 0.12.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower 0.5.3",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
+dependencies = [
+ "alloy-json-rpc 1.8.3",
+ "alloy-transport 1.8.3",
+ "itertools 0.13.0",
+ "reqwest 0.13.4",
+ "serde_json",
+ "tower 0.5.3",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -534,12 +1016,12 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e79a2c1793afc61eed9ca0963da370a988b27d2bbfa67c78013e262d47424c4"
 dependencies = [
- "alloy-json-rpc",
- "alloy-transport",
+ "alloy-json-rpc 2.1.1",
+ "alloy-transport 2.1.1",
  "itertools 0.14.0",
- "reqwest",
+ "reqwest 0.13.4",
  "serde_json",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "url",
 ]
@@ -562,11 +1044,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "alloy-tx-macros"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "406bc1183f6843e0aba09f7b3365e828b597213d60793ba5cb41befc863e3a78"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -699,6 +1193,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ark-bls12-381"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-r1cs-std",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-poly",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +1364,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "ark-r1cs-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-relations",
+ "ark-std 0.5.0",
+ "educe",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "tracing",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
+dependencies = [
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+ "tracing",
+ "tracing-subscriber 0.2.25",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,10 +1434,22 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
+ "ark-serialize-derive",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
  "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -909,6 +1504,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,6 +1558,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,7 +1576,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 name = "attestation-verify"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ciborium",
  "der",
  "hex",
@@ -959,6 +1584,16 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "x509-cert",
+]
+
+[[package]]
+name = "aurora-engine-modexp"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518bc5745a6264b5fd7b09dffb9667e400ee9e2bbe18555fac75e1fe9afa0df9"
+dependencies = [
+ "hex",
+ "num",
 ]
 
 [[package]]
@@ -1024,8 +1659,8 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "itoa",
  "matchit",
@@ -1035,7 +1670,7 @@ dependencies = [
  "pin-project-lite",
  "serde_core",
  "sync_wrapper",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -1048,8 +1683,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -1059,15 +1694,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "az"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
+
+[[package]]
 name = "baid64"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cb4a8b2f1afee4ef00a190b260ad871842b93206177b59631fecd325d48d538"
 dependencies = [
  "amplify",
- "base64",
+ "base64 0.22.1",
  "mnemonic",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1085,6 +1726,18 @@ dependencies = [
  "bitcoin-internals",
  "bitcoin_hashes",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -1112,6 +1765,15 @@ name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bip39"
@@ -1205,6 +1867,9 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitvec"
@@ -1214,6 +1879,7 @@ checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
+ "serde",
  "tap",
  "wyz",
 ]
@@ -1234,6 +1900,15 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -1248,6 +1923,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "bls12_381"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
+dependencies = [
+ "digest 0.9.0",
+ "ff",
+ "group",
+ "pairing",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1286,10 +1975,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8fb4fb5740e4b2c4884ff95f5f32f5e8479db1e8fd8eb49ddbe09eb09bb7c"
 dependencies = [
  "once_cell",
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -1299,6 +2009,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "serde_core",
 ]
 
 [[package]]
@@ -1312,6 +2032,12 @@ name = "byte-slice-cast"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -1473,7 +2199,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -1482,7 +2208,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1518,6 +2244,26 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "const-hex"
@@ -1575,6 +2321,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1621,6 +2377,39 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -1704,12 +2493,60 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1722,7 +2559,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "strsim",
+ "strsim 0.11.1",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core 0.13.4",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -1732,7 +2591,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -1748,8 +2607,14 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core",
+ "parking_lot_core 0.9.12",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -1793,6 +2658,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1847,6 +2723,27 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
  "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1931,6 +2828,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1978,6 +2896,73 @@ dependencies = [
  "minreq",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "ethereum_hashing"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "ring",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "ethereum_serde_utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38df44a7a271ab43835678f9215b53cc2523e4714a215da6643d83dc110245da"
+dependencies = [
+ "alloy-primitives",
+ "hex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "ethereum_ssz"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
+dependencies = [
+ "alloy-primitives",
+ "ethereum_serde_utils",
+ "itertools 0.13.0",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "typenum",
+]
+
+[[package]]
+name = "ethereum_ssz_derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -2032,6 +3017,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
+ "bitvec",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2041,6 +3027,20 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "toml",
+ "uncased",
+ "version_check",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -2073,6 +3073,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fluent-uri"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2099,6 +3109,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2193,6 +3218,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper",
+]
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2274,6 +3309,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "gloo-net"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a66b4e3c7d9ed8d315fd6b97c8b1f74a7c6ecbbc2320e65ae7ed38b7068cc620"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils",
+ "http 0.2.12",
+ "js-sys",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gmp-mpfr-sys"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db155b537cb791b133341f99f68371d86ee7fa4c79aacfbc376d72d23c70531"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,6 +3386,25 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -2295,7 +3418,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap 2.13.0",
  "slab",
  "tokio",
@@ -2328,6 +3451,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -2338,6 +3467,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
  "foldhash 0.1.5",
 ]
 
@@ -2365,9 +3495,168 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "helios-common"
+version = "0.11.1"
+source = "git+https://github.com/a16z/helios?tag=0.11.1#204c998a927348e1c000a664f08d5b37b1b0d924"
+dependencies = [
+ "alloy 1.8.3",
+ "async-trait",
+ "eyre",
+ "hex",
+ "revm",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "helios-consensus-core"
+version = "0.11.1"
+source = "git+https://github.com/a16z/helios?tag=0.11.1#204c998a927348e1c000a664f08d5b37b1b0d924"
+dependencies = [
+ "alloy 1.8.3",
+ "alloy-rlp",
+ "bls12_381",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "eyre",
+ "getrandom 0.2.17",
+ "serde",
+ "sha2 0.9.9",
+ "ssz_types",
+ "superstruct",
+ "thiserror 1.0.69",
+ "tracing",
+ "tree_hash",
+ "tree_hash_derive",
+ "typenum",
+ "wasmtimer",
+]
+
+[[package]]
+name = "helios-core"
+version = "0.11.1"
+source = "git+https://github.com/a16z/helios?tag=0.11.1#204c998a927348e1c000a664f08d5b37b1b0d924"
+dependencies = [
+ "alloy 1.8.3",
+ "alloy-trie",
+ "async-trait",
+ "eyre",
+ "futures",
+ "getrandom 0.3.4",
+ "helios-common",
+ "helios-verifiable-api-client",
+ "hex",
+ "jsonrpsee",
+ "openssl",
+ "parking_lot 0.12.5",
+ "reqwest 0.12.28",
+ "revm",
+ "schnellru",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+ "wasmtimer",
+]
+
+[[package]]
+name = "helios-ethereum"
+version = "0.11.1"
+source = "git+https://github.com/a16z/helios?tag=0.11.1#204c998a927348e1c000a664f08d5b37b1b0d924"
+dependencies = [
+ "alloy 1.8.3",
+ "alloy-trie",
+ "async-trait",
+ "chrono",
+ "dirs",
+ "eyre",
+ "figment",
+ "futures",
+ "getrandom 0.3.4",
+ "helios-common",
+ "helios-consensus-core",
+ "helios-core",
+ "helios-revm-utils",
+ "hex",
+ "openssl",
+ "parking_lot 0.12.5",
+ "reqwest 0.12.28",
+ "retri",
+ "revm",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "strum 0.26.3",
+ "superstruct",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tree_hash",
+ "typenum",
+ "url",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "helios-revm-utils"
+version = "0.11.1"
+source = "git+https://github.com/a16z/helios?tag=0.11.1#204c998a927348e1c000a664f08d5b37b1b0d924"
+dependencies = [
+ "alloy 1.8.3",
+ "eyre",
+ "helios-common",
+ "helios-core",
+ "hex",
+ "revm",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "helios-verifiable-api-client"
+version = "0.11.1"
+source = "git+https://github.com/a16z/helios?tag=0.11.1#204c998a927348e1c000a664f08d5b37b1b0d924"
+dependencies = [
+ "alloy 1.8.3",
+ "async-trait",
+ "eyre",
+ "helios-common",
+ "helios-verifiable-api-types",
+ "reqwest 0.12.28",
+ "reqwest-middleware",
+ "reqwest-retry",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "helios-verifiable-api-types"
+version = "0.11.1"
+source = "git+https://github.com/a16z/helios?tag=0.11.1#204c998a927348e1c000a664f08d5b37b1b0d924"
+dependencies = [
+ "alloy 1.8.3",
+ "helios-common",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -2397,6 +3686,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.2",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot 0.12.5",
+ "rand 0.9.2",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,6 +3751,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -2426,12 +3772,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -2442,8 +3799,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2470,6 +3827,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -2478,9 +3859,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -2493,16 +3874,32 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
  "rustls 0.23.41",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -2512,10 +3909,26 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2525,21 +3938,23 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2702,6 +4117,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2725,12 +4146,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.3",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2848,6 +4300,162 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f3783308bddc49d0218307f66a09330c106fbd792c58bac5c8dc294fdd0f98"
+dependencies = [
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-http-client",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-server",
+ "jsonrpsee-types",
+ "jsonrpsee-wasm-client",
+ "jsonrpsee-ws-client",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abc5630e4fa0096f00ec7b44d520701fda4504170cb85e22dca603ae5d7ad0d7"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "gloo-net",
+ "http 0.2.12",
+ "jsonrpsee-core",
+ "pin-project",
+ "rustls-native-certs 0.6.3",
+ "soketto",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tokio-util",
+ "tracing",
+ "webpki-roots 0.24.0",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa4c4d5fb801dcc316d81f76422db259809037a86b3194ae538dd026b05ed7"
+dependencies = [
+ "anyhow",
+ "async-lock",
+ "async-trait",
+ "beef",
+ "futures-timer",
+ "futures-util",
+ "globset",
+ "hyper 0.14.32",
+ "jsonrpsee-types",
+ "parking_lot 0.12.5",
+ "rand 0.8.5",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "soketto",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa7165efcbfbc951d180162ff28fe91b657ed81925e37a35e4a396ce12109f96"
+dependencies = [
+ "async-trait",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tower 0.4.13",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-proc-macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dc12b1d4f16a86e8c522823c4fab219c88c03eb7c924ec0501a64bf12e058b"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "jsonrpsee-server"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e79d78cfd5abd8394da10753723093c3ff64391602941c9c4b1d80a3414fd53"
+dependencies = [
+ "futures-util",
+ "hyper 0.14.32",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "serde",
+ "serde_json",
+ "soketto",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower 0.4.13",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00aa7cc87bc42e04e26c8ac3e7186142f7fd2949c763d9b6a7e64a69672d8fb2"
+dependencies = [
+ "anyhow",
+ "beef",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-wasm-client"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe953c2801356f214d3f4051f786b3d11134512a46763ee8c39a9e3fa2cc1c0"
+dependencies = [
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c71b2597ec1c958c6d5bc94bb61b44d74eb28e69dc421731ab0035706f13882"
+dependencies = [
+ "http 0.2.12",
+ "jsonrpsee-client-transport",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2858,7 +4466,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -2929,6 +4537,61 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libsecp256k1"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
+dependencies = [
+ "arrayref",
+ "base64 0.22.1",
+ "digest 0.9.0",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.9.9",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
+dependencies = [
+ "libsecp256k1-core",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -3029,17 +4692,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "minreq"
 version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05015102dad0f7d61691ca347e9d9d9006685a64aefb3d79eecf62665de2153d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "rustls 0.21.12",
  "rustls-webpki 0.101.7",
  "serde",
  "serde_json",
- "webpki-roots",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -3058,6 +4731,40 @@ name = "mnemonic"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b8f3a258db515d5e91a904ce4ae3f73e091149b90cadbdb93d210bee07f63b"
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot 0.12.5",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe 0.2.1",
+ "openssl-sys",
+ "schannel",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "nix"
@@ -3104,12 +4811,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
  "num-traits",
 ]
 
@@ -3125,6 +4855,27 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3164,6 +4915,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3188,6 +4940,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3202,10 +4958,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "p384"
@@ -3216,7 +5043,16 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "pairing"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
+dependencies = [
+ "group",
 ]
 
 [[package]]
@@ -3241,10 +5077,21 @@ version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
 ]
 
 [[package]]
@@ -3254,7 +5101,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.12",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -3265,7 +5126,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -3275,6 +5136,29 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -3316,11 +5200,54 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.11.3",
+ "serde",
+]
+
+[[package]]
+name = "phf"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.14.0",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3392,6 +5319,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,6 +5380,16 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
@@ -3483,6 +5426,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -3553,9 +5509,9 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "rustls 0.23.41",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3574,7 +5530,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "rustls 0.23.41",
  "rustls-pki-types",
  "slab",
@@ -3593,7 +5549,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -3719,7 +5675,17 @@ version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
 dependencies = [
+ "getrandom 0.3.4",
  "rustversion",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3729,6 +5695,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3770,18 +5747,60 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2 0.4.13",
+ "hickory-resolver",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.9",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
@@ -3795,14 +5814,265 @@ dependencies = [
  "serde_json",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
- "tower",
+ "tokio-rustls 0.26.4",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.4.0",
+ "reqwest 0.12.28",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "getrandom 0.2.17",
+ "http 1.4.0",
+ "hyper 1.8.1",
+ "parking_lot 0.11.2",
+ "reqwest 0.12.28",
+ "reqwest-middleware",
+ "retry-policies",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "wasm-timer",
+]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
+name = "retri"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c38316070fbd6504dcbb6042225f2608f2323c71155836c9b48f192113f68782"
+dependencies = [
+ "tokio",
+ "zduny-wasm-timer",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "revm"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718d90dce5f07e115d0e66450b1b8aa29694c1cf3f89ebddaddccc2ccbd2f13e"
+dependencies = [
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-inspector",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c52031b73cae95d84cd1b07725808b5fd1500da3e5e24574a3b2dc13d9f16d"
+dependencies = [
+ "bitvec",
+ "phf 0.11.3",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "revm-context"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a20c98e7008591a6f012550c2a00aa36cba8c14cc88eb88dec32eb9102554b4"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "10.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50d241ed1ce647b94caf174fcd0239b7651318b2c4c06b825b59b973dfb8495"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database"
+version = "7.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a276ed142b4718dcf64bc9624f474373ed82ef20611025045c3fb23edbef9c"
+dependencies = [
+ "alloy-eips 1.8.3",
+ "revm-bytecode",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "7.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c523c77e74eeedbac5d6f7c092e3851dbe9c7fec6f418b85992bd79229db361"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-handler"
+version = "10.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "550331ea85c1d257686e672081576172fe3d5a10526248b663bbf54f1bef226a"
+dependencies = [
+ "auto_impl",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "10.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c0a6e9ccc2ae006f5bed8bd80cd6f8d3832cd55c5e861b9402fdd556098512f"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-context",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-interpreter",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "25.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06575dc51b1d8f5091daa12a435733a90b4a132dca7ccee0666c7db3851bc30c"
+dependencies = [
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b57d4bd9e6b5fe469da5452a8a137bc2d030a3cd47c46908efc615bbc699da"
+dependencies = [
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "arrayref",
+ "aurora-engine-modexp",
+ "c-kzg",
+ "cfg-if",
+ "k256",
+ "libsecp256k1",
+ "p256",
+ "revm-primitives",
+ "ripemd",
+ "rug",
+ "secp256k1 0.31.1",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "20.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa29d9da06fe03b249b6419b33968ecdf92ad6428e2f012dc57bcd619b5d94e"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
+version = "7.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f64fbacb86008394aaebd3454f9643b7d5a782bd251135e17c5b33da592d84d"
+dependencies = [
+ "bitflags 2.11.0",
+ "revm-bytecode",
+ "revm-primitives",
+ "serde",
 ]
 
 [[package]]
@@ -3832,7 +6102,7 @@ dependencies = [
  "rgb-strict-types",
  "ripemd",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "wasm-bindgen",
 ]
 
@@ -3846,7 +6116,7 @@ dependencies = [
  "baid64",
  "base85",
  "rgb-strict-encoding",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3872,7 +6142,7 @@ dependencies = [
  "ripemd",
  "secp256k1 0.29.1",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "wasm-bindgen",
 ]
 
@@ -3961,7 +6231,7 @@ version = "1.0.1"
 source = "git+https://github.com/rgb-protocol/rgb-strict-encoding?branch=master#ddeae3b546b9668cda8fb11efa9eafd0c61ef467"
 dependencies = [
  "amplify_syn",
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3981,7 +6251,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "toml",
  "wasm-bindgen",
 ]
@@ -4020,6 +6290,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rug"
+version = "1.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07a8857882aec59d27254b02481c709327c13de6fad1da60bfc4f9783eaaa61e"
+dependencies = [
+ "az",
+ "gmp-mpfr-sys",
+ "libc",
+ "libm",
+]
+
+[[package]]
 name = "ruint"
 version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4055,9 +6337,18 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+dependencies = [
+ "rand 0.9.2",
+]
 
 [[package]]
 name = "rustc-hex"
@@ -4124,14 +6415,35 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -4150,16 +6462,16 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
  "rustls 0.23.41",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.4",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -4260,6 +6572,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "schnellru"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "356285bbf17bea63d9e52e96bd18f039672ac92b55b8cb997d6162a2a37d1649"
+dependencies = [
+ "ahash",
+ "cfg-if",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4354,12 +6677,25 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4398,6 +6734,12 @@ checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
 ]
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -4455,6 +6797,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -4482,12 +6825,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
@@ -4507,7 +6862,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4534,6 +6889,32 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -4613,6 +6994,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4651,12 +7038,38 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "soketto"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
+dependencies = [
+ "base64 0.13.1",
+ "bytes",
+ "futures",
+ "http 0.2.12",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha-1",
 ]
 
 [[package]]
@@ -4667,6 +7080,22 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "ssz_types"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b55bedc9a18ed2860a46d6beb4f4082416ee1d60be0cc364cebdcdddc7afd4"
+dependencies = [
+ "ethereum_serde_utils",
+ "ethereum_ssz",
+ "itertools 0.13.0",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "tree_hash",
+ "typenum",
 ]
 
 [[package]]
@@ -4693,15 +7122,78 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "superstruct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f4e1f478a7728f8855d7e620e9a152cf8932c6614f86564c886f9b8141f3201"
+dependencies = [
+ "darling 0.13.4",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "smallvec",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "syn"
@@ -4756,6 +7248,33 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"
@@ -4919,10 +7438,10 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
+ "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4936,6 +7455,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
 ]
 
 [[package]]
@@ -4968,6 +7507,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -5001,6 +7541,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -5052,22 +7603,22 @@ checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2",
+ "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5082,6 +7633,21 @@ dependencies = [
  "bytes",
  "prost",
  "tonic",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5109,13 +7675,18 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "pin-project-lite",
- "tower",
+ "tokio",
+ "tokio-util",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "url",
@@ -5139,6 +7710,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5178,6 +7750,15 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
@@ -5192,6 +7773,31 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tree_hash"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
+dependencies = [
+ "alloy-primitives",
+ "ethereum_hashing",
+ "ethereum_ssz",
+ "smallvec",
+ "typenum",
+]
+
+[[package]]
+name = "tree_hash_derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5229,6 +7835,15 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -5296,7 +7911,7 @@ dependencies = [
 name = "utexo-bridge-enclave"
 version = "0.1.0"
 dependencies = [
- "alloy",
+ "alloy 2.1.1",
  "alloy-primitives",
  "alloy-sol-types",
  "attestation-verify",
@@ -5306,6 +7921,7 @@ dependencies = [
  "chacha20poly1305",
  "federated-signer-proto",
  "getrandom 0.4.2",
+ "helios-ethereum",
  "hex",
  "hkdf",
  "hmac",
@@ -5319,13 +7935,13 @@ dependencies = [
  "rgb-schemas",
  "secrecy",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "sha3 0.10.8",
  "subtle",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
  "vsock",
  "x25519-dalek",
  "zeroize",
@@ -5343,13 +7959,13 @@ dependencies = [
  "hex",
  "prost",
  "rand 0.8.5",
- "sha2",
+ "sha2 0.10.9",
  "sha3 0.10.8",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
  "utexo-bridge-enclave",
  "vsock",
 ]
@@ -5367,10 +7983,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -5522,6 +8155,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5541,7 +8189,7 @@ checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
 dependencies = [
  "futures",
  "js-sys",
- "parking_lot",
+ "parking_lot 0.12.5",
  "pin-utils",
  "slab",
  "wasm-bindgen",
@@ -5578,9 +8226,40 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b291546d5d9d1eab74f069c77749f2cb8504a12caa20f0f2de93ddbf6f411888"
+dependencies = [
+ "rustls-webpki 0.101.7",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
@@ -5590,6 +8269,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -5633,6 +8318,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5652,11 +8348,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5670,19 +8375,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -5692,9 +8418,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5710,9 +8448,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5722,15 +8472,36 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"
@@ -5766,7 +8537,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -5777,7 +8548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap 2.13.0",
  "prettyplease",
  "syn 2.0.117",
@@ -5878,6 +8649,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
 name = "yoke"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5898,6 +8675,21 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zduny-wasm-timer"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52bd30296679f51dce4a4da2a5050d9401d09866d89b89d860da37bc3ec08df"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.12.5",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -5999,3 +8791,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3002,7 +3002,7 @@ dependencies = [
 [[package]]
 name = "federated-signer-proto"
 version = "0.1.0"
-source = "git+ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git?rev=f61dcb76595c69af914107a74852ad013afed9df#f61dcb76595c69af914107a74852ad013afed9df"
+source = "git+ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git?rev=295f9596ca78bba47f76985cdc405b712de025a1#295f9596ca78bba47f76985cdc405b712de025a1"
 dependencies = [
  "bytes",
  "prost",

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ nitro-cli terminate-enclave --enclave-id <enclave-id>
 | `HELIOS_EXECUTION_RPC` | (unset) | **`helios` builds (#77, experimental).** Loopback execution RPC Helios verifies. **Setting this selects the trustless Helios path** over the raw #60 path. |
 | `HELIOS_CONSENSUS_RPC` | `http://127.0.0.1:18550` | Loopback beacon (consensus) RPC for Helios light-client sync (`helios` builds) |
 | `HELIOS_CHECKPOINT` | (unset, **required**) | 0x 32-byte weak-subjectivity beacon block root, refreshed < ~2 weeks old. Without it Helios init fails closed (no untrusted community fallback). |
-| `HELIOS_NETWORK` | `mainnet` | `mainnet` \| `sepolia` \| `holesky` (`helios` builds) |
+| `HELIOS_NETWORK` | `mainnet` | `mainnet` \| `sepolia` \| `holesky` (`helios` builds). Must be consistent with the pinned `EVM_CHAIN_ID` (mainnet=1 / sepolia=11155111 / holesky=17000) or Helios init fails closed. |
 | `HELIOS_EXECUTION_VSOCK_PORT` / `HELIOS_CONSENSUS_VSOCK_PORT` | `8003` / `8004` | vsock ports for the host's Helios exec/consensus proxies |
 | `HELIOS_EXECUTION_LOCAL_PORT` / `HELIOS_CONSENSUS_LOCAL_PORT` | `18545` / `18550` | Loopback ports the enclave exposes those upstreams on |
 
@@ -398,7 +398,7 @@ DOCKER_BUILDKIT=1 docker build --ssh default \
 - **No unsafe code** — `#![deny(unsafe_code)]` enforced in the enclave crate.
 - **Zeroize-on-drop** — All seeds and private keys wrapped in `SecretBox`. Memory zeroed on drop.
 - **In-enclave RGB validation** — Consignments validated inside the TEE via rgbstd, not trusted from external sources.
-- **In-enclave EVM FundsIn verification** (`evm-rpc`, #60) — bridge-mode `signPsbt` confirms the EVM deposit itself via `eth_getTransactionReceipt`, instead of trusting the listener's `evm_event_valid`/`evm_event_finalized` flags (audit M-06 / #51). The RPC is reached through the untrusted host, so responses are treated as evidence (verified fail-closed) and this becomes trustless only once Helios (#77) verifies them.
+- **In-enclave EVM FundsIn verification** (`evm-rpc`, #60) — bridge-mode `signPsbt` confirms the EVM deposit itself via `eth_getTransactionReceipt`, instead of trusting the listener's `evm_event_valid`/`evm_event_finalized` flags (audit M-06 / #51). The RPC is reached through the untrusted host, so responses are treated as evidence (verified fail-closed) and this becomes trustless only once Helios (#77) verifies them. A build **without** this feature refuses bridge-mode `signPsbt` outright (the deposit cannot be verified), so production EIFs MUST enable `evm-rpc` (or `helios`).
 - **Trustless EVM verification via Helios** (`helios`, #77 — EXPERIMENTAL, default-OFF, not in the shipped EIF) — embeds the a16z Helios light client so the enclave cryptographically verifies the execution/consensus RPCs against a pinned weak-subjectivity checkpoint before accepting a FundsIn receipt. Runtime-selectable (`HELIOS_EXECUTION_RPC` set → verified path, else the #60 raw path) and fail-closed (an unsynced/errored Helios refuses signing, never downgrades). Heavy build (a second alloy major, revm, BLS, vendored OpenSSL); no production experience yet.
 - **Cross-check validation** — Amount consistency, calldata extraction, deadline, and chain/domain checks before any signature is produced.
 - **Seed import gated** — Raw seed import requires `allow-seed-import` feature, never enabled in production.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Cryptographic signing service for the UTEXO RGB-EVM bridge, running inside an [A
 │  └── TCP / vsock to enclave                                      │
 │                                                                  │
 │  vsock-proxy 8001 → Esplora API  (for RGB validation)            │
+│  vsock-proxy 8002 → EVM RPC      (for FundsIn verify, evm-rpc)   │
 │                                                                  │
 │  ┌────────────────────────────────────────────────────────────┐  │
 │  │  Nitro Enclave                                              │  │
@@ -206,6 +207,10 @@ nitro-cli run-enclave \
 # Start vsock-proxy for Esplora access (on the host)
 vsock-proxy 8001 <esplora-host> <esplora-port>
 
+# Start vsock-proxy for the EVM RPC (on the host) — only for `evm-rpc` builds,
+# used by in-enclave FundsIn verification (#60). Allowlist to the RPC endpoint.
+vsock-proxy 8002 <evm-rpc-host> <evm-rpc-port>
+
 # Start the gRPC server (Parent Adapter)
 GRPC_PORT=5000 USE_VSOCK=true cargo run --release -p utexo-bridge-parent
 ```
@@ -253,6 +258,9 @@ nitro-cli terminate-enclave --enclave-id <enclave-id>
 | `ESPLORA_URL` | `http://127.0.0.1:3443` | Esplora API endpoint for RGB validation |
 | `BITCOIN_NETWORK` | `bitcoin` | One of: `bitcoin`, `testnet`, `signet`, `regtest`. Affects BIP-86 coin type (0 vs 1) and xpub prefix (xpub vs tpub). |
 | `ESPLORA_VSOCK_PORT` | `8001` | vsock port for the host's vsock-proxy |
+| `EVM_RPC_URL` | `http://127.0.0.1:3444` | Loopback EVM JSON-RPC endpoint for in-enclave FundsIn verification (#60, `evm-rpc` builds). MUST be loopback — reached via the vsock forwarder. Responses are relayed by the untrusted host (evidence verified fail-closed; trustless only once Helios #77 lands). |
+| `EVM_RPC_VSOCK_PORT` | `8002` | vsock port for the host's EVM-RPC vsock-proxy (`evm-rpc` builds) |
+| `EVM_MIN_CONFIRMATIONS` | `12` | Minimum confirmation depth a FundsIn receipt must have (`evm-rpc` builds) |
 
 #### Parent Adapter
 
@@ -379,10 +387,11 @@ DOCKER_BUILDKIT=1 docker build --ssh default \
 - **No unsafe code** — `#![deny(unsafe_code)]` enforced in the enclave crate.
 - **Zeroize-on-drop** — All seeds and private keys wrapped in `SecretBox`. Memory zeroed on drop.
 - **In-enclave RGB validation** — Consignments validated inside the TEE via rgbstd, not trusted from external sources.
+- **In-enclave EVM FundsIn verification** (`evm-rpc`, #60) — bridge-mode `signPsbt` confirms the EVM deposit itself via `eth_getTransactionReceipt`, instead of trusting the listener's `evm_event_valid`/`evm_event_finalized` flags (audit M-06 / #51). The RPC is reached through the untrusted host, so responses are treated as evidence (verified fail-closed) and this becomes trustless only once Helios (#77) verifies them.
 - **Cross-check validation** — Amount consistency, calldata extraction, deadline, and chain/domain checks before any signature is produced.
 - **Seed import gated** — Raw seed import requires `allow-seed-import` feature, never enabled in production.
 - **Nitro Enclave isolation** — No persistent storage, no network access (only vsock), no shell.
-- **vsock-proxy allowlist** — Enclave can only reach Esplora through the host's vsock-proxy with explicit allowlist.
+- **vsock-proxy allowlist** — Enclave can only reach Esplora (and, for `evm-rpc` builds, the EVM RPC) through the host's vsock-proxy with explicit allowlist.
 - **Release hardening** — `opt-level = "z"`, LTO, symbol stripping, `panic = "abort"`, single codegen unit.
 - **gRPC localhost-only** — Parent Adapter binds to `127.0.0.1`, not `0.0.0.0`.
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,11 @@ vsock-proxy 8001 <esplora-host> <esplora-port>
 # used by in-enclave FundsIn verification (#60). Allowlist to the RPC endpoint.
 vsock-proxy 8002 <evm-rpc-host> <evm-rpc-port>
 
+# Trustless (Helios) variant — only for `helios` builds (#77, experimental).
+# Two upstreams Helios verifies against a pinned checkpoint:
+vsock-proxy 8003 <evm-execution-rpc-host> <port>   # HELIOS_EXECUTION_RPC
+vsock-proxy 8004 <beacon-consensus-rpc-host> <port> # HELIOS_CONSENSUS_RPC
+
 # Start the gRPC server (Parent Adapter)
 GRPC_PORT=5000 USE_VSOCK=true cargo run --release -p utexo-bridge-parent
 ```
@@ -260,7 +265,13 @@ nitro-cli terminate-enclave --enclave-id <enclave-id>
 | `ESPLORA_VSOCK_PORT` | `8001` | vsock port for the host's vsock-proxy |
 | `EVM_RPC_URL` | `http://127.0.0.1:3444` | Loopback EVM JSON-RPC endpoint for in-enclave FundsIn verification (#60, `evm-rpc` builds). MUST be loopback — reached via the vsock forwarder. Responses are relayed by the untrusted host (evidence verified fail-closed; trustless only once Helios #77 lands). |
 | `EVM_RPC_VSOCK_PORT` | `8002` | vsock port for the host's EVM-RPC vsock-proxy (`evm-rpc` builds) |
-| `EVM_MIN_CONFIRMATIONS` | `12` | Minimum confirmation depth a FundsIn receipt must have (`evm-rpc` builds) |
+| `EVM_MIN_CONFIRMATIONS` | `12` | Minimum confirmation depth a FundsIn receipt must have (`evm-rpc` / `helios` builds) |
+| `HELIOS_EXECUTION_RPC` | (unset) | **`helios` builds (#77, experimental).** Loopback execution RPC Helios verifies. **Setting this selects the trustless Helios path** over the raw #60 path. |
+| `HELIOS_CONSENSUS_RPC` | `http://127.0.0.1:18550` | Loopback beacon (consensus) RPC for Helios light-client sync (`helios` builds) |
+| `HELIOS_CHECKPOINT` | (unset, **required**) | 0x 32-byte weak-subjectivity beacon block root, refreshed < ~2 weeks old. Without it Helios init fails closed (no untrusted community fallback). |
+| `HELIOS_NETWORK` | `mainnet` | `mainnet` \| `sepolia` \| `holesky` (`helios` builds) |
+| `HELIOS_EXECUTION_VSOCK_PORT` / `HELIOS_CONSENSUS_VSOCK_PORT` | `8003` / `8004` | vsock ports for the host's Helios exec/consensus proxies |
+| `HELIOS_EXECUTION_LOCAL_PORT` / `HELIOS_CONSENSUS_LOCAL_PORT` | `18545` / `18550` | Loopback ports the enclave exposes those upstreams on |
 
 #### Parent Adapter
 
@@ -388,6 +399,7 @@ DOCKER_BUILDKIT=1 docker build --ssh default \
 - **Zeroize-on-drop** — All seeds and private keys wrapped in `SecretBox`. Memory zeroed on drop.
 - **In-enclave RGB validation** — Consignments validated inside the TEE via rgbstd, not trusted from external sources.
 - **In-enclave EVM FundsIn verification** (`evm-rpc`, #60) — bridge-mode `signPsbt` confirms the EVM deposit itself via `eth_getTransactionReceipt`, instead of trusting the listener's `evm_event_valid`/`evm_event_finalized` flags (audit M-06 / #51). The RPC is reached through the untrusted host, so responses are treated as evidence (verified fail-closed) and this becomes trustless only once Helios (#77) verifies them.
+- **Trustless EVM verification via Helios** (`helios`, #77 — EXPERIMENTAL, default-OFF, not in the shipped EIF) — embeds the a16z Helios light client so the enclave cryptographically verifies the execution/consensus RPCs against a pinned weak-subjectivity checkpoint before accepting a FundsIn receipt. Runtime-selectable (`HELIOS_EXECUTION_RPC` set → verified path, else the #60 raw path) and fail-closed (an unsynced/errored Helios refuses signing, never downgrades). Heavy build (a second alloy major, revm, BLS, vendored OpenSSL); no production experience yet.
 - **Cross-check validation** — Amount consistency, calldata extraction, deadline, and chain/domain checks before any signature is produced.
 - **Seed import gated** — Raw seed import requires `allow-seed-import` feature, never enabled in production.
 - **Nitro Enclave isolation** — No persistent storage, no network access (only vsock), no shell.

--- a/build/Dockerfile.enclave
+++ b/build/Dockerfile.enclave
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-# Production enclave image (vsock + rgb-validation + spv).
+# Production enclave image (vsock + rgb-validation + spv + evm-rpc).
 # Usage:
 #   DOCKER_BUILDKIT=1 docker build --ssh default \
 #     -f build/Dockerfile.enclave -t utexo-bridge-enclave .
@@ -36,7 +36,11 @@ WORKDIR /build/enclave
 # `--mount=type=ssh` exposes the SSH_AUTH_SOCK forwarded by `--ssh default`
 # only for the duration of this RUN, so no credentials end up in the
 # image layers.
-RUN --mount=type=ssh cargo build --release --features vsock,rgb-validation,spv
+# `evm-rpc` adds in-enclave FundsIn event verification (#60); it pulls the
+# alloy + tokio subtree, which grows the binary and therefore PCR0 - pinned via
+# Cargo.lock for reproducibility. Requires a second host vsock-proxy for the
+# EVM RPC (EVM_RPC_VSOCK_PORT, default 8002).
+RUN --mount=type=ssh cargo build --release --features vsock,rgb-validation,spv,evm-rpc
 
 # --- Runtime ---
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal AS runtime

--- a/build/Dockerfile.enclave
+++ b/build/Dockerfile.enclave
@@ -9,7 +9,7 @@
 # over SSH. The same SSH mount is also used for the private `rgb-consignment`
 # git dependency pulled by the `rgb-validation`/`spv` features.
 
-FROM rust:1.89-slim AS builder
+FROM rust:1.96-slim AS builder
 
 # `git` + `openssh-client`: the workspace `[patch.crates-io]` uses public
 # git URLs for rgb-consensus / rgb-ops / rgb-invoicing / rgb-strict-encoding,

--- a/build/Dockerfile.enclave-dev
+++ b/build/Dockerfile.enclave-dev
@@ -12,7 +12,7 @@
 # loads the required deploy key.
 
 # ===== Builder Stage =====
-FROM rust:1.89-slim AS builder
+FROM rust:1.96-slim AS builder
 
 # `git` + `openssh-client`: the workspace `[patch.crates-io]` uses public
 # git URLs for rgb-consensus / rgb-ops / rgb-invoicing / rgb-strict-encoding,

--- a/build/Dockerfile.parent
+++ b/build/Dockerfile.parent
@@ -18,7 +18,7 @@
 #     utexo-bridge-parent
 
 # ===== Builder Stage =====
-FROM rust:1.89-slim AS builder
+FROM rust:1.96-slim AS builder
 
 # `git` + `ca-certificates`: the workspace `[patch.crates-io]` rewrites
 # rgb-consensus / rgb-ops / rgb-invoicing / rgb-strict-encoding to public

--- a/docs/diagrams/01-components.md
+++ b/docs/diagrams/01-components.md
@@ -35,7 +35,7 @@ flowchart TB
         EFr[framing.rs<br/>len-prefixed proto, 4 MB cap]
         EErr[error.rs<br/>EnclaveError + error_code]
         BCfg[config.rs<br/>BridgeConfig env-pinned<br/>chain_id / contract / rgb_asset_id]
-        VFwd[vsock_forwarder.rs<br/>TCP 127.0.0.1:3443<br/>→ vsock CID 3:8001]
+        VFwd[vsock_forwarder.rs<br/>loopback → vsock, per-port instances<br/>3443→8001 Esplora, 3444→8002 EVM RPC,<br/>18545→8003 / 18550→8004 Helios]
 
         subgraph KEYS [keys.rs]
             KM[KeyManager<br/>BIP-39/32/84/86<br/>SecretBox seed + keys]
@@ -47,9 +47,11 @@ flowchart TB
         end
         subgraph VAL [validation/]
             VEvm[evm_crosscheck.rs<br/>selector allowlist + pinned-config<br/>amount bound to consignment<br/>funds_out burn/transfer]
-            VPsbt[psbt_crosscheck.rs<br/>bridge vs vanilla<br/>amount consistency]
+            VPsbt[psbt_crosscheck.rs<br/>bridge vs vanilla<br/>amount + consignment bind]
             VRgb[rgb.rs<br/>rgbstd Transfer<br/>+ Esplora resolver]
             VSpv[spv_crosscheck.rs<br/>coverage + depth<br/>+ chain_net + staleness]
+            VEvt[evm_event.rs<br/>independent FundsIn verify<br/>alloy #60 / Helios #77<br/>evm-rpc / helios features]
+            VGas[evm_gas_tx.rs<br/>gas-tx shape allowlist]
         end
         subgraph SPVMOD [spv/]
             SCh[chain.rs<br/>HeaderChain<br/>bounded reorg ≤100]
@@ -68,6 +70,8 @@ flowchart TB
     NSM[(AWS NSM device<br/>/dev/nsm)]
     Esp{{Esplora indexer}}
     VP[(host vsock-proxy<br/>port 8001)]
+    EvmRpc{{EVM JSON-RPC / Helios<br/>exec + consensus upstreams}}
+    VPe[(host vsock-proxy<br/>8002 / 8003 / 8004)]
 
     %% Wires
     L -->|"gRPC EnclaveService<br/>Sign / PublicKey / Initialize / Clone /<br/>SubmitHeaders / GetLastSavedBlock /<br/>AttestedPublicKey"| PMain
@@ -102,6 +106,12 @@ flowchart TB
     VRgb -.->|"HTTP"| VFwd
     VFwd -->|"vsock CID 3:8001"| VP
     VP -->|"real HTTP"| Esp
+
+    ESrv --> VEvt
+    ESrv --> VGas
+    VEvt -.->|"eth_getTransactionReceipt /<br/>eth_blockNumber (host-relayed evidence,<br/>Helios-verified in #77)"| VFwd
+    VFwd -->|"vsock 8002 / 8003 / 8004"| VPe
+    VPe -->|"real HTTP"| EvmRpc
 
     VSpv --> SCh
     VSpv --> SMk

--- a/docs/diagrams/02-deployment.md
+++ b/docs/diagrams/02-deployment.md
@@ -13,20 +13,23 @@ flowchart TB
     subgraph EC2 [EC2 instance — Nitro-enabled, UNTRUSTED parent host]
         Parent[utexo-bridge-parent<br/>tonic gRPC, 127.0.0.1:5000<br/>―<br/>Bound to 127.0.0.1 only.<br/>30 s timeout per enclave RPC.<br/>USE_VSOCK=true in production.]
         Cli[utexo-bridge-parent-cli<br/>attest-verify CLI]
-        VP[vsock-proxy port 8001<br/>―<br/>Allowlist points to the<br/>Esplora endpoint only.]
+        VP[vsock-proxy port 8001<br/>―<br/>Allowlist → Esplora endpoint.]
+        VPe[vsock-proxy 8002 / 8003 / 8004<br/>―<br/>evm-rpc / helios builds only.<br/>8002 → EVM JSON-RPC (#60);<br/>8003 / 8004 → Helios exec / consensus (#77).<br/>Allowlisted per upstream.]
 
         subgraph ENCL [AWS Nitro Enclave — TRUSTED, PCR-pinned]
             Bin[utexo-bridge-enclave<br/>static-linked Rust<br/>―<br/>Listens on vsock CID 16, port 5000.<br/>One connection = one request.<br/>No filesystem persistence.<br/>No shell. No /dev access except /dev/nsm.<br/>Bridge config pinned from env at boot<br/>EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID<br/>→ bound into attestation.]
             Headers[(Header chain<br/>in-memory)]
             State[(EnclaveState<br/>Phase + KeyManager in SecretBox)]
             Replay[(NonceReplayGuard<br/>≤10 000 entries)]
-            Fwd[vsock_forwarder<br/>TCP 127.0.0.1:3443 → vsock]
+            Fwd[vsock_forwarder<br/>loopback → vsock, per-port<br/>3443/3444/18545/18550]
             RgbVal[RgbValidator<br/>rgbstd + Esplora HTTP]
+            EvmVer[evm_event verifier<br/>alloy #60 / Helios #77<br/>fail-closed FundsIn check]
             NSM[/dev/nsm — Nitro Security Module/]
         end
     end
 
     Esp{{Esplora API}}
+    EvmRpc{{EVM JSON-RPC / Helios<br/>exec + consensus upstreams}}
 
     V -->|"gRPC /50051<br/>AttestedPublicKey(nonce)"| Parent
     L -->|"gRPC /5000<br/>Sign / PublicKey / SubmitHeaders ..."| Parent
@@ -38,11 +41,15 @@ flowchart TB
     Bin --> Replay
     Bin --> Headers
     Bin --> RgbVal
+    Bin --> EvmVer
     Bin -->|"DescribePCR / Attestation"| NSM
     Bin -->|"intra-enclave loopback"| Fwd
     RgbVal --> Fwd
+    EvmVer --> Fwd
     Fwd -->|"vsock CID 3:8001"| VP
+    Fwd -->|"vsock CID 3:8002/8003/8004"| VPe
     VP -->|"real HTTP"| Esp
+    VPe -->|"real HTTP"| EvmRpc
 ```
 
 ### Build / cluster notes
@@ -52,3 +59,10 @@ flowchart TB
   verifiers reject.
 - A cluster of N ≥ 2 EC2 instances share **one HD seed** via the cloning handshake.
   Each node holds an identical `KeyManager` after `Cloning → Active`.
+- **Bridge-mode `signPsbt` requires the `evm-rpc` feature** (or `helios`): a build
+  without it refuses bridge PSBTs, since it cannot independently verify the EVM
+  `FundsIn` deposit (audit M-06 / #60, #51). Operators MUST run the matching host
+  `vsock-proxy` allowlists (8002 for `evm-rpc`; 8003 + 8004 for `helios`). Env:
+  `EVM_RPC_URL` / `EVM_MIN_CONFIRMATIONS`, and for Helios `HELIOS_EXECUTION_RPC`
+  (selects the trustless path), `HELIOS_CHECKPOINT` (required), `HELIOS_NETWORK`
+  (must match `EVM_CHAIN_ID`). See the README env table.

--- a/docs/diagrams/02-deployment.md
+++ b/docs/diagrams/02-deployment.md
@@ -14,7 +14,7 @@ flowchart TB
         Parent[utexo-bridge-parent<br/>tonic gRPC, 127.0.0.1:5000<br/>―<br/>Bound to 127.0.0.1 only.<br/>30 s timeout per enclave RPC.<br/>USE_VSOCK=true in production.]
         Cli[utexo-bridge-parent-cli<br/>attest-verify CLI]
         VP[vsock-proxy port 8001<br/>―<br/>Allowlist → Esplora endpoint.]
-        VPe[vsock-proxy 8002 / 8003 / 8004<br/>―<br/>evm-rpc / helios builds only.<br/>8002 → EVM JSON-RPC (#60);<br/>8003 / 8004 → Helios exec / consensus (#77).<br/>Allowlisted per upstream.]
+        VPe["vsock-proxy 8002 / 8003 / 8004<br/>―<br/>evm-rpc / helios builds only.<br/>8002 → EVM JSON-RPC #60.<br/>8003 / 8004 → Helios exec / consensus #77.<br/>Allowlisted per upstream."]
 
         subgraph ENCL [AWS Nitro Enclave — TRUSTED, PCR-pinned]
             Bin[utexo-bridge-enclave<br/>static-linked Rust<br/>―<br/>Listens on vsock CID 16, port 5000.<br/>One connection = one request.<br/>No filesystem persistence.<br/>No shell. No /dev access except /dev/nsm.<br/>Bridge config pinned from env at boot<br/>EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID<br/>→ bound into attestation.]

--- a/docs/diagrams/04-seq-sign-psbt.md
+++ b/docs/diagrams/04-seq-sign-psbt.md
@@ -7,30 +7,55 @@ sequenceDiagram
     participant Parent as utexo-bridge-parent<br/>(grpc_server.rs)
     participant Srv as enclave/server.rs<br/>handle_sign_psbt
     participant PsbtCx as validation::psbt_crosscheck
+    participant Rgb as validation::rgb<br/>(rgbstd + Esplora + SPV)
+    participant Evt as validation::evm_event
+    participant Rpc as EVM RPC / Helios<br/>loopback→vsock→host
+    participant State as EnclaveState<br/>op_replay_guard
     participant Km as KeyManager::sign_psbt
     participant Tap as signing::taproot<br/>find_taproot_sign_jobs
     participant Sw as signing::psbt<br/>should_sign_segwit_input
     participant Crypto as secp256k1 / k256
 
     Note over Orc,Listener: Intent
-    Orc->>Listener: bridge intent (FundsIn event observed on EVM)
-    Listener->>Listener: fetch PSBT from rgb-multisig-bridge,<br/>enrich with EVM event fields
+    Orc->>Listener: bridge intent (FundsIn deposit observed on EVM)
+    Listener->>Listener: fetch PSBT from rgb-multisig-bridge,<br/>enrich with EVM event fields + RGB consignment
     Listener->>Parent: gRPC Sign(TRANSACTION, EnrichedPsbtPayload)
 
     Note over Parent,Srv: Translate
-    Parent->>Srv: SignPsbtRequest (psbt_bytes, evm_tx_hash, amounts, ...)
+    Parent->>Srv: SignPsbtRequest (psbt_bytes, evm_tx_hash, operation_idx,<br/>amounts, consignment, ...)
 
-    Note over Srv,PsbtCx: Cross-checks
+    Note over Srv,PsbtCx: Shape + amount cross-checks (skipped in dev-mode)
     Srv->>PsbtCx: validate_psbt_request(req)
     PsbtCx->>PsbtCx: PSBT shape whitelist (#40):<br/>psbt_bytes non-empty,<br/>Psbt::deserialize ok,<br/>unsigned tx has ≥ 1 input
-    alt evm_tx_hash empty (vanilla)
-        PsbtCx-->>Srv: Ok — only psbt_bytes required
+    alt evm_tx_hash empty (vanilla, e.g. create_utxo)
+        PsbtCx-->>Srv: Ok — only psbt_bytes required, skip bridge checks
     else bridge mode
         PsbtCx->>PsbtCx: len(evm_tx_hash) == 32
-        PsbtCx->>PsbtCx: evm_event_valid && evm_event_finalized
-        PsbtCx->>PsbtCx: evm_amount ≥ psbt_output_amount + commission
+        Note right of PsbtCx: listener evm_event_valid /<br/>evm_event_finalized are IGNORED (#51) —<br/>validity/finality established below, not trusted
+        PsbtCx->>PsbtCx: evm_amount ≥ psbt_output_amount + evm_commission
     end
     PsbtCx-->>Srv: Ok / CrossCheck err
+
+    Note over Srv,State: Bridge-mode authorisation (bridge mode only)
+    opt rgb-validation build — send-RGB consignment binding (#79)
+        Srv->>Rgb: psbt_consignment_crosscheck: validate_consignment<br/>(rgbstd + Esplora resolver + SPV anchoring)
+        Rgb-->>Srv: ValidatedConsignment / REFUSE
+        Srv->>Srv: keccak256(consignment)==consignment_hash;<br/>contract_id==pinned RGB_ASSET_ID;<br/>unsigned txid==last TS_TRANSFER witness txid;<br/>input prevouts match; sighash ALL/DEFAULT;<br/>total_output ≥ evm_amount − evm_commission
+    end
+    alt evm-rpc build — independent FundsIn verification (M-06 / #60, #77)
+        Srv->>Evt: verify_funds_in_event(PINNED contract, EVM_MIN_CONFIRMATIONS,<br/>tx_hash, operation_id, evm_amount, evm_commission)
+        Evt->>Rpc: eth_getTransactionReceipt / eth_blockNumber
+        Note right of Rpc: raw alloy path = host-relayed evidence (#60);<br/>Helios path = cryptographically verified in-TEE (#77)
+        Rpc-->>Evt: receipt / head (or none)
+        Evt->>Evt: receipt exists + status success;<br/>UNIQUE FundsIn/BridgeFundsIn log from PINNED contract;<br/>operationId/amount/commission bind (net==gross−commission);<br/>depth ≥ EVM_MIN_CONFIRMATIONS
+        Evt-->>Srv: Ok / CrossCheck err (fail closed)
+    else no evm-rpc feature (bridge mode)
+        Srv->>Srv: REFUSE — deposit cannot be independently verified;<br/>rebuild with --features evm-rpc (or helios)
+    end
+    opt bridge mode — soft replay guard (#84)
+        Srv->>State: op_replay_guard.check_and_record(op_key)
+        State-->>Srv: Ok / duplicate operation → REFUSE
+    end
 
     Note over Srv,Km: Sign PSBT inputs
     Srv->>Km: sign_psbt(psbt_bytes)
@@ -81,7 +106,35 @@ sequenceDiagram
     end
 
     Km-->>Srv: (signed_psbt_bytes, inputs_signed)
+    Srv->>Srv: reject inputs_signed == 0 (#85, no-op not a contribution)
     Srv-->>Parent: SignedPsbtResponse
     Parent-->>Listener: gRPC Signature
     Listener-->>Orc: signed PSBT (assembles + broadcasts)
+```
+
+## FundsIn verification predicate (`validation::evm_event`, #60 / #77)
+
+Bridge-mode `signPsbt` releases RGB against an EVM deposit. The listener-supplied
+`evm_event_valid` / `evm_event_finalized` booleans are **no longer trusted** (audit
+M-06 / #51); the enclave establishes validity + finality itself, fail-closed:
+
+1. **Receipt exists** for `evm_tx_hash` — `None` (not mined / host withheld) → refuse.
+2. **Receipt status == success** — a reverted tx emits no real `FundsIn`.
+3. **Unique** `FundsIn` / `BridgeFundsIn` log from the **pinned** `BRIDGE_CONTRACT`
+   (address from config, never the request); multiple matches are ambiguous → refuse.
+4. **Field binding** — decoded `operationId` (== `operation_idx`), gross `amount`
+   (== `evm_amount`), `tokenCommission` (== `evm_commission`), and the internal
+   `net == gross − commission`. A `uint256` exceeding `u64` is rejected, not truncated.
+5. **Confirmation depth** — `head − receipt.block` ≥ `EVM_MIN_CONFIRMATIONS`
+   (default 12); a receipt block above head (reorg) → refuse.
+
+**Provider selection (build/runtime):**
+- No `evm-rpc` feature → bridge-mode `signPsbt` is **refused** (deposit unverifiable).
+- `evm-rpc` → raw alloy JSON-RPC over the loopback vsock forwarder; responses are
+  **host-relayed evidence**, verified fail-closed but not trustless.
+- `helios` + `HELIOS_EXECUTION_RPC` set → the a16z Helios light client verifies the
+  execution/consensus RPCs against a pinned checkpoint **inside the TEE** (trustless);
+  `HELIOS_NETWORK` must be consistent with the pinned `EVM_CHAIN_ID`.
+
+See [`10-signing-gate.md`](10-signing-gate.md) for the `fundsOut` (RGB → EVM) direction.
 ```

--- a/docs/diagrams/04-seq-sign-psbt.md
+++ b/docs/diagrams/04-seq-sign-psbt.md
@@ -40,17 +40,17 @@ sequenceDiagram
     opt rgb-validation build — send-RGB consignment binding (#79)
         Srv->>Rgb: psbt_consignment_crosscheck: validate_consignment<br/>(rgbstd + Esplora resolver + SPV anchoring)
         Rgb-->>Srv: ValidatedConsignment / REFUSE
-        Srv->>Srv: keccak256(consignment)==consignment_hash;<br/>contract_id==pinned RGB_ASSET_ID;<br/>unsigned txid==last TS_TRANSFER witness txid;<br/>input prevouts match; sighash ALL/DEFAULT;<br/>total_output ≥ evm_amount − evm_commission
+        Srv->>Srv: keccak256(consignment)==consignment_hash<br/>contract_id==pinned RGB_ASSET_ID<br/>unsigned txid==last TS_TRANSFER witness txid<br/>input prevouts match, sighash ALL/DEFAULT<br/>total_output ≥ evm_amount − evm_commission
     end
     alt evm-rpc build — independent FundsIn verification (M-06 / #60, #77)
         Srv->>Evt: verify_funds_in_event(PINNED contract, EVM_MIN_CONFIRMATIONS,<br/>tx_hash, operation_id, evm_amount, evm_commission)
         Evt->>Rpc: eth_getTransactionReceipt / eth_blockNumber
-        Note right of Rpc: raw alloy path = host-relayed evidence (#60);<br/>Helios path = cryptographically verified in-TEE (#77)
+        Note right of Rpc: raw alloy path = host-relayed evidence (#60)<br/>Helios path = cryptographically verified in-TEE (#77)
         Rpc-->>Evt: receipt / head (or none)
-        Evt->>Evt: receipt exists + status success;<br/>UNIQUE FundsIn/BridgeFundsIn log from PINNED contract;<br/>operationId/amount/commission bind (net==gross−commission);<br/>depth ≥ EVM_MIN_CONFIRMATIONS
+        Evt->>Evt: receipt exists + status success<br/>UNIQUE FundsIn/BridgeFundsIn log from PINNED contract<br/>operationId/amount/commission bind (net==gross−commission)<br/>depth ≥ EVM_MIN_CONFIRMATIONS
         Evt-->>Srv: Ok / CrossCheck err (fail closed)
     else no evm-rpc feature (bridge mode)
-        Srv->>Srv: REFUSE — deposit cannot be independently verified;<br/>rebuild with --features evm-rpc (or helios)
+        Srv->>Srv: REFUSE — deposit cannot be independently verified<br/>rebuild with --features evm-rpc (or helios)
     end
     opt bridge mode — soft replay guard (#84)
         Srv->>State: op_replay_guard.check_and_record(op_key)

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -12,7 +12,7 @@ display these inline; no separate render step.
 | [`01-components.md`](01-components.md) | Crate-level component structure across `enclave`, `parent`, `attestation-verify`, and the external infrastructure (NSM, Esplora, vsock-proxy). |
 | [`02-deployment.md`](02-deployment.md) | Production deployment: Orchestrator → EC2 (parent) → Nitro Enclave → vsock-proxy → Esplora, with trust zones called out. |
 | [`03-seq-sign-evm.md`](03-seq-sign-evm.md) | EIP-712 signing path (RGB → EVM unlock): build-skew guard, in-enclave RGB validation, cross-checks, SPV gate, signature. |
-| [`04-seq-sign-psbt.md`](04-seq-sign-psbt.md) | PSBT signing path (EVM → RGB lock): taproot script-path (Schnorr) + SegWit v0 P2WSH (ECDSA), both anchored to `witness_utxo.script_pubkey`. |
+| [`04-seq-sign-psbt.md`](04-seq-sign-psbt.md) | PSBT signing path (EVM → RGB lock): bridge-mode authorisation (independent FundsIn verification #60/#77, consignment binding), then taproot script-path (Schnorr) + SegWit v0 P2WSH (ECDSA), both anchored to `witness_utxo.script_pubkey`. |
 | [`05-seq-attested-pubkey.md`](05-seq-attested-pubkey.md) | External verifier ↔ enclave attested-pubkey protocol (`attest-verify` CLI, NSM, COSE_Sign1, cert-chain to AWS Nitro root, PCR + nonce + bundle commitment). |
 | [`06-seq-cloning.md`](06-seq-cloning.md) | Three-message enclave-to-enclave seed cloning (X25519 + HKDF-SHA256 + ChaCha20-Poly1305 + HMAC + PCR equality). |
 | [`07-seq-initialize-keys.md`](07-seq-initialize-keys.md) | First-time key initialisation from OS entropy (BIP-39 → BIP-32 → BIP-84/86 derivation). |

--- a/docs/tee-spec.md
+++ b/docs/tee-spec.md
@@ -127,6 +127,20 @@ Taproot script-path (BIP-340 Schnorr) + SegWit v0 P2WSH (ECDSA), each anchored
 to the input's `witness_utxo.script_pubkey` so the enclave signs only the
 intended UTXO.
 
+In **bridge mode** (non-empty `evm_tx_hash`) the release is authorised by an EVM
+deposit. The listener-supplied `evm_event_valid` / `evm_event_finalized` booleans
+are **NOT trusted** (audit M-06 / #51); the enclave establishes validity and
+finality itself, fail-closed, in `validation::evm_event::verify_funds_in_event`:
+a successful receipt must exist for `evm_tx_hash`, carry a **unique** `FundsIn` /
+`BridgeFundsIn` log from the **pinned** `BRIDGE_CONTRACT`, bind `operationId` /
+gross amount / commission (with `net == gross - commission`), and sit at depth
+>= `EVM_MIN_CONFIRMATIONS`. Under `rgb-validation` the PSBT is additionally bound
+to the validated consignment's `TS_TRANSFER` witness tx (txid + prevouts +
+sighash + amount). A build **without** the `evm-rpc` feature refuses bridge-mode
+`signPsbt` outright. With `helios` (#77) the RPC is verified inside the TEE
+against a pinned checkpoint (trustless); otherwise responses are host-relayed
+evidence, verified fail-closed but not trustless.
+
 [Sign PSBT](diagrams/04-seq-sign-psbt.md)
 *Source: [`diagrams/04-seq-sign-psbt.md`](diagrams/04-seq-sign-psbt.md)*
 
@@ -254,6 +268,7 @@ The enclave MUST uphold the following. Each maps to parent spec Sec 14/Sec 15.
 | **SI-10** | On any validation failure the unlock path MUST fail closed (no partial signature, no fallback). [OK]                                                    |
 | **SI-11** | A feature/build mismatch (e.g. request carries `merkle_proofs` but the binary lacks `spv`) MUST cause refusal, never a sign-without-verification. [OK]  |
 | **SI-12** | Cross-network consignments (e.g. regtest replayed at a mainnet enclave) MUST be rejected. [OK]                                                          |
+| **SI-13** | Bridge-mode `signPsbt` MUST independently verify the EVM `FundsIn` deposit (receipt success, pinned-contract log, operationId/amount/commission bind, depth ≥ `EVM_MIN_CONFIRMATIONS`); listener validity/finality flags MUST NOT authorise (#51). A build lacking `evm-rpc` MUST refuse bridge-mode signing. [OK, #60] |
 
 ## 11. Failure conditions
 
@@ -267,7 +282,9 @@ replayed cloning nonce.
 ## 12. Implementation status & blockers
 
 Conformant and solid: Sec 7 SPV stack (incl. SI-8), Sec 9 attestation + cloning
-(Sec 16.4), fail-closed posture (SI-10/11), cross-network defense (SI-12).
+(Sec 16.4), fail-closed posture (SI-10/11), cross-network defense (SI-12),
+independent EVM `FundsIn` verification for bridge-mode `signPsbt` (SI-13 / #60,
+with the trustless Helios variant #77 experimental / default-off).
 
 **Pre-mainnet blockers** (detail in `cross-flow-findings.md` (in `internal_audit` repo at `release 1.0/enclave-signer/`)):
 

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -81,6 +81,11 @@ hmac = "0.12"
 sha2 = "0.10"
 subtle = "2"
 rand_core = { version = "0.6", features = ["getrandom"] }
+# rustls (not native-tls) to match the enclave's existing TLS stack (minreq
+# rustls) and keep OpenSSL out of the TEE. The enclave->forwarder hop is plain
+# loopback HTTP; TLS to the real RPC (if any) terminates at the host proxy.
+alloy = { version = "2.1.0", default-features = false, features = ["provider-http", "rpc-types-eth", "reqwest-rustls-tls"], optional = true }
+tokio = { version = "1.52.3", default-features = false, features = ["rt", "rt-multi-thread"], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 vsock = "0.5"
@@ -116,6 +121,16 @@ spv = ["rgb-validation"]
 # Mock attestation path: skip NSM / COSE / cert-chain checks and use raw CBOR docs.
 # Testing only — never enable in production builds.
 mock-attestation = ["attestation-verify/mock"]
+# Independent in-enclave EVM `FundsIn` event verification for signPsbt (#60).
+# Default-OFF. When ON, bridge-mode signPsbt fetches the deposit receipt via an
+# in-enclave alloy JSON-RPC client (loopback -> vsock forwarder -> host EVM RPC)
+# and fails closed on a missing/invalid receipt or unmet confirmation depth.
+# Implies `rgb-validation`: the bridge path this augments (`psbt_consignment_crosscheck`)
+# is already gated there, and the amount/asset context the predicate reconciles
+# lives behind it. NOTE: RPC responses are relayed by the UNTRUSTED host, so this
+# is the predicate + plumbing layer and only becomes trustless once Helios (#77)
+# verifies the RPC.
+evm-rpc = ["rgb-validation", "dep:alloy", "dep:tokio"]
 
 [dev-dependencies]
 rand = "0.10.0"

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 # Protobuf
 prost = "0.14.3"
-federated-signer-proto = { git = "ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git", rev = "f61dcb76595c69af914107a74852ad013afed9df", package = "federated-signer-proto" }
+federated-signer-proto = { git = "ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git", rev = "295f9596ca78bba47f76985cdc405b712de025a1", package = "federated-signer-proto" }
 
 # Crypto — ECDSA on secp256k1 (EVM address derivation + signing later)
 k256 = { version = "0.13", features = ["ecdsa"] }

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -85,7 +85,26 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 # rustls) and keep OpenSSL out of the TEE. The enclave->forwarder hop is plain
 # loopback HTTP; TLS to the real RPC (if any) terminates at the host proxy.
 alloy = { version = "2.1.0", default-features = false, features = ["provider-http", "rpc-types-eth", "reqwest-rustls-tls"], optional = true }
-tokio = { version = "1.52.3", default-features = false, features = ["rt", "rt-multi-thread"], optional = true }
+tokio = { version = "1.52.3", default-features = false, features = ["rt", "rt-multi-thread", "time"], optional = true }
+# Helios Ethereum light client for trustless in-enclave EVM event verification
+# (#77), behind the default-OFF `helios` feature. Depend on the `helios-ethereum`
+# member crate (NOT the `helios` umbrella) to avoid pulling helios-opstack ->
+# libp2p and its heavy/yanked transitive deps. Git dep (crates.io copies are
+# stale); Cargo.lock pins the exact rev. HEAVY: brings a second alloy major
+# (1.x, vs our 2.x), revm, BLS, reqwest, and vendored OpenSSL.
+#
+# OpenSSL note: it comes only from Helios's own manifests (an unused
+# `openssl = {vendored}` dep in helios-core/ethereum + reqwest's default
+# native-tls) - not removable from here (cargo feature unification is additive).
+# To drop it, fork Helios and (1) set reqwest `default-features = false` +
+# `rustls-tls`, (2) delete the `openssl` workspace dep + the `openssl.workspace`
+# lines, then pin this to the fork. Deferred (helios is experimental/default-off).
+helios-ethereum = { git = "https://github.com/a16z/helios", tag = "0.11.1", optional = true }
+# NOTE: the `helios` module hands `B256`/`U256` to/from the Helios API using the
+# always-on `alloy-primitives = "1"` declared above (dev-ng's new-arch EVM
+# validation already depends on it non-optionally). Helios also uses the alloy 1.x
+# major, so cargo unifies to the same crate instance; no separate optional
+# alloy-primitives dep is needed here.
 
 [target.'cfg(target_os = "linux")'.dependencies]
 vsock = "0.5"
@@ -131,6 +150,14 @@ mock-attestation = ["attestation-verify/mock"]
 # is the predicate + plumbing layer and only becomes trustless once Helios (#77)
 # verifies the RPC.
 evm-rpc = ["rgb-validation", "dep:alloy", "dep:tokio"]
+# Trustless variant of `evm-rpc` (#77, EXPERIMENTAL, default-OFF): embed the
+# Helios light client so the enclave cryptographically verifies the EVM RPC
+# against a pinned weak-subjectivity checkpoint before accepting a FundsIn
+# receipt. Extends `evm-rpc` (reuses the EvmReceiptProvider seam, predicate, and
+# EVM_MIN_CONFIRMATIONS). Runtime-selectable: with HELIOS_EXECUTION_RPC set the
+# enclave uses the verified path, else the raw alloy path. HEAVY build (2 alloy
+# majors, revm, BLS, vendored OpenSSL) - not in the shipped EIF yet.
+helios = ["evm-rpc", "dep:helios-ethereum"]
 
 [dev-dependencies]
 rand = "0.10.0"

--- a/enclave/src/config.rs
+++ b/enclave/src/config.rs
@@ -204,6 +204,81 @@ fn is_loopback_url(url: &str) -> bool {
     host.starts_with("127.0.0.1") || host.starts_with("[::1]") || host.starts_with("localhost")
 }
 
+/// Helios light-client config for TRUSTLESS in-enclave EVM event verification
+/// (#77), loaded at boot when the `helios` feature is built.
+///
+/// Selection is runtime: [`HeliosConfig::from_env`] returns `Some` only when
+/// `HELIOS_EXECUTION_RPC` is set - that is the signal to use the Helios-verified
+/// provider instead of the raw alloy path (#60). Like [`EvmRpcConfig`], the RPC
+/// URLs MUST be loopback (reached through vsock forwarders); Helios treats those
+/// upstreams as untrusted and verifies them against the pinned checkpoint.
+#[cfg(feature = "helios")]
+#[derive(Debug, Clone)]
+pub struct HeliosConfig {
+    /// Untrusted execution RPC Helios verifies against (`HELIOS_EXECUTION_RPC`,
+    /// required - typically the local exec forwarder `http://127.0.0.1:18545`).
+    /// Its presence is the signal to select the Helios-verified path.
+    pub execution_rpc: String,
+    /// Consensus (beacon) RPC for light-client sync (`HELIOS_CONSENSUS_RPC`,
+    /// loopback forwarder, default `http://127.0.0.1:18550`).
+    pub consensus_rpc: String,
+    /// Helios network name: `mainnet` | `sepolia` | `holesky`
+    /// (`HELIOS_NETWORK`, default `mainnet`).
+    pub network: String,
+    /// Weak-subjectivity checkpoint: 0x-prefixed 32-byte beacon block root
+    /// (`HELIOS_CHECKPOINT`). Required for a trustless build - without it Helios
+    /// would fall back to an untrusted community checkpoint list, which the
+    /// enclave never enables. `None` here fails client init closed.
+    pub checkpoint: Option<String>,
+    /// Reject a checkpoint older than the safe weak-subjectivity window
+    /// (`HELIOS_STRICT_CHECKPOINT_AGE`, default `true`).
+    pub strict_checkpoint_age: bool,
+}
+
+#[cfg(feature = "helios")]
+impl HeliosConfig {
+    const DEFAULT_CONSENSUS_RPC: &'static str = "http://127.0.0.1:18550";
+
+    /// Load from `HELIOS_*` env. Returns `None` when `HELIOS_EXECUTION_RPC` is
+    /// unset (the raw alloy path is used instead). A non-loopback RPC URL is
+    /// logged as an error but kept - the enclave has no direct egress, so a
+    /// non-loopback URL simply won't connect.
+    pub fn from_env() -> Option<Self> {
+        let execution_rpc = std::env::var("HELIOS_EXECUTION_RPC").ok()?;
+        warn_if_not_loopback("HELIOS_EXECUTION_RPC", &execution_rpc);
+
+        let consensus_rpc = std::env::var("HELIOS_CONSENSUS_RPC")
+            .unwrap_or_else(|_| Self::DEFAULT_CONSENSUS_RPC.to_string());
+        warn_if_not_loopback("HELIOS_CONSENSUS_RPC", &consensus_rpc);
+
+        let network = std::env::var("HELIOS_NETWORK").unwrap_or_else(|_| "mainnet".to_string());
+        let checkpoint = std::env::var("HELIOS_CHECKPOINT").ok();
+        let strict_checkpoint_age = std::env::var("HELIOS_STRICT_CHECKPOINT_AGE")
+            .ok()
+            .map(|s| s != "false" && s != "0")
+            .unwrap_or(true);
+
+        Some(Self {
+            execution_rpc,
+            consensus_rpc,
+            network,
+            checkpoint,
+            strict_checkpoint_age,
+        })
+    }
+}
+
+#[cfg(feature = "helios")]
+fn warn_if_not_loopback(var: &str, url: &str) {
+    if !is_loopback_url(url) {
+        tracing::error!(
+            %var, %url,
+            "Helios RPC URL is not loopback - the enclave reaches upstreams only via the vsock \
+             forwarder; a non-loopback URL will not connect"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/enclave/src/config.rs
+++ b/enclave/src/config.rs
@@ -123,6 +123,87 @@ fn parse_eth_address(s: &str) -> Result<[u8; 20]> {
     })
 }
 
+/// EVM JSON-RPC config for in-enclave `FundsIn` event verification (#60),
+/// loaded at boot when the `evm-rpc` feature is built.
+///
+/// This is operational signing-plumbing, NOT part of the enclave's committed
+/// identity: like [`BridgeConfig::gas_tx_allowed_to`], it is deliberately
+/// **not** folded into the attestation `user_data` bundle.
+///
+/// TRUST BOUNDARY: `rpc_url` MUST be loopback. The enclave has no direct
+/// network; it reaches the EVM RPC only through the loopback -> vsock
+/// forwarder ([`crate::vsock_forwarder`]), so the responses are relayed by the
+/// UNTRUSTED host. `verify_funds_in_event` treats them as evidence and fails
+/// closed; full trustlessness needs Helios (#77).
+#[cfg(feature = "evm-rpc")]
+#[derive(Debug, Clone)]
+pub struct EvmRpcConfig {
+    /// Loopback URL of the in-enclave EVM RPC forwarder
+    /// (`EVM_RPC_URL`, default `http://127.0.0.1:3444`).
+    pub rpc_url: String,
+    /// Minimum confirmation depth a `FundsIn` receipt must have, measured
+    /// against the RPC head block (`EVM_MIN_CONFIRMATIONS`, default 12).
+    pub min_confirmations: u64,
+}
+
+#[cfg(feature = "evm-rpc")]
+impl EvmRpcConfig {
+    /// Default loopback RPC URL - the enclave side of the EVM vsock forwarder.
+    const DEFAULT_RPC_URL: &'static str = "http://127.0.0.1:3444";
+    /// Default confirmation depth (~a safe head distance for most EVM chains).
+    const DEFAULT_MIN_CONFIRMATIONS: u64 = 12;
+
+    /// Load from `EVM_RPC_URL` and `EVM_MIN_CONFIRMATIONS`. Both fall back to
+    /// safe defaults. A non-loopback `EVM_RPC_URL` is rejected back to the
+    /// default and logged: routing EVM RPC anywhere but the vsock forwarder
+    /// would bypass the only sanctioned egress path.
+    pub fn from_env() -> Self {
+        let rpc_url = match std::env::var("EVM_RPC_URL") {
+            Ok(url) if is_loopback_url(&url) => url,
+            Ok(url) => {
+                tracing::error!(
+                    %url,
+                    "EVM_RPC_URL is not loopback - ignoring and using the default vsock-forwarder \
+                     URL; the enclave must reach the EVM RPC only via the loopback forwarder"
+                );
+                Self::DEFAULT_RPC_URL.to_string()
+            }
+            Err(_) => Self::DEFAULT_RPC_URL.to_string(),
+        };
+        let min_confirmations = std::env::var("EVM_MIN_CONFIRMATIONS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(Self::DEFAULT_MIN_CONFIRMATIONS);
+        Self {
+            rpc_url,
+            min_confirmations,
+        }
+    }
+}
+
+#[cfg(feature = "evm-rpc")]
+impl Default for EvmRpcConfig {
+    fn default() -> Self {
+        Self {
+            rpc_url: Self::DEFAULT_RPC_URL.to_string(),
+            min_confirmations: Self::DEFAULT_MIN_CONFIRMATIONS,
+        }
+    }
+}
+
+/// True if `url`'s host is a loopback literal (`127.0.0.1` or `[::1]`). A
+/// deliberately narrow, dependency-free check - the enclave only ever points
+/// this at its own loopback forwarder.
+#[cfg(feature = "evm-rpc")]
+fn is_loopback_url(url: &str) -> bool {
+    let after_scheme = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
+    let host = after_scheme
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or(after_scheme);
+    host.starts_with("127.0.0.1") || host.starts_with("[::1]") || host.starts_with("localhost")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/enclave/src/config.rs
+++ b/enclave/src/config.rs
@@ -191,17 +191,34 @@ impl Default for EvmRpcConfig {
     }
 }
 
-/// True if `url`'s host is a loopback literal (`127.0.0.1` or `[::1]`). A
-/// deliberately narrow, dependency-free check - the enclave only ever points
-/// this at its own loopback forwarder.
+/// True if `url`'s host is exactly a loopback literal (`127.0.0.1`, `[::1]`, or
+/// `localhost`). A deliberately narrow, dependency-free check - the enclave only
+/// ever points this at its own loopback forwarder. Matches the host *exactly*
+/// (after stripping scheme, userinfo, path, and port) so a look-alike authority
+/// like `127.0.0.1.evil.com` or `localhost.evil.com` is NOT treated as loopback.
 #[cfg(feature = "evm-rpc")]
 fn is_loopback_url(url: &str) -> bool {
     let after_scheme = url.split_once("://").map(|(_, rest)| rest).unwrap_or(url);
-    let host = after_scheme
+    // Drop path/query/fragment, then any `userinfo@` prefix.
+    let authority = after_scheme
         .split(['/', '?', '#'])
         .next()
         .unwrap_or(after_scheme);
-    host.starts_with("127.0.0.1") || host.starts_with("[::1]") || host.starts_with("localhost")
+    let hostport = authority.rsplit_once('@').map_or(authority, |(_, h)| h);
+    // Strip the port. IPv6 literals are bracketed (`[::1]:8545`), so split off
+    // the `]` first; otherwise the host is everything before the first `:`.
+    let host = if let Some(rest) = hostport.strip_prefix('[') {
+        match rest.split_once(']') {
+            // Valid IPv6 authority: `]` is followed by nothing or `:port`.
+            Some((inner, after)) => {
+                return inner == "::1" && (after.is_empty() || after.starts_with(':'))
+            }
+            None => hostport,
+        }
+    } else {
+        hostport.split(':').next().unwrap_or(hostport)
+    };
+    host == "127.0.0.1" || host == "localhost"
 }
 
 /// Helios light-client config for TRUSTLESS in-enclave EVM event verification
@@ -358,5 +375,28 @@ mod tests {
         };
         assert!(!c.is_configured());
         assert!(c.is_partially_configured());
+    }
+
+    #[cfg(feature = "evm-rpc")]
+    #[test]
+    fn loopback_url_accepts_real_loopback() {
+        assert!(is_loopback_url("http://127.0.0.1:3444"));
+        assert!(is_loopback_url("http://127.0.0.1"));
+        assert!(is_loopback_url("http://localhost:8545"));
+        assert!(is_loopback_url("http://[::1]:18545/path"));
+        assert!(is_loopback_url("http://[::1]"));
+        assert!(is_loopback_url("http://user:pass@127.0.0.1:3444"));
+    }
+
+    #[cfg(feature = "evm-rpc")]
+    #[test]
+    fn loopback_url_rejects_lookalike_authorities() {
+        // The old `starts_with` check accepted all of these.
+        assert!(!is_loopback_url("http://127.0.0.1.evil.com"));
+        assert!(!is_loopback_url("http://localhost.evil.com/rpc"));
+        assert!(!is_loopback_url("http://127.0.0.1@evil.com"));
+        assert!(!is_loopback_url("http://[::1].evil.com"));
+        assert!(!is_loopback_url("http://10.0.0.1:8545"));
+        assert!(!is_loopback_url("http://evil.com/127.0.0.1"));
     }
 }

--- a/enclave/src/main.rs
+++ b/enclave/src/main.rs
@@ -91,6 +91,27 @@ fn main() {
         if let Err(e) = utexo_bridge_enclave::vsock_forwarder::start_forwarder(3443, vsock_port) {
             tracing::error!("failed to start vsock forwarder: {e}");
         }
+
+        // Second forwarder for the EVM JSON-RPC used by in-enclave FundsIn
+        // verification (#60). Distinct loopback/vsock ports from Esplora
+        // (3443/8001). Untrusted, host-controlled egress boundary (audit I-01);
+        // the host must run: vsock-proxy <EVM_RPC_VSOCK_PORT> <evm-rpc-host> <port>.
+        #[cfg(feature = "evm-rpc")]
+        {
+            let evm_vsock_port: u32 = std::env::var("EVM_RPC_VSOCK_PORT")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(8002);
+            tracing::info!(
+                evm_vsock_port,
+                "starting EVM RPC vsock forwarder (host must run: vsock-proxy {evm_vsock_port} <evm-rpc-host> <evm-rpc-port>)"
+            );
+            if let Err(e) =
+                utexo_bridge_enclave::vsock_forwarder::start_forwarder(3444, evm_vsock_port)
+            {
+                tracing::error!("failed to start EVM RPC vsock forwarder: {e}");
+            }
+        }
     }
 
     // Build RGB consignment validator (when feature enabled).
@@ -148,11 +169,39 @@ fn main() {
     }
     let header_chain = std::sync::Mutex::new(HeaderChain::new(spv_network, checkpoint));
 
+    // Build the in-enclave EVM RPC client for independent FundsIn verification
+    // (#60). The URL must be the loopback forwarder; responses are host-relayed
+    // and treated as evidence (verified fail-closed), not trusted input.
+    #[cfg(feature = "evm-rpc")]
+    let (evm_rpc_client, evm_rpc_config) = {
+        let cfg = utexo_bridge_enclave::config::EvmRpcConfig::from_env();
+        let client =
+            match utexo_bridge_enclave::networks::evm::evm_event::AlloyEvmClient::new(&cfg.rpc_url) {
+                Ok(c) => {
+                    tracing::info!(
+                        rpc_url = %cfg.rpc_url,
+                        min_confirmations = cfg.min_confirmations,
+                        "EVM RPC client initialized (FundsIn verification, #60)"
+                    );
+                    Some(c)
+                }
+                Err(e) => {
+                    tracing::error!("failed to init EVM RPC client: {e}");
+                    None
+                }
+            };
+        (client, cfg)
+    };
+
     let ctx = ServerContext {
         state,
         bridge_config,
         #[cfg(feature = "rgb-validation")]
         rgb_validator,
+        #[cfg(feature = "evm-rpc")]
+        evm_rpc_client,
+        #[cfg(feature = "evm-rpc")]
+        evm_rpc_config,
         header_chain,
         submit_rate_limiter: std::sync::Mutex::new(server::SubmitRateLimiter::default()),
     };

--- a/enclave/src/main.rs
+++ b/enclave/src/main.rs
@@ -244,7 +244,12 @@ fn main() {
         #[cfg(feature = "helios")]
         let client: Option<Boxed> = match utexo_bridge_enclave::config::HeliosConfig::from_env() {
             Some(hcfg) => {
-                match utexo_bridge_enclave::networks::evm::evm_event::HeliosEvmClient::new(&hcfg) {
+                // Pass the pinned EVM_CHAIN_ID so Helios rejects a
+                // HELIOS_NETWORK inconsistent with it (#77 predicate 1).
+                match utexo_bridge_enclave::networks::evm::evm_event::HeliosEvmClient::new(
+                    &hcfg,
+                    bridge_config.chain_id,
+                ) {
                     Ok(c) => {
                         tracing::info!(
                             network = %hcfg.network,

--- a/enclave/src/main.rs
+++ b/enclave/src/main.rs
@@ -112,6 +112,47 @@ fn main() {
                 tracing::error!("failed to start EVM RPC vsock forwarder: {e}");
             }
         }
+
+        // Helios execution + consensus RPC forwarders (#77, trustless EVM
+        // verification). Helios verifies these UNTRUSTED upstreams against a
+        // pinned checkpoint. Local ports mirror HeliosConfig defaults
+        // (18545/18550); the host must run one vsock-proxy per upstream.
+        #[cfg(feature = "helios")]
+        {
+            let exec_local: u16 = std::env::var("HELIOS_EXECUTION_LOCAL_PORT")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(18545);
+            let exec_vsock: u32 = std::env::var("HELIOS_EXECUTION_VSOCK_PORT")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(8003);
+            let cons_local: u16 = std::env::var("HELIOS_CONSENSUS_LOCAL_PORT")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(18550);
+            let cons_vsock: u32 = std::env::var("HELIOS_CONSENSUS_VSOCK_PORT")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(8004);
+            tracing::info!(
+                exec_local,
+                exec_vsock,
+                cons_local,
+                cons_vsock,
+                "starting Helios execution + consensus vsock forwarders (#77)"
+            );
+            if let Err(e) =
+                utexo_bridge_enclave::vsock_forwarder::start_forwarder(exec_local, exec_vsock)
+            {
+                tracing::error!("failed to start Helios execution RPC forwarder: {e}");
+            }
+            if let Err(e) =
+                utexo_bridge_enclave::vsock_forwarder::start_forwarder(cons_local, cons_vsock)
+            {
+                tracing::error!("failed to start Helios consensus RPC forwarder: {e}");
+            }
+        }
     }
 
     // Build RGB consignment validator (when feature enabled).
@@ -174,22 +215,57 @@ fn main() {
     // and treated as evidence (verified fail-closed), not trusted input.
     #[cfg(feature = "evm-rpc")]
     let (evm_rpc_client, evm_rpc_config) = {
+        use utexo_bridge_enclave::networks::evm::evm_event::{AlloyEvmClient, EvmReceiptProvider};
         let cfg = utexo_bridge_enclave::config::EvmRpcConfig::from_env();
-        let client =
-            match utexo_bridge_enclave::networks::evm::evm_event::AlloyEvmClient::new(&cfg.rpc_url) {
+        type Boxed = Box<dyn EvmReceiptProvider + Send + Sync>;
+
+        // Raw alloy provider (#60): host-relayed, unverified.
+        let build_alloy = || -> Option<Boxed> {
+            match AlloyEvmClient::new(&cfg.rpc_url) {
                 Ok(c) => {
                     tracing::info!(
                         rpc_url = %cfg.rpc_url,
                         min_confirmations = cfg.min_confirmations,
-                        "EVM RPC client initialized (FundsIn verification, #60)"
+                        "EVM FundsIn verification: raw alloy path (#60, host-relayed/unverified)"
                     );
-                    Some(c)
+                    Some(Box::new(c) as Boxed)
                 }
                 Err(e) => {
                     tracing::error!("failed to init EVM RPC client: {e}");
                     None
                 }
-            };
+            }
+        };
+
+        // #77 runtime-selectable: HELIOS_EXECUTION_RPC set -> Helios-verified
+        // path; else the raw alloy path. Fail closed on the SELECTED provider:
+        // a Helios build/sync failure leaves the client unset so bridge signing
+        // refuses, never silently downgrading to the unverified path.
+        #[cfg(feature = "helios")]
+        let client: Option<Boxed> = match utexo_bridge_enclave::config::HeliosConfig::from_env() {
+            Some(hcfg) => {
+                match utexo_bridge_enclave::networks::evm::evm_event::HeliosEvmClient::new(&hcfg) {
+                    Ok(c) => {
+                        tracing::info!(
+                            network = %hcfg.network,
+                            min_confirmations = cfg.min_confirmations,
+                            "EVM FundsIn verification: Helios-verified path (#77, trustless)"
+                        );
+                        Some(Box::new(c) as Boxed)
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "Helios client init/sync failed: {e} - bridge signing will fail closed"
+                        );
+                        None
+                    }
+                }
+            }
+            None => build_alloy(),
+        };
+        #[cfg(not(feature = "helios"))]
+        let client: Option<Boxed> = build_alloy();
+
         (client, cfg)
     };
 

--- a/enclave/src/networks/evm/crosscheck.rs
+++ b/enclave/src/networks/evm/crosscheck.rs
@@ -320,7 +320,7 @@ fn read_u256_as_usize(call_data: &[u8], offset: usize) -> Result<usize> {
 
 /// Read a uint256 from call_data at a byte offset, as u64. Fails if too short or
 /// the value exceeds u64.
-fn extract_uint256_as_u64(call_data: &[u8], offset: usize) -> Result<u64> {
+pub(crate) fn extract_uint256_as_u64(call_data: &[u8], offset: usize) -> Result<u64> {
     let end = offset + 32;
     if call_data.len() < end {
         return Err(EnclaveError::CrossCheck(format!(

--- a/enclave/src/networks/evm/evm_event.rs
+++ b/enclave/src/networks/evm/evm_event.rs
@@ -331,6 +331,170 @@ fn map_alloy_receipt(r: alloy::rpc::types::TransactionReceipt) -> ReceiptData {
     }
 }
 
+/// Boot-time bound on the Helios light-client initial sync. If the client is
+/// not synced within this window, [`HeliosEvmClient::new`] fails and the
+/// provider stays unset - bridge signing then fails closed rather than run
+/// against an unverified/unsynced client.
+#[cfg(feature = "helios")]
+const HELIOS_BOOT_SYNC_TIMEOUT_SECS: u64 = 300;
+
+/// TRUSTLESS [`EvmReceiptProvider`] (#77): the a16z Helios light client embedded
+/// in-process. Helios treats the execution/consensus RPCs (reached via loopback
+/// vsock forwarders) as UNTRUSTED and verifies them against a pinned
+/// weak-subjectivity checkpoint before returning a receipt - so unlike
+/// [`AlloyEvmClient`], a malicious host cannot forge the result.
+///
+/// Helios is async and runs a background sync task, so a long-lived tokio
+/// runtime is built at boot and kept alive for the client's lifetime; each
+/// query is driven via `block_on`. The returned receipt (alloy 1.x types) is
+/// mapped to the enclave-local [`ReceiptData`] so no alloy-version types cross
+/// the [`EvmReceiptProvider`] boundary.
+#[cfg(feature = "helios")]
+pub struct HeliosEvmClient {
+    // Field order matters for drop: the client is dropped before the runtime.
+    client: helios_ethereum::EthereumClient,
+    runtime: tokio::runtime::Runtime,
+}
+
+#[cfg(feature = "helios")]
+impl HeliosEvmClient {
+    /// Build and SYNC the Helios client at boot. Blocks (bounded by
+    /// [`HELIOS_BOOT_SYNC_TIMEOUT_SECS`]) until the light client is synced so
+    /// the first query is already verified. Any error (bad config, no
+    /// checkpoint, sync timeout) is returned so boot leaves the provider unset
+    /// and bridge signing fails closed.
+    pub fn new(cfg: &crate::config::HeliosConfig) -> Result<Self> {
+        use helios_ethereum::{config::networks::Network, EthereumClientBuilder};
+
+        let network = match cfg.network.to_ascii_lowercase().as_str() {
+            "mainnet" => Network::Mainnet,
+            "sepolia" => Network::Sepolia,
+            "holesky" => Network::Holesky,
+            other => {
+                return Err(EnclaveError::CrossCheck(format!(
+                    "helios: unsupported HELIOS_NETWORK {other:?} (want mainnet|sepolia|holesky)"
+                )))
+            }
+        };
+        let checkpoint = parse_checkpoint(cfg.checkpoint.as_deref())?;
+
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .map_err(|e| EnclaveError::CrossCheck(format!("helios: tokio runtime: {e}")))?;
+
+        let exec = cfg.execution_rpc.clone();
+        let cons = cfg.consensus_rpc.clone();
+        let strict = cfg.strict_checkpoint_age;
+
+        let client = runtime.block_on(async move {
+            let builder = EthereumClientBuilder::new()
+                .network(network)
+                .execution_rpc(&exec)
+                .map_err(|e| EnclaveError::CrossCheck(format!("helios: bad execution_rpc: {e}")))?
+                .consensus_rpc(&cons)
+                .map_err(|e| EnclaveError::CrossCheck(format!("helios: bad consensus_rpc: {e}")))?
+                .checkpoint(checkpoint);
+            // No `load_external_fallback`/`fallback`: the ONLY egress is the two
+            // forwarded RPCs, and the checkpoint is operator-pinned.
+            let builder = if strict {
+                builder.strict_checkpoint_age()
+            } else {
+                builder
+            };
+            let client = builder
+                .with_config_db() // in-memory, no disk in the enclave
+                .build()
+                .map_err(|e| EnclaveError::CrossCheck(format!("helios: build: {e}")))?;
+
+            let timeout = std::time::Duration::from_secs(HELIOS_BOOT_SYNC_TIMEOUT_SECS);
+            tokio::time::timeout(timeout, client.wait_synced())
+                .await
+                .map_err(|_| {
+                    EnclaveError::CrossCheck(format!(
+                        "helios: light client did not sync within {HELIOS_BOOT_SYNC_TIMEOUT_SECS}s \
+                         - refusing to start (bridge signing fails closed until synced)"
+                    ))
+                })?
+                .map_err(|e| EnclaveError::CrossCheck(format!("helios: sync failed: {e}")))?;
+            Ok::<_, EnclaveError>(client)
+        })?;
+
+        tracing::info!(
+            network = %cfg.network,
+            execution_rpc = %cfg.execution_rpc,
+            consensus_rpc = %cfg.consensus_rpc,
+            "Helios light client synced (trustless FundsIn verification, #77)"
+        );
+        Ok(Self { client, runtime })
+    }
+}
+
+#[cfg(feature = "helios")]
+impl EvmReceiptProvider for HeliosEvmClient {
+    fn get_transaction_receipt(&self, tx_hash: &[u8; 32]) -> Result<Option<ReceiptData>> {
+        let hash = alloy_primitives::B256::from_slice(tx_hash);
+        let receipt = self
+            .runtime
+            .block_on(self.client.get_transaction_receipt(hash))
+            .map_err(|e| {
+                EnclaveError::CrossCheck(format!("helios: eth_getTransactionReceipt failed: {e}"))
+            })?;
+        // Map inline so the alloy-1.x receipt type is inferred, never named -
+        // it must not cross the EvmReceiptProvider boundary (our alloy is 2.x).
+        Ok(receipt.map(|r| ReceiptData {
+            status_success: r.status(),
+            block_number: r.block_number.unwrap_or(0),
+            logs: r
+                .inner
+                .logs()
+                .iter()
+                .map(|log| LogEntry {
+                    address: log.address().into_array(),
+                    topics: log.topics().iter().map(|t| t.0).collect(),
+                    data: log.data().data.to_vec(),
+                })
+                .collect(),
+        }))
+    }
+
+    fn get_block_number(&self) -> Result<u64> {
+        let n = self
+            .runtime
+            .block_on(self.client.get_block_number())
+            .map_err(|e| {
+                EnclaveError::CrossCheck(format!("helios: eth_blockNumber failed: {e}"))
+            })?;
+        u64::try_from(n)
+            .map_err(|_| EnclaveError::CrossCheck("helios: head block number exceeds u64".into()))
+    }
+}
+
+/// Parse the operator-pinned `HELIOS_CHECKPOINT` (0x-prefixed 32-byte beacon
+/// block root) into an alloy-1.x `B256`. A checkpoint is mandatory for a
+/// trustless build; `None`/malformed fails closed.
+#[cfg(feature = "helios")]
+fn parse_checkpoint(checkpoint: Option<&str>) -> Result<alloy_primitives::B256> {
+    let hex_str = checkpoint.ok_or_else(|| {
+        EnclaveError::CrossCheck(
+            "helios: HELIOS_CHECKPOINT is required (a recent weak-subjectivity beacon block root) \
+             - refusing to sync against an untrusted community checkpoint"
+                .into(),
+        )
+    })?;
+    let stripped = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+    let bytes = hex::decode(stripped)
+        .map_err(|e| EnclaveError::CrossCheck(format!("helios: HELIOS_CHECKPOINT not hex: {e}")))?;
+    let arr: [u8; 32] = bytes.try_into().map_err(|v: Vec<u8>| {
+        EnclaveError::CrossCheck(format!(
+            "helios: HELIOS_CHECKPOINT must be 32 bytes, got {}",
+            v.len()
+        ))
+    })?;
+    Ok(alloy_primitives::B256::from(arr))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/enclave/src/networks/evm/evm_event.rs
+++ b/enclave/src/networks/evm/evm_event.rs
@@ -1,0 +1,604 @@
+//! Independent in-enclave verification of the EVM `FundsIn` deposit event for
+//! bridge-mode `signPsbt` (audit M-06 / issues #60, #51).
+//!
+//! Bridge-mode `signPsbt` releases RGB against an EVM deposit. Previously the
+//! enclave trusted two listener-supplied booleans (`evm_event_valid` /
+//! `evm_event_finalized`) that anyone reaching the enclave could set to `true`.
+//! This module replaces that trust: the enclave fetches the deposit's
+//! transaction receipt over an in-enclave EVM RPC and checks, itself, that a
+//! `FundsIn` / `BridgeFundsIn` log was emitted by the pinned bridge contract
+//! with the claimed `operationId` and amount, and at sufficient confirmation
+//! depth. Every predicate is **fail-closed**.
+//!
+//! TRUST BOUNDARY: the RPC is reached through the loopback -> vsock forwarder,
+//! i.e. responses are relayed by the UNTRUSTED host. A malicious host can
+//! withhold a receipt (-> we fail closed, safe) but could in principle forge
+//! one; this predicate becomes trustless only once Helios (#77) verifies the
+//! RPC inside the TEE. This is the predicate + plumbing layer.
+//!
+//! WHAT THIS DOES NOT BIND: `operationId` is a backend-assigned `uint256` with
+//! no on-chain cryptographic link to the RGB mint being signed, so confirming
+//! the deposit does not by itself prove it corresponds to *this* RGB transfer;
+//! that association stays listener-supplied (related to #66). And because the
+//! proto carries `operation_idx`/`evm_amount` as `u64` while the chain uses
+//! `uint256`, an on-chain value exceeding `u64` is rejected fail-closed (see
+//! [`super::crosscheck::extract_uint256_as_u64`]); full-width support needs
+//! a `bytes operation_id` proto field + a listener change.
+
+use sha3::{Digest, Keccak256};
+
+use super::crosscheck::extract_uint256_as_u64;
+use crate::error::{EnclaveError, Result};
+
+/// Canonical `BridgeFundsIn` signature (the richer event: carries gross amount,
+/// net, and commission, so the enclave can verify all three independently).
+/// Verbatim from `bridge-smart-contracts` `IBridge.sol`. `sender` is indexed
+/// (-> topic1), so the non-indexed args below are what lands in log `data`.
+const BRIDGE_FUNDS_IN_SIG: &str =
+    "BridgeFundsIn(address,uint256,uint256,uint256,uint256,uint256,uint256,uint256,string)";
+
+/// Canonical plain `FundsIn` signature (`BridgeBase.sol`). Weaker fallback:
+/// its `amount` is the post-commission net, so the commission stays
+/// listener-trusted when only this shape is present.
+const FUNDS_IN_SIG: &str = "FundsIn(address,uint256,uint256)";
+
+/// Byte offsets of the non-indexed `BridgeFundsIn` data words (each 32 bytes).
+/// Order: operationId, amount(gross), netAmount, tokenCommission,
+/// nativeCommission, sourceChainId, destinationChainId, <string offset>.
+const BFI_OPERATION_ID_OFF: usize = 0;
+const BFI_AMOUNT_OFF: usize = 32;
+const BFI_NET_AMOUNT_OFF: usize = 64;
+const BFI_TOKEN_COMMISSION_OFF: usize = 96;
+/// 7 static words + 1 dynamic-string offset word must be present.
+const BFI_MIN_DATA_LEN: usize = 8 * 32;
+
+/// Byte offsets of the plain `FundsIn` data words: operationId, amount(net).
+const FI_OPERATION_ID_OFF: usize = 0;
+const FI_NET_AMOUNT_OFF: usize = 32;
+const FI_MIN_DATA_LEN: usize = 2 * 32;
+
+/// One decoded EVM log, enclave-local so no RPC-client types leak past this
+/// module boundary (keeps the predicate unit-testable without a live RPC).
+#[derive(Debug, Clone)]
+pub struct LogEntry {
+    pub address: [u8; 20],
+    pub topics: Vec<[u8; 32]>,
+    pub data: Vec<u8>,
+}
+
+/// The subset of a transaction receipt the predicate needs.
+#[derive(Debug, Clone)]
+pub struct ReceiptData {
+    /// Post-Byzantium receipt status: `true` == success (`0x1`).
+    pub status_success: bool,
+    /// Block the tx was mined in (used for confirmation-depth).
+    pub block_number: u64,
+    pub logs: Vec<LogEntry>,
+}
+
+/// Read-only EVM RPC surface the predicate needs. Behind a trait so unit tests
+/// inject synthetic receipts and CI never touches a real RPC; the alloy-backed
+/// [`AlloyEvmClient`] is the production impl.
+pub trait EvmReceiptProvider {
+    /// `eth_getTransactionReceipt`. `Ok(None)` == tx not mined / not found.
+    fn get_transaction_receipt(&self, tx_hash: &[u8; 32]) -> Result<Option<ReceiptData>>;
+    /// `eth_blockNumber` (current head).
+    fn get_block_number(&self) -> Result<u64>;
+}
+
+/// keccak256 of an event signature -> its `topic0`.
+fn event_topic0(sig: &str) -> [u8; 32] {
+    Keccak256::digest(sig.as_bytes()).into()
+}
+
+/// Independently verify the `FundsIn` deposit for a bridge-mode `signPsbt`.
+///
+/// Fail-closed: a missing/failed receipt, no matching log, an ambiguous match,
+/// any field mismatch, an on-chain value exceeding `u64`, or insufficient
+/// confirmation depth all return `Err` and the caller refuses to sign.
+///
+/// `bridge_contract` and `min_confirmations` come from PINNED config, never the
+/// request. `expected_*` come from the request fields the listener supplied and
+/// that this function is confirming against the chain.
+#[allow(clippy::too_many_arguments)]
+pub fn verify_funds_in_event(
+    provider: &dyn EvmReceiptProvider,
+    bridge_contract: &[u8; 20],
+    min_confirmations: u64,
+    evm_tx_hash: &[u8; 32],
+    expected_operation_id: u64,
+    expected_gross_amount: u64,
+    expected_commission: u64,
+) -> Result<()> {
+    // 1. Receipt must exist. `None` == not mined or host withheld it.
+    let receipt = provider
+        .get_transaction_receipt(evm_tx_hash)?
+        .ok_or_else(|| {
+            EnclaveError::CrossCheck(format!(
+            "FundsIn receipt not found for tx 0x{} (not mined, or host withheld it) - refusing \
+             to sign",
+            hex::encode(evm_tx_hash)
+        ))
+        })?;
+
+    // 2. The deposit tx must have succeeded; a reverted tx emits no real FundsIn.
+    if !receipt.status_success {
+        return Err(EnclaveError::CrossCheck(format!(
+            "FundsIn tx 0x{} reverted (receipt status != success)",
+            hex::encode(evm_tx_hash)
+        )));
+    }
+
+    // 3/4. Find the UNIQUE log emitted by the pinned bridge contract whose
+    //      topic0 is FundsIn / BridgeFundsIn. Pinning the address means a
+    //      compromised host cannot satisfy this with a look-alike contract.
+    let bridge_topic0 = event_topic0(BRIDGE_FUNDS_IN_SIG);
+    let funds_in_topic0 = event_topic0(FUNDS_IN_SIG);
+    let mut matches = receipt.logs.iter().filter(|log| {
+        log.address == *bridge_contract
+            && log
+                .topics
+                .first()
+                .is_some_and(|t| *t == bridge_topic0 || *t == funds_in_topic0)
+    });
+    let log = matches.next().ok_or_else(|| {
+        EnclaveError::CrossCheck(format!(
+            "no FundsIn/BridgeFundsIn log from bridge contract 0x{} in tx 0x{}",
+            hex::encode(bridge_contract),
+            hex::encode(evm_tx_hash)
+        ))
+    })?;
+    if matches.next().is_some() {
+        return Err(EnclaveError::CrossCheck(format!(
+            "ambiguous: multiple FundsIn logs from bridge contract 0x{} in tx 0x{} - refusing to \
+             guess which authorises this release",
+            hex::encode(bridge_contract),
+            hex::encode(evm_tx_hash)
+        )));
+    }
+
+    // 5/6/7. Decode the log data and bind operationId + amounts. `sender` is
+    //        indexed, so it is in topics, not data.
+    let is_bridge_shape = log.topics.first() == Some(&bridge_topic0);
+    if is_bridge_shape {
+        if log.data.len() < BFI_MIN_DATA_LEN {
+            return Err(EnclaveError::CrossCheck(format!(
+                "BridgeFundsIn data too short: {} bytes (need {BFI_MIN_DATA_LEN})",
+                log.data.len()
+            )));
+        }
+        let operation_id = decode_u64_word(&log.data, BFI_OPERATION_ID_OFF, "operationId")?;
+        let gross = decode_u64_word(&log.data, BFI_AMOUNT_OFF, "amount")?;
+        let net = decode_u64_word(&log.data, BFI_NET_AMOUNT_OFF, "netAmount")?;
+        let commission = decode_u64_word(&log.data, BFI_TOKEN_COMMISSION_OFF, "tokenCommission")?;
+
+        check_eq("operationId", operation_id, expected_operation_id)?;
+        check_eq("amount", gross, expected_gross_amount)?;
+        check_eq("tokenCommission", commission, expected_commission)?;
+        // Internal consistency: net == gross - commission (also pins net to the
+        // request's derived net without trusting a separate wire field).
+        let want_net = gross.checked_sub(commission).ok_or_else(|| {
+            EnclaveError::CrossCheck(format!(
+                "BridgeFundsIn commission ({commission}) exceeds gross amount ({gross})"
+            ))
+        })?;
+        check_eq("netAmount", net, want_net)?;
+    } else {
+        // Plain FundsIn: only net amount is available; commission stays
+        // listener-supplied (weaker). Prefer BridgeFundsIn in production.
+        if log.data.len() < FI_MIN_DATA_LEN {
+            return Err(EnclaveError::CrossCheck(format!(
+                "FundsIn data too short: {} bytes (need {FI_MIN_DATA_LEN})",
+                log.data.len()
+            )));
+        }
+        let operation_id = decode_u64_word(&log.data, FI_OPERATION_ID_OFF, "operationId")?;
+        let net = decode_u64_word(&log.data, FI_NET_AMOUNT_OFF, "netAmount")?;
+        let want_net = expected_gross_amount
+            .checked_sub(expected_commission)
+            .ok_or_else(|| {
+                EnclaveError::CrossCheck(format!(
+                    "expected commission ({expected_commission}) exceeds expected gross \
+                     ({expected_gross_amount})"
+                ))
+            })?;
+        check_eq("operationId", operation_id, expected_operation_id)?;
+        check_eq("netAmount", net, want_net)?;
+        tracing::warn!(
+            "verified only plain FundsIn (net amount); tokenCommission stays listener-trusted - \
+             emit BridgeFundsIn to bind the commission"
+        );
+    }
+
+    // 8. Confirmation depth against the current head. `eth_blockNumber` and the
+    //    receipt are two separate calls, so a reorg between them is possible;
+    //    min_confirmations bounds it. head < block_number == the receipt's
+    //    block was reorged out from under us -> reject.
+    let head = provider.get_block_number()?;
+    let depth = head.checked_sub(receipt.block_number).ok_or_else(|| {
+        EnclaveError::CrossCheck(format!(
+            "FundsIn receipt block {} is above RPC head {head} (reorg?) - refusing to sign",
+            receipt.block_number
+        ))
+    })?;
+    if depth < min_confirmations {
+        return Err(EnclaveError::CrossCheck(format!(
+            "FundsIn not final: depth {depth} < required {min_confirmations} (receipt block {}, \
+             head {head})",
+            receipt.block_number
+        )));
+    }
+
+    tracing::info!(
+        tx = %hex::encode(evm_tx_hash),
+        operation_id = expected_operation_id,
+        depth,
+        "FundsIn event independently verified in-enclave"
+    );
+    Ok(())
+}
+
+/// Read a 32-byte ABI word at `offset` in `data` as a `u64`, mapping the
+/// generic overflow/short errors to a field-named, fail-closed message. The
+/// `u64`-fit check (high 24 bytes zero) is the documented width guard: an
+/// on-chain value exceeding `u64` is rejected, not truncated.
+fn decode_u64_word(data: &[u8], offset: usize, field: &str) -> Result<u64> {
+    extract_uint256_as_u64(data, offset).map_err(|e| {
+        EnclaveError::CrossCheck(format!(
+            "FundsIn {field}: {e} (a uint256 exceeding u64 needs the bytes operation_id proto \
+             follow-up)"
+        ))
+    })
+}
+
+/// Equality assertion with a field-named fail-closed error.
+fn check_eq(field: &str, got: u64, want: u64) -> Result<()> {
+    if got != want {
+        return Err(EnclaveError::CrossCheck(format!(
+            "FundsIn {field} mismatch: on-chain {got} != request {want}"
+        )));
+    }
+    Ok(())
+}
+
+/// Production [`EvmReceiptProvider`]: an alloy JSON-RPC client over the
+/// in-enclave loopback URL (which a vsock forwarder tunnels to the host EVM
+/// RPC). alloy is async, so a single-worker tokio runtime is built once at boot
+/// and each blocking call is driven via `block_on`. One worker is enough (the
+/// receipt fetch is the only async work) and keeps `Send + Sync` so the shared
+/// `ServerContext` can call it from any handler thread.
+pub struct AlloyEvmClient {
+    runtime: tokio::runtime::Runtime,
+    provider: alloy::providers::RootProvider,
+}
+
+impl AlloyEvmClient {
+    /// Build the client against `rpc_url` (must be the loopback forwarder URL).
+    pub fn new(rpc_url: &str) -> Result<Self> {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .map_err(|e| {
+                EnclaveError::CrossCheck(format!("evm-rpc: failed to build tokio runtime: {e}"))
+            })?;
+        let url = rpc_url.parse().map_err(|e| {
+            EnclaveError::CrossCheck(format!("evm-rpc: invalid rpc_url {rpc_url:?}: {e}"))
+        })?;
+        let provider = alloy::providers::RootProvider::new_http(url);
+        Ok(Self { runtime, provider })
+    }
+}
+
+impl EvmReceiptProvider for AlloyEvmClient {
+    fn get_transaction_receipt(&self, tx_hash: &[u8; 32]) -> Result<Option<ReceiptData>> {
+        use alloy::providers::Provider;
+        let hash = alloy::primitives::B256::from_slice(tx_hash);
+        let receipt = self
+            .runtime
+            .block_on(self.provider.get_transaction_receipt(hash))
+            .map_err(|e| {
+                EnclaveError::CrossCheck(format!("evm-rpc: eth_getTransactionReceipt failed: {e}"))
+            })?;
+        Ok(receipt.map(map_alloy_receipt))
+    }
+
+    fn get_block_number(&self) -> Result<u64> {
+        use alloy::providers::Provider;
+        self.runtime
+            .block_on(self.provider.get_block_number())
+            .map_err(|e| EnclaveError::CrossCheck(format!("evm-rpc: eth_blockNumber failed: {e}")))
+    }
+}
+
+/// Translate an alloy receipt into the enclave-local [`ReceiptData`] so no
+/// alloy types leak into the predicate.
+fn map_alloy_receipt(r: alloy::rpc::types::TransactionReceipt) -> ReceiptData {
+    let logs = r
+        .inner
+        .logs()
+        .iter()
+        .map(|log| LogEntry {
+            address: log.address().into_array(),
+            topics: log.topics().iter().map(|t| t.0).collect(),
+            data: log.data().data.to_vec(),
+        })
+        .collect();
+    ReceiptData {
+        status_success: r.status(),
+        block_number: r.block_number.unwrap_or(0),
+        logs,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BRIDGE: [u8; 20] = [0xB1; 20];
+    const OTHER: [u8; 20] = [0xC2; 20];
+    const TX: [u8; 32] = [0x11; 32];
+
+    /// In-memory provider for the predicate tests - no real RPC.
+    struct FakeProvider {
+        receipt: Option<ReceiptData>,
+        head: u64,
+    }
+    impl EvmReceiptProvider for FakeProvider {
+        fn get_transaction_receipt(&self, _tx_hash: &[u8; 32]) -> Result<Option<ReceiptData>> {
+            Ok(self.receipt.clone())
+        }
+        fn get_block_number(&self) -> Result<u64> {
+            Ok(self.head)
+        }
+    }
+
+    fn word(v: u64) -> [u8; 32] {
+        let mut w = [0u8; 32];
+        w[24..].copy_from_slice(&v.to_be_bytes());
+        w
+    }
+
+    /// Build BridgeFundsIn data: operationId, gross, net, commission, then
+    /// nativeCommission/srcChain/destChain/string-offset zero-filled.
+    fn bridge_data(op: u64, gross: u64, net: u64, commission: u64) -> Vec<u8> {
+        let mut d = Vec::new();
+        d.extend_from_slice(&word(op));
+        d.extend_from_slice(&word(gross));
+        d.extend_from_slice(&word(net));
+        d.extend_from_slice(&word(commission));
+        d.extend_from_slice(&[0u8; 32 * 4]); // nativeCommission, src, dest, str offset
+        d
+    }
+
+    fn bridge_log(op: u64, gross: u64, net: u64, commission: u64) -> LogEntry {
+        LogEntry {
+            address: BRIDGE,
+            topics: vec![event_topic0(BRIDGE_FUNDS_IN_SIG), word(0xdead)], // topic1 = sender (unused)
+            data: bridge_data(op, gross, net, commission),
+        }
+    }
+
+    fn receipt_with(logs: Vec<LogEntry>, block_number: u64) -> ReceiptData {
+        ReceiptData {
+            status_success: true,
+            block_number,
+            logs,
+        }
+    }
+
+    /// gross=1000, commission=50, net=950, op=7. head 112, block 100 -> depth 12.
+    fn happy_provider() -> FakeProvider {
+        FakeProvider {
+            receipt: Some(receipt_with(vec![bridge_log(7, 1000, 950, 50)], 100)),
+            head: 112,
+        }
+    }
+
+    fn verify(p: &FakeProvider) -> Result<()> {
+        verify_funds_in_event(p, &BRIDGE, 12, &TX, 7, 1000, 50)
+    }
+
+    // ---- topic0 drift guards (offline-pinned known-good vectors) ----
+
+    #[test]
+    fn topic0_vectors_are_pinned() {
+        assert_eq!(
+            hex::encode(event_topic0(FUNDS_IN_SIG)),
+            "cf4f3270b7400c5ca42954767c516b7c595dcd8038cdd121945a474c616208f8",
+            "FundsIn topic0 drifted"
+        );
+        assert_eq!(
+            hex::encode(event_topic0(BRIDGE_FUNDS_IN_SIG)),
+            "08f62fdb70e8436181cbb1e561f6059677b179778bb0e0b9789a277eca0767e5",
+            "BridgeFundsIn topic0 drifted"
+        );
+    }
+
+    // ---- happy path ----
+
+    #[test]
+    fn accepts_matching_bridge_funds_in() {
+        assert!(verify(&happy_provider()).is_ok());
+    }
+
+    // ---- receipt-level rejections ----
+
+    #[test]
+    fn rejects_missing_receipt() {
+        let p = FakeProvider {
+            receipt: None,
+            head: 112,
+        };
+        let e = verify(&p).unwrap_err().to_string();
+        assert!(e.contains("receipt not found"), "got: {e}");
+    }
+
+    #[test]
+    fn rejects_reverted_tx() {
+        let mut r = receipt_with(vec![bridge_log(7, 1000, 950, 50)], 100);
+        r.status_success = false;
+        let p = FakeProvider {
+            receipt: Some(r),
+            head: 112,
+        };
+        let e = verify(&p).unwrap_err().to_string();
+        assert!(e.contains("reverted"), "got: {e}");
+    }
+
+    // ---- log-matching rejections ----
+
+    #[test]
+    fn rejects_log_from_wrong_contract() {
+        let mut log = bridge_log(7, 1000, 950, 50);
+        log.address = OTHER;
+        let p = FakeProvider {
+            receipt: Some(receipt_with(vec![log], 100)),
+            head: 112,
+        };
+        let e = verify(&p).unwrap_err().to_string();
+        assert!(e.contains("no FundsIn/BridgeFundsIn log"), "got: {e}");
+    }
+
+    #[test]
+    fn rejects_wrong_topic0() {
+        let mut log = bridge_log(7, 1000, 950, 50);
+        log.topics[0] = word(0x1234); // not a FundsIn topic
+        let p = FakeProvider {
+            receipt: Some(receipt_with(vec![log], 100)),
+            head: 112,
+        };
+        let e = verify(&p).unwrap_err().to_string();
+        assert!(e.contains("no FundsIn/BridgeFundsIn log"), "got: {e}");
+    }
+
+    #[test]
+    fn rejects_ambiguous_multiple_logs() {
+        let p = FakeProvider {
+            receipt: Some(receipt_with(
+                vec![bridge_log(7, 1000, 950, 50), bridge_log(7, 1000, 950, 50)],
+                100,
+            )),
+            head: 112,
+        };
+        let e = verify(&p).unwrap_err().to_string();
+        assert!(e.contains("ambiguous"), "got: {e}");
+    }
+
+    #[test]
+    fn ignores_unrelated_logs_and_accepts() {
+        let unrelated = LogEntry {
+            address: OTHER,
+            topics: vec![word(0x9999)],
+            data: vec![],
+        };
+        let p = FakeProvider {
+            receipt: Some(receipt_with(
+                vec![unrelated, bridge_log(7, 1000, 950, 50)],
+                100,
+            )),
+            head: 112,
+        };
+        assert!(verify(&p).is_ok());
+    }
+
+    // ---- field-mismatch rejections ----
+
+    #[test]
+    fn rejects_operation_id_mismatch() {
+        let p = FakeProvider {
+            receipt: Some(receipt_with(vec![bridge_log(8, 1000, 950, 50)], 100)),
+            head: 112,
+        };
+        let e = verify(&p).unwrap_err().to_string();
+        assert!(e.contains("operationId mismatch"), "got: {e}");
+    }
+
+    #[test]
+    fn rejects_amount_mismatch() {
+        let p = FakeProvider {
+            receipt: Some(receipt_with(vec![bridge_log(7, 999, 949, 50)], 100)),
+            head: 112,
+        };
+        let e = verify(&p).unwrap_err().to_string();
+        assert!(e.contains("amount mismatch"), "got: {e}");
+    }
+
+    #[test]
+    fn rejects_commission_mismatch() {
+        let p = FakeProvider {
+            receipt: Some(receipt_with(vec![bridge_log(7, 1000, 950, 40)], 100)),
+            head: 112,
+        };
+        let e = verify(&p).unwrap_err().to_string();
+        assert!(e.contains("tokenCommission mismatch"), "got: {e}");
+    }
+
+    #[test]
+    fn rejects_inconsistent_net_amount() {
+        // gross-commission = 950 but log claims net = 900.
+        let p = FakeProvider {
+            receipt: Some(receipt_with(vec![bridge_log(7, 1000, 900, 50)], 100)),
+            head: 112,
+        };
+        let e = verify(&p).unwrap_err().to_string();
+        assert!(e.contains("netAmount mismatch"), "got: {e}");
+    }
+
+    #[test]
+    fn rejects_operation_id_exceeding_u64() {
+        let mut log = bridge_log(7, 1000, 950, 50);
+        // Set a high byte in the operationId word -> exceeds u64.
+        log.data[BFI_OPERATION_ID_OFF] = 0x01;
+        let p = FakeProvider {
+            receipt: Some(receipt_with(vec![log], 100)),
+            head: 112,
+        };
+        let e = verify(&p).unwrap_err().to_string();
+        assert!(e.contains("operationId") && e.contains("u64"), "got: {e}");
+    }
+
+    // ---- confirmation-depth rejections ----
+
+    #[test]
+    fn rejects_insufficient_depth() {
+        // head 111, block 100 -> depth 11 < 12.
+        let p = FakeProvider {
+            receipt: Some(receipt_with(vec![bridge_log(7, 1000, 950, 50)], 100)),
+            head: 111,
+        };
+        let e = verify(&p).unwrap_err().to_string();
+        assert!(e.contains("not final"), "got: {e}");
+    }
+
+    #[test]
+    fn accepts_exact_min_depth() {
+        // head 112, block 100 -> depth 12 == 12.
+        assert!(verify(&happy_provider()).is_ok());
+    }
+
+    #[test]
+    fn rejects_head_below_receipt_block() {
+        // head 99 < block 100 -> reorg.
+        let p = FakeProvider {
+            receipt: Some(receipt_with(vec![bridge_log(7, 1000, 950, 50)], 100)),
+            head: 99,
+        };
+        let e = verify(&p).unwrap_err().to_string();
+        assert!(e.contains("reorg"), "got: {e}");
+    }
+
+    // ---- #51 regression: listener booleans can no longer authorize ----
+
+    #[test]
+    fn issue_51_no_receipt_means_no_authorization() {
+        // Simulates a request whose listener set evm_event_valid/finalized=true
+        // but for which no real deposit exists: verification must still reject,
+        // proving the removed booleans no longer gate signing.
+        let p = FakeProvider {
+            receipt: None,
+            head: 112,
+        };
+        assert!(verify(&p).is_err());
+    }
+}

--- a/enclave/src/networks/evm/evm_event.rs
+++ b/enclave/src/networks/evm/evm_event.rs
@@ -16,6 +16,15 @@
 //! one; this predicate becomes trustless only once Helios (#77) verifies the
 //! RPC inside the TEE. This is the predicate + plumbing layer.
 //!
+//! #77 PREDICATE SHAPE (deliberate divergence): issue #77 sketches matching the
+//! exact listener-forwarded log (`evm_contract`, `evm_log_index`,
+//! `evm_event_topics`, `evm_event_data`). This module instead PINS the contract
+//! from config and independently DECODES + binds the semantic fields
+//! (`operationId`, gross/net/commission) from the log data. That is strictly
+//! stronger — the enclave never trusts a listener-forwarded raw log — so
+//! `evm_log_index` / `evm_event_topics` / `evm_event_data` are intentionally
+//! unused rather than an oversight.
+//!
 //! WHAT THIS DOES NOT BIND: `operationId` is a backend-assigned `uint256` with
 //! no on-chain cryptographic link to the RGB mint being signed, so confirming
 //! the deposit does not by itself prove it corresponds to *this* RGB transfer;
@@ -300,7 +309,7 @@ impl EvmReceiptProvider for AlloyEvmClient {
             .map_err(|e| {
                 EnclaveError::CrossCheck(format!("evm-rpc: eth_getTransactionReceipt failed: {e}"))
             })?;
-        Ok(receipt.map(map_alloy_receipt))
+        receipt.map(map_alloy_receipt).transpose()
     }
 
     fn get_block_number(&self) -> Result<u64> {
@@ -313,7 +322,13 @@ impl EvmReceiptProvider for AlloyEvmClient {
 
 /// Translate an alloy receipt into the enclave-local [`ReceiptData`] so no
 /// alloy types leak into the predicate.
-fn map_alloy_receipt(r: alloy::rpc::types::TransactionReceipt) -> ReceiptData {
+///
+/// Fails closed on a missing `block_number`: the confirmation-depth check is
+/// `head - block_number`, so a `None` defaulted to `0` would report the receipt
+/// as infinitely deep and pass finality. A mined tx always carries a block
+/// number (a pending tx yields no receipt at all), so this only guards against
+/// a malformed response, but a finality check must never default to "deep".
+fn map_alloy_receipt(r: alloy::rpc::types::TransactionReceipt) -> Result<ReceiptData> {
     let logs = r
         .inner
         .logs()
@@ -324,11 +339,18 @@ fn map_alloy_receipt(r: alloy::rpc::types::TransactionReceipt) -> ReceiptData {
             data: log.data().data.to_vec(),
         })
         .collect();
-    ReceiptData {
+    let block_number = r.block_number.ok_or_else(|| {
+        EnclaveError::CrossCheck(
+            "evm-rpc: FundsIn receipt has no block_number (pending/malformed) - refusing to \
+             treat an unmined receipt as confirmed"
+                .into(),
+        )
+    })?;
+    Ok(ReceiptData {
         status_success: r.status(),
-        block_number: r.block_number.unwrap_or(0),
+        block_number,
         logs,
-    }
+    })
 }
 
 /// Boot-time bound on the Helios light-client initial sync. If the client is
@@ -363,19 +385,36 @@ impl HeliosEvmClient {
     /// the first query is already verified. Any error (bad config, no
     /// checkpoint, sync timeout) is returned so boot leaves the provider unset
     /// and bridge signing fails closed.
-    pub fn new(cfg: &crate::config::HeliosConfig) -> Result<Self> {
+    pub fn new(cfg: &crate::config::HeliosConfig, expected_chain_id: u64) -> Result<Self> {
         use helios_ethereum::{config::networks::Network, EthereumClientBuilder};
 
-        let network = match cfg.network.to_ascii_lowercase().as_str() {
-            "mainnet" => Network::Mainnet,
-            "sepolia" => Network::Sepolia,
-            "holesky" => Network::Holesky,
+        // Canonical chain id for each supported network. Kept here rather than
+        // read from the network object so the consistency check below does not
+        // depend on Helios internals.
+        let (network, network_chain_id) = match cfg.network.to_ascii_lowercase().as_str() {
+            "mainnet" => (Network::Mainnet, 1u64),
+            "sepolia" => (Network::Sepolia, 11155111u64),
+            "holesky" => (Network::Holesky, 17000u64),
             other => {
                 return Err(EnclaveError::CrossCheck(format!(
                     "helios: unsupported HELIOS_NETWORK {other:?} (want mainnet|sepolia|holesky)"
                 )))
             }
         };
+        // #77 predicate 1: HELIOS_NETWORK must be consistent with the pinned
+        // EVM_CHAIN_ID. Both are operator-set at boot, so a mismatch is a
+        // misconfiguration (e.g. Helios on sepolia while the bridge is pinned to
+        // mainnet) that would otherwise verify FundsIn on the wrong chain.
+        // Skipped only when EVM_CHAIN_ID is unset (0), i.e. an unconfigured
+        // dev/mock deploy that pins no identity.
+        if expected_chain_id != 0 && expected_chain_id != network_chain_id {
+            return Err(EnclaveError::CrossCheck(format!(
+                "helios: HELIOS_NETWORK {:?} (chain id {network_chain_id}) is inconsistent with \
+                 the pinned EVM_CHAIN_ID {expected_chain_id} - refusing to verify FundsIn on a \
+                 different chain than the bridge is configured for",
+                cfg.network
+            )));
+        }
         let checkpoint = parse_checkpoint(cfg.checkpoint.as_deref())?;
 
         let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -443,20 +482,32 @@ impl EvmReceiptProvider for HeliosEvmClient {
             })?;
         // Map inline so the alloy-1.x receipt type is inferred, never named -
         // it must not cross the EvmReceiptProvider boundary (our alloy is 2.x).
-        Ok(receipt.map(|r| ReceiptData {
-            status_success: r.status(),
-            block_number: r.block_number.unwrap_or(0),
-            logs: r
-                .inner
-                .logs()
-                .iter()
-                .map(|log| LogEntry {
-                    address: log.address().into_array(),
-                    topics: log.topics().iter().map(|t| t.0).collect(),
-                    data: log.data().data.to_vec(),
+        // Fails closed on a missing block_number, same as `map_alloy_receipt`.
+        receipt
+            .map(|r| {
+                let block_number = r.block_number.ok_or_else(|| {
+                    EnclaveError::CrossCheck(
+                        "helios: FundsIn receipt has no block_number (pending/malformed) - \
+                         refusing to treat an unmined receipt as confirmed"
+                            .into(),
+                    )
+                })?;
+                Ok(ReceiptData {
+                    status_success: r.status(),
+                    block_number,
+                    logs: r
+                        .inner
+                        .logs()
+                        .iter()
+                        .map(|log| LogEntry {
+                            address: log.address().into_array(),
+                            topics: log.topics().iter().map(|t| t.0).collect(),
+                            data: log.data().data.to_vec(),
+                        })
+                        .collect(),
                 })
-                .collect(),
-        }))
+            })
+            .transpose()
     }
 
     fn get_block_number(&self) -> Result<u64> {

--- a/enclave/src/networks/evm/mod.rs
+++ b/enclave/src/networks/evm/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "rgb-validation")]
 pub mod crosscheck;
+#[cfg(feature = "evm-rpc")]
+pub mod evm_event;
 pub mod gas_tx;
 pub mod signing;
 pub mod validation;

--- a/enclave/src/networks/evm/validation.rs
+++ b/enclave/src/networks/evm/validation.rs
@@ -57,16 +57,15 @@ pub fn validate_source(amount: u64, source: &EvmSource) -> Result<RouteProof> {
             source.tx_hash.len()
         )));
     }
-    if !source.event_valid {
-        return Err(EnclaveError::CrossCheck(
-            "EVM event not validated by Listener".into(),
-        ));
-    }
-    if !source.event_finalized {
-        return Err(EnclaveError::CrossCheck(
-            "EVM event not yet finalized".into(),
-        ));
-    }
+
+    // NOTE (audit M-06 / #51): the listener-supplied `event_valid` /
+    // `event_finalized` booleans are NO LONGER trusted here - anyone reaching
+    // the enclave could set both `true`. EVM-event validity and finality are
+    // now established independently by the enclave itself in `handle_sign` via
+    // `networks::evm::evm_event::verify_funds_in_event` (the `evm-rpc` feature:
+    // fetches the FundsIn receipt and checks the operationId/amount/depth
+    // against the pinned bridge contract). The proto fields remain (ignored)
+    // until the listener stops sending them.
 
     Ok(RouteProof {
         amount,
@@ -281,24 +280,18 @@ mod tests {
             .contains(&format!("evm_tx_hash must be {TX_HASH_LEN} bytes")));
     }
 
+    /// Audit M-06 / #51: the listener-supplied `event_valid` / `event_finalized`
+    /// booleans are no longer read by `validate_source`, so flipping them to
+    /// `false` does NOT change the outcome. EVM-event validity/finality is now
+    /// established independently by `evm_event::verify_funds_in_event` in the
+    /// handler (see that module's `issue_51_no_receipt_means_no_authorization`).
     #[test]
-    fn source_rejects_invalid_event() {
+    fn source_ignores_listener_evm_booleans() {
         let mut source = source();
         source.event_valid = false;
-        assert!(validate_source(1_000, &source)
-            .unwrap_err()
-            .to_string()
-            .contains("EVM event not validated"));
-    }
-
-    #[test]
-    fn source_rejects_unfinalized_event() {
-        let mut source = source();
         source.event_finalized = false;
-        assert!(validate_source(1_000, &source)
-            .unwrap_err()
-            .to_string()
-            .contains("not yet finalized"));
+        // Shape is still valid and the booleans are ignored now.
+        assert!(validate_source(1_000, &source).is_ok());
     }
 
     #[test]

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -22,6 +22,16 @@ pub struct ServerContext {
     pub bridge_config: BridgeConfig,
     #[cfg(feature = "rgb-validation")]
     pub rgb_validator: Option<crate::networks::rgb::validation::RgbValidator>,
+    /// In-enclave EVM RPC client for independent `FundsIn` verification (#60).
+    /// `None` when the client could not be built; `handle_sign` fails closed on
+    /// `None` in bridge mode. Reaches the RPC only through the loopback vsock
+    /// forwarder, so responses are host-relayed and untrusted - see
+    /// [`crate::networks::evm::evm_event`].
+    #[cfg(feature = "evm-rpc")]
+    pub evm_rpc_client: Option<crate::networks::evm::evm_event::AlloyEvmClient>,
+    /// Pinned EVM-RPC config (loopback URL + min confirmations) for #60.
+    #[cfg(feature = "evm-rpc")]
+    pub evm_rpc_config: crate::config::EvmRpcConfig,
     /// In-enclave Bitcoin header chain for SPV verification. Populated at
     /// boot from the compile-time checkpoint; mutated by SubmitHeaders.
     /// `Mutex` because the enclave handles connections from a single
@@ -95,6 +105,10 @@ impl ServerContext {
             bridge_config,
             #[cfg(feature = "rgb-validation")]
             rgb_validator: None,
+            #[cfg(feature = "evm-rpc")]
+            evm_rpc_client: None,
+            #[cfg(feature = "evm-rpc")]
+            evm_rpc_config: crate::config::EvmRpcConfig::default(),
             header_chain,
             submit_rate_limiter: std::sync::Mutex::new(SubmitRateLimiter::default()),
         }
@@ -236,6 +250,45 @@ fn handle_sign(ctx: &ServerContext, req: SignRequest) -> Result<EnclaveResponse>
         &source_validated.proof,
         &destination_proof,
     )?;
+
+    // Independent EVM `FundsIn` verification (audit M-06 / #60, #51). In
+    // EVM -> RGB bridge mode, confirm the deposit really happened on-chain - via
+    // the enclave's own RPC call, not the listener's `event_valid` /
+    // `event_finalized` booleans (which are no longer trusted; see
+    // `evm::validation::validate_source`). Fail-closed: a missing client or any
+    // unmet predicate refuses the signature. Runs after the cheap local
+    // cross-checks and before the replay guard records the op, so the external
+    // RPC is only paid once the request is otherwise valid.
+    // NOTE: the RPC is reached through the untrusted host, so this becomes fully
+    // trustless only once Helios (#77) verifies it; see
+    // `crate::networks::evm::evm_event`.
+    #[cfg(all(feature = "evm-rpc", not(feature = "dev-mode")))]
+    if let (SourceNetwork::EvmSource(source), DestinationNetwork::RgbDestination(destination)) =
+        (source_ref, destination_ref)
+    {
+        let tx_hash: [u8; 32] = source.tx_hash.as_slice().try_into().map_err(|_| {
+            EnclaveError::CrossCheck(format!(
+                "evm_tx_hash must be 32 bytes, got {}",
+                source.tx_hash.len()
+            ))
+        })?;
+        let client = ctx.evm_rpc_client.as_ref().ok_or_else(|| {
+            EnclaveError::CrossCheck(
+                "evm-rpc build but RPC client unavailable - refusing to sign a bridge PSBT \
+                 without independently verifying the FundsIn deposit"
+                    .into(),
+            )
+        })?;
+        crate::networks::evm::evm_event::verify_funds_in_event(
+            client,
+            &ctx.bridge_config.bridge_contract,
+            ctx.evm_rpc_config.min_confirmations,
+            &tx_hash,
+            destination.operation_idx,
+            req.amount,
+            source.commission,
+        )?;
+    }
 
     // Soft operation-uniqueness guard (audit W-02 / #84). In EVM -> RGB
     // bridge mode, record the source/destination operation tuple and reject a

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -28,7 +28,8 @@ pub struct ServerContext {
     /// forwarder, so responses are host-relayed and untrusted - see
     /// [`crate::networks::evm::evm_event`].
     #[cfg(feature = "evm-rpc")]
-    pub evm_rpc_client: Option<crate::networks::evm::evm_event::AlloyEvmClient>,
+    pub evm_rpc_client:
+        Option<Box<dyn crate::networks::evm::evm_event::EvmReceiptProvider + Send + Sync>>,
     /// Pinned EVM-RPC config (loopback URL + min confirmations) for #60.
     #[cfg(feature = "evm-rpc")]
     pub evm_rpc_config: crate::config::EvmRpcConfig,
@@ -280,7 +281,7 @@ fn handle_sign(ctx: &ServerContext, req: SignRequest) -> Result<EnclaveResponse>
             )
         })?;
         crate::networks::evm::evm_event::verify_funds_in_event(
-            client,
+            &**client,
             &ctx.bridge_config.bridge_contract,
             ctx.evm_rpc_config.min_confirmations,
             &tx_hash,

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -291,6 +291,34 @@ fn handle_sign(ctx: &ServerContext, req: SignRequest) -> Result<EnclaveResponse>
         )?;
     }
 
+    // Fail-closed when the FundsIn verifier is not compiled in (audit M-06 /
+    // #60, #51). An EVM -> RGB bridge request is authorised by an EVM deposit,
+    // but #51 removed the listener-supplied `event_valid`/`event_finalized`
+    // booleans that used to gate it and the independent replacement lives behind
+    // the `evm-rpc` feature. A build without that feature therefore has NO
+    // evidence the deposit occurred - the consignment/PSBT checks prove the
+    // transfer shape but not that any EVM deposit backs it. Refuse rather than
+    // sign on the missing authorisation. Mirrors the M-01/#61 no-`spv` fundsOut
+    // refusal. dev-mode retains the legacy path for local testing. Compiled only
+    // when `evm-rpc` is absent, so it and the verification block above are
+    // mutually exclusive.
+    #[cfg(all(not(feature = "evm-rpc"), not(feature = "dev-mode")))]
+    if matches!(
+        (source_ref, destination_ref),
+        (
+            SourceNetwork::EvmSource(_),
+            DestinationNetwork::RgbDestination(_)
+        )
+    ) {
+        return Err(EnclaveError::CrossCheck(
+            "enclave was not built with --features evm-rpc: refusing to sign a bridge-mode PSBT \
+             without independently verifying the FundsIn deposit (the listener-supplied \
+             event_valid/event_finalized booleans are no longer trusted — audit M-06 / #60/#51). \
+             Rebuild with `--features evm-rpc` (or `helios` for the trustless path)."
+                .into(),
+        ));
+    }
+
     // Soft operation-uniqueness guard (audit W-02 / #84). In EVM -> RGB
     // bridge mode, record the source/destination operation tuple and reject a
     // same-op resubmission inside the TTL window. This is defense-in-depth

--- a/enclave/src/state.rs
+++ b/enclave/src/state.rs
@@ -212,7 +212,7 @@ pub struct EnclaveState {
     pub replay_guard: NonceReplayGuard,
     /// **Soft** dedup guard for EVM→RGB bridge PSBT operations, keyed on a
     /// hash of `(chain_id, bridge_contract, evm_tx_hash, operation_idx,
-    /// rgb_asset_id)` (see `validation::psbt_crosscheck::psbt_operation_key`).
+    /// rgb_asset_id)` (see `networks::rgb::psbt_validation::psbt_operation_key`).
     /// Rejects a same-operation resubmission inside the TTL window before
     /// signing (audit W-02 / #84).
     ///

--- a/enclave/tests/common/mod.rs
+++ b/enclave/tests/common/mod.rs
@@ -52,6 +52,10 @@ pub fn start_test_server_with_config(
         bridge_config,
         #[cfg(feature = "rgb-validation")]
         rgb_validator: None,
+        #[cfg(feature = "evm-rpc")]
+        evm_rpc_client: None,
+        #[cfg(feature = "evm-rpc")]
+        evm_rpc_config: utexo_bridge_enclave::config::EvmRpcConfig::default(),
         header_chain,
         submit_rate_limiter: std::sync::Mutex::new(server::SubmitRateLimiter::default()),
     });

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -550,6 +550,59 @@ fn test_sign_psbt_ignores_listener_evm_booleans() {
     }
 }
 
+/// Audit M-06 / #60 & #51: a build without the `evm-rpc` FundsIn verifier must
+/// refuse a bridge-mode PSBT rather than sign it on the (now-removed) listener
+/// booleans. This exercises the minimal build, where the `evm-rpc` fail-closed
+/// guard is the first bridge-mode gate (no `rgb-validation` consignment
+/// crosscheck precedes it). In `rgb-validation` builds the consignment binding
+/// is an additional earlier gate; the guard still fires for a request that
+/// carries a valid consignment but no in-enclave deposit verification.
+#[cfg(all(
+    not(feature = "rgb-validation"),
+    not(feature = "evm-rpc"),
+    not(feature = "dev-mode")
+))]
+#[test]
+fn test_no_evm_rpc_build_refuses_bridge_psbt() {
+    let port = common::start_test_server();
+
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+            mnemonic: String::new(),
+        })),
+    };
+    common::send_request(port, &init_req);
+
+    // Bridge mode (EVM source + RGB destination) with a shape-valid PSBT and
+    // consistent amounts, so it clears the route cross-checks and reaches the
+    // evm-rpc fail-closed guard. The listener booleans are set true but ignored.
+    let sign_req = EnclaveRequest {
+        request: Some(Request::Sign(sign_psbt_request(
+            vec![0xAA; 32],
+            true,
+            true,
+            1000,
+            0,
+            minimal_valid_psbt_bytes(),
+            500,
+        ))),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    match resp.response {
+        Some(Response::Error(e)) => {
+            assert_eq!(e.code, 3);
+            assert!(
+                e.message.contains("--features evm-rpc"),
+                "expected an evm-rpc feature refusal, got: {}",
+                e.message
+            );
+        }
+        other => panic!("expected a fail-closed error, got: {other:?}"),
+    }
+}
+
 #[test]
 #[cfg(not(feature = "dev-mode"))]
 fn test_sign_psbt_rejects_amount_mismatch() {

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -505,9 +505,16 @@ fn test_sign_psbt_before_init() {
 // PSBT enriched cross-check tests
 // =============================================================================
 
+/// Audit M-06 / #51: the listener-supplied `evm_event_valid` /
+/// `evm_event_finalized` booleans no longer authorize *or* block signing. With
+/// both `false`, the request is never rejected with the old boolean-driven
+/// messages: EVM-event validity/finality is now established independently by
+/// `networks::evm::evm_event` (unit-tested). Whatever else happens to the request
+/// (rejected for a missing consignment under rgb-validation, or for no
+/// enclave-owned PSBT input), it is never the booleans that decide it.
 #[test]
 #[cfg(not(feature = "dev-mode"))]
-fn test_sign_psbt_rejects_unfinalized() {
+fn test_sign_psbt_ignores_listener_evm_booleans() {
     let port = common::start_test_server();
 
     let init_req = EnclaveRequest {
@@ -521,7 +528,7 @@ fn test_sign_psbt_rejects_unfinalized() {
     let sign_req = EnclaveRequest {
         request: Some(Request::Sign(sign_psbt_request(
             vec![0xAA; 32],
-            true,
+            false,
             false,
             1000,
             0,
@@ -531,12 +538,15 @@ fn test_sign_psbt_rejects_unfinalized() {
     };
     let resp = common::send_request(port, &sign_req);
 
-    match &resp.response {
-        Some(Response::Error(e)) => {
-            assert_eq!(e.code, 3);
-            assert!(e.message.contains("not yet finalized"));
-        }
-        other => panic!("expected ErrorResponse, got {:?}", other),
+    // Any error is fine (other real checks may reject this synthetic request),
+    // but it must NOT be the removed listener-boolean checks.
+    if let Some(Response::Error(e)) = &resp.response {
+        assert!(
+            !e.message.contains("not yet finalized")
+                && !e.message.contains("not validated by Listener"),
+            "listener booleans must no longer drive rejection, got: {}",
+            e.message
+        );
     }
 }
 

--- a/parent/Cargo.toml
+++ b/parent/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/bin/attest_verify.rs"
 prost = "0.14"
 tonic = "0.14"
 tokio = { version = "1", features = ["full"] }
-federated-signer-proto = { git = "ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git", rev = "f61dcb76595c69af914107a74852ad013afed9df", package = "federated-signer-proto" }
+federated-signer-proto = { git = "ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git", rev = "295f9596ca78bba47f76985cdc405b712de025a1", package = "federated-signer-proto" }
 
 clap = { version = "4", features = ["derive"] }
 


### PR DESCRIPTION
feat(https://github.com/UTEXO-Protocol/enclave-signer/issues/77): trustless Helios-backed EVM FundsIn verification (experimental, default-off)
Adds a Helios light-client provider that cryptographically verifies the
execution/consensus RPC against a pinned weak-subjectivity checkpoint before a
FundsIn receipt is trusted, closing the host-trust gap left by https://github.com/UTEXO-Protocol/enclave-signer/issues/60 (whose RPC is
relayed by the untrusted host).

Reuses https://github.com/UTEXO-Protocol/enclave-signer/issues/60's EvmReceiptProvider trait + verify_funds_in_event predicate
unchanged: ServerContext now holds Option<Box<dyn EvmReceiptProvider>>, and
HeliosEvmClient (helios-ethereum, git tag 0.11.1) implements the same trait,
mapping Helios's alloy-1.x receipt inline so the second alloy major never
crosses the seam.

 - New default-OFF `helios` feature (extends `evm-rpc`); NOT in the shipped EIF.
 - Runtime-selectable + fail-closed: HELIOS_EXECUTION_RPC set -> verified path,
   else the raw https://github.com/UTEXO-Protocol/enclave-signer/issues/60 path; an unsynced/errored Helios refuses signing rather than
   downgrading. In-memory ConfigDB (no disk), mandatory pinned checkpoint,
   strict_checkpoint_age, no external fallback (only egress = two forwarders).
 - HeliosConfig + two loopback->vsock forwarders (18545/18550 -> 8003/8004).
 - CI compile/clippy bitrot-guard job (a live sync needs real RPCs; the predicate
   is already covered by https://github.com/UTEXO-Protocol/enclave-signer/issues/60's FakeProvider tests). README env rows + caveats.