### PR TITLE
test: restore audit regression tests dropped in the dev merge resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,15 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev protobuf-compiler
 
       # The `rgb-consignment` dep (used by the rgb-validation / spv
-      # feature combos) is hosted in a private repo and fetched over
-      # SSH. Load a read-only deploy key registered on
-      # UTEXO-Protocol/rgb-consignment-parser into the agent so cargo's
-      # `git fetch` can authenticate. Default-feature jobs don't pull
-      # the dep and run without this; every job below that enables
-      # `rgb-validation` or `spv` requires it.
+      # feature combos) and the `federated-signer-proto` dep are hosted
+      # in private repos and fetched over SSH. Load read-only deploy
+      # keys registered on UTEXO-Protocol/rgb-consignment-parser and
+      # UTEXO-Protocol/federated-signer-proto into the agent so cargo's
+      # `git fetch` can authenticate. The default feature set now
+      # includes `spv` (which pulls `rgb-validation`), so every build
+      # below needs these keys — including the minimal
+      # `--no-default-features` build, which still fetches the private
+      # proto crate.
       - name: Set up SSH for private RGB deps
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -54,6 +57,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+      # The default feature set is now `spv` (which pulls `rgb-validation`), so
+      # the default build/clippy/test below exercise the production signing
+      # path — the SPV-anchored fundsOut flow shipped in the EIF.
       - name: Build (default features)
         run: cargo build --workspace
 
@@ -78,6 +84,21 @@ jobs:
       # what the SPV unit + integration tests exercise.
       - name: Test (--features spv)
         run: cargo test -p utexo-bridge-enclave --features spv
+
+      # Minimal build: no features at all (`--no-default-features` drops the
+      # now-default `spv`). Keeps the no-SPV path compiling and exercises the
+      # M-01 / #61 guard that a no-spv build refuses to sign `fundsOut`
+      # (test_no_spv_build_refuses_funds_out_even_without_merkle_proofs).
+      # Skips the private `rgb-consignment` dep, but still fetches the private
+      # `federated-signer-proto` crate — the SSH agent set up above covers it.
+      - name: Build (minimal — no default features)
+        run: cargo build -p utexo-bridge-enclave --no-default-features
+
+      - name: Clippy (minimal — no default features)
+        run: cargo clippy -p utexo-bridge-enclave --no-default-features --all-targets -- -D warnings
+
+      - name: Test (minimal — no default features)
+        run: cargo test -p utexo-bridge-enclave --no-default-features
 
       # In-enclave EVM FundsIn verification (#60). The predicate + decoding
       # tests use a FakeProvider, so no real RPC is needed in CI.

--- a/enclave/src/networks/evm/crosscheck.rs
+++ b/enclave/src/networks/evm/crosscheck.rs
@@ -406,3 +406,668 @@ fn bytes32_to_usize(word: &[u8; 32]) -> Result<usize> {
     buf.copy_from_slice(&word[24..32]);
     Ok(u64::from_be_bytes(buf) as usize)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a mock `fundsOut` calldata in the 8-arg shape
+    /// (`fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)`
+    /// = [`FUNDS_OUT_SELECTOR_POOLS`]) with `amount` at
+    /// [`FUNDS_OUT_AMOUNT_OFFSET`] (byte 36). Remaining head slots are
+    /// zero-filled — none of the cross-checks here read them.
+    fn mock_funds_out_calldata(amount: u64) -> Vec<u8> {
+        let mut data = Vec::with_capacity(4 + 8 * 32);
+        data.extend_from_slice(&FUNDS_OUT_SELECTOR_POOLS);
+        // recipient (32, address)
+        data.extend_from_slice(&[0u8; 32]);
+        // amount (uint256) @ offset 36
+        let mut amt = [0u8; 32];
+        amt[24..].copy_from_slice(&amount.to_be_bytes());
+        data.extend_from_slice(&amt);
+        // 6 more head slots zero-filled (burnId, sourceChainId,
+        // destinationChainId, srcAddrOffset, proofOffset, settlementDataOffset).
+        data.extend_from_slice(&[0u8; 32 * 6]);
+        data
+    }
+
+    /// Parse the `fundsOut` `settlementData` (`abi.encode(uint256[] fundsInIds)`)
+    /// and return each `fundsInId` as a raw 32-byte word.
+    ///
+    /// Two levels of ABI indirection: (1) the `settlementData` head slot at
+    /// [`FUNDS_OUT_SETTLEMENT_DATA_HEAD_OFFSET`] holds a tail offset measured from
+    /// the start of the argument block (byte 4); (2) at that tail the `bytes` has
+    /// a length word followed by its payload, which is itself
+    /// `abi.encode(uint256[])` = `[0x20 offset][len N][N words]`. Every read is
+    /// bounds-checked (via [`extract_bytes32`]) and every offset/length is range
+    /// checked (via [`bytes32_to_usize`]); a malformed or truncated blob is a hard
+    /// error. Returns an empty vec when `settlementData` is empty.
+    ///
+    /// The enclave OVERWRITES `settlementData` ([`apply_op_id_binding`]) rather
+    /// than reading it, so this reader exists only to verify, in tests, that the
+    /// writer's encoding round-trips — hence it lives in the test module.
+    fn extract_funds_in_ids(call_data: &[u8]) -> Result<Vec<[u8; 32]>> {
+        // (1) settlementData tail offset (relative to the args start = byte 4).
+        let rel = bytes32_to_usize(&extract_bytes32(
+            call_data,
+            FUNDS_OUT_SETTLEMENT_DATA_HEAD_OFFSET,
+        )?)?;
+        let sd_start = 4usize
+            .checked_add(rel)
+            .ok_or_else(|| EnclaveError::CrossCheck("settlementData offset overflow".into()))?;
+
+        // settlementData `bytes`: [length word][payload].
+        let sd_len = bytes32_to_usize(&extract_bytes32(call_data, sd_start)?)?;
+        if sd_len == 0 {
+            return Ok(vec![]); // no fundsInIds claimed
+        }
+        let sd_body = sd_start
+            .checked_add(32)
+            .ok_or_else(|| EnclaveError::CrossCheck("settlementData body overflow".into()))?;
+        let sd_end = sd_body
+            .checked_add(sd_len)
+            .ok_or_else(|| EnclaveError::CrossCheck("settlementData length overflow".into()))?;
+        if call_data.len() < sd_end {
+            return Err(EnclaveError::CrossCheck(format!(
+                "call_data too short for settlementData: need {sd_end}, got {}",
+                call_data.len()
+            )));
+        }
+        let sd = &call_data[sd_body..sd_end];
+
+        // (2) sd = abi.encode(uint256[]) = [offset (0x20)][len N][N words].
+        let arr_off = bytes32_to_usize(&extract_bytes32(sd, 0)?)?;
+        let n = bytes32_to_usize(&extract_bytes32(sd, arr_off)?)?;
+        let elems_start = arr_off.checked_add(32).ok_or_else(|| {
+            EnclaveError::CrossCheck("fundsInIds elements offset overflow".into())
+        })?;
+        let span = n
+            .checked_mul(32)
+            .and_then(|x| elems_start.checked_add(x))
+            .ok_or_else(|| EnclaveError::CrossCheck("fundsInIds array size overflow".into()))?;
+        if sd.len() < span {
+            return Err(EnclaveError::CrossCheck(format!(
+                "settlementData too short for {n} fundsInIds: need {span}, got {}",
+                sd.len()
+            )));
+        }
+
+        let mut ids = Vec::with_capacity(n);
+        for i in 0..n {
+            ids.push(extract_bytes32(sd, elems_start + i * 32)?);
+        }
+        Ok(ids)
+    }
+
+    #[test]
+    fn extract_uint256_works() {
+        let mut data = vec![0u8; 40];
+        // Put value 42 at offset 8 (bytes 8..40)
+        data[39] = 42;
+        assert_eq!(extract_uint256_as_u64(&data, 8).unwrap(), 42);
+    }
+
+    #[test]
+    fn extract_uint256_rejects_short_data() {
+        let data = vec![0u8; 10];
+        assert!(extract_uint256_as_u64(&data, 0).is_err());
+    }
+
+    #[test]
+    fn extract_uint256_rejects_overflow() {
+        let mut data = vec![0u8; 32];
+        data[0] = 1; // high byte set — exceeds u64
+        assert!(extract_uint256_as_u64(&data, 0).is_err());
+    }
+
+    #[test]
+    fn extract_bytes32_works() {
+        let mut data = vec![0u8; 4 + 32 + 32 + 32];
+        let mut word = [0u8; 32];
+        word[0] = 0xab;
+        word[31] = 0xcd;
+        data[68..100].copy_from_slice(&word); // burnId head slot
+        assert_eq!(extract_bytes32(&data, 68).unwrap(), word);
+    }
+
+    #[test]
+    fn extract_bytes32_rejects_short_data() {
+        let data = vec![0u8; 90]; // burnId slot ends at 100
+        assert!(extract_bytes32(&data, 68).is_err());
+    }
+
+    #[test]
+    fn bytes32_to_usize_works() {
+        let mut w = [0u8; 32];
+        w[24..].copy_from_slice(&320u64.to_be_bytes());
+        assert_eq!(bytes32_to_usize(&w).unwrap(), 320);
+    }
+
+    #[test]
+    fn bytes32_to_usize_rejects_out_of_range() {
+        let mut w = [0u8; 32];
+        w[0] = 1; // high byte set — exceeds usize/u64
+        assert!(bytes32_to_usize(&w).is_err());
+    }
+
+    // =========================================================================
+    // Pools fundsOut tests — `validate_funds_out_transfer` (+ the #95 witness
+    // recency guard `assert_witnesses_confirmed`).
+    // =========================================================================
+
+    mod transfer {
+        use super::*;
+        use crate::networks::rgb::validation::{ifa, TransitionSummary, ValidatedConsignment};
+
+        fn validated_with_last(transition: TransitionSummary) -> ValidatedConsignment {
+            ValidatedConsignment {
+                contract_id: "rgb:test".into(),
+                chain_net: "bc".into(),
+                witness_txids: vec![],
+                all_op_ids: vec![transition.op_id.clone()],
+                mint_op_ids: vec![],
+                last_transition: Some(transition),
+                last_transfer_witness_txid: None,
+                last_transfer_witness_prevouts: None,
+                last_transfer_op_id: None,
+                non_mined_witness_txids: vec![],
+            }
+        }
+
+        fn transfer_transition(total_output_amount: u64) -> TransitionSummary {
+            TransitionSummary {
+                op_id: "transfer-op".into(),
+                transition_type: ifa::TS_TRANSFER,
+                total_output_amount,
+                asset_output_amount: total_output_amount,
+                outputs: Vec::new(),
+                burned_asset_amount: None,
+            }
+        }
+
+        #[test]
+        fn passes_when_total_output_covers_calldata_amount() {
+            let cd = mock_funds_out_calldata(1000);
+            let validated = validated_with_last(transfer_transition(1000));
+            assert!(validate_funds_out_transfer(&cd, &validated).is_ok());
+        }
+
+        #[test]
+        fn witnesses_confirmed_passes_when_all_mined() {
+            // No non-mined witnesses surfaced -> the recency guard is a no-op
+            // (audit 4th I-03 / #95).
+            let validated = validated_with_last(transfer_transition(1000));
+            assert!(super::super::assert_witnesses_confirmed(&validated).is_ok());
+        }
+
+        #[test]
+        fn witnesses_confirmed_rejects_non_mined() {
+            // A tentative/ignored witness in the RGB->EVM direction is an
+            // anomaly: the unlock settles an already-confirmed transfer.
+            let mut validated = validated_with_last(transfer_transition(1000));
+            validated.non_mined_witness_txids = vec![[0xABu8; 32]];
+            let err = super::super::assert_witnesses_confirmed(&validated).unwrap_err();
+            assert!(
+                err.to_string().contains("mined"),
+                "expected not-mined rejection, got: {err}"
+            );
+        }
+
+        #[test]
+        fn passes_when_total_output_exceeds_calldata_amount() {
+            let cd = mock_funds_out_calldata(1000);
+            let validated = validated_with_last(transfer_transition(2000));
+            assert!(validate_funds_out_transfer(&cd, &validated).is_ok());
+        }
+
+        /// P0 regression: even with a valid consignment that deserializes
+        /// and validates, the EVM-side release cannot exceed the RGB-side
+        /// transfer total. A consignment for 1 unit must not authorise a
+        /// withdrawal for 10^9.
+        #[test]
+        fn rejects_when_total_output_less_than_calldata_amount() {
+            let cd = mock_funds_out_calldata(1_000_000_000);
+            let validated = validated_with_last(transfer_transition(1));
+            let err = validate_funds_out_transfer(&cd, &validated).unwrap_err();
+            assert!(
+                err.to_string().contains("transfer amount mismatch"),
+                "expected transfer amount mismatch, got: {err}"
+            );
+        }
+
+        /// A burn consignment arriving on the (single) `fundsOut`
+        /// selector must be rejected by the transfer check — this is how
+        /// mint/burn stays off until it's wired by contract address.
+        #[test]
+        fn rejects_when_last_transition_is_not_transfer() {
+            let cd = mock_funds_out_calldata(500);
+            let mut t = transfer_transition(500);
+            t.transition_type = ifa::TS_BURN;
+            let validated = validated_with_last(t);
+            let err = validate_funds_out_transfer(&cd, &validated).unwrap_err();
+            assert!(
+                err.to_string().contains("requires a Transfer transition"),
+                "expected Transfer-required rejection, got: {err}"
+            );
+        }
+
+        #[test]
+        fn rejects_when_consignment_has_no_transition() {
+            let cd = mock_funds_out_calldata(500);
+            let validated = ValidatedConsignment {
+                contract_id: "rgb:test".into(),
+                chain_net: "bc".into(),
+                witness_txids: vec![],
+                all_op_ids: vec![],
+                mint_op_ids: vec![],
+                last_transition: None,
+                last_transfer_witness_txid: None,
+                last_transfer_witness_prevouts: None,
+                last_transfer_op_id: None,
+                non_mined_witness_txids: vec![],
+            };
+            let err = validate_funds_out_transfer(&cd, &validated).unwrap_err();
+            assert!(
+                err.to_string().contains("at least one transition"),
+                "expected no-transition rejection, got: {err}"
+            );
+        }
+
+        #[test]
+        fn rejects_non_funds_out_selector() {
+            // Calldata with a selector that isn't `fundsOut` — the
+            // selector-specific validator fails closed instead of silently
+            // passing (audit I-03: the pre-#127 contract was a no-op; a caller
+            // skipping the `apply_funds_out_binding` whitelist must not get an
+            // `Ok`).
+            let mut cd = vec![0u8; 4 + 8 * 32];
+            cd[..4].copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+            let validated = validated_with_last(transfer_transition(0));
+            let err = validate_funds_out_transfer(&cd, &validated).unwrap_err();
+            assert!(
+                err.to_string().contains("non-fundsOut selector"),
+                "expected the fail-closed selector guard, got: {err}"
+            );
+        }
+    }
+
+    // =========================================================================
+    // OpId binding — `apply_op_id_binding` (audit TEE-SE-02, spec §6/§7). The
+    // enclave derives burnId / fundsInIds from the consignment it validated and
+    // OVERWRITES them in the calldata it signs. No listener-supplied OpId is
+    // trusted or even read. `extract_funds_in_ids` confirms the writer's
+    // settlementData round-trips through the reader.
+    // =========================================================================
+
+    mod op_id_binding {
+        use super::*;
+        use crate::networks::rgb::validation::{ifa, TransitionSummary, ValidatedConsignment};
+        use sha3::{Digest, Keccak256};
+
+        const OP_ID: &str = "74c1d59264894a1bd44887fe84b36739c024bd50188e69baeeda845569313543";
+        const MINT_A: &str = "f5106c6ddb8b8fd3d1de3bda0106ae13ef0705dc36bfc543566362e5e8dd4bd5";
+        const MINT_B: &str = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+
+        /// The binding transform: keccak256 of the raw 32-byte OpId.
+        fn id(op_id: &str) -> [u8; 32] {
+            Keccak256::digest(hex::decode(op_id).unwrap()).into()
+        }
+
+        fn u256(n: usize) -> [u8; 32] {
+            let mut w = [0u8; 32];
+            w[24..].copy_from_slice(&(n as u64).to_be_bytes());
+            w
+        }
+
+        /// Build `fundsOut` calldata with the given `burnId` (offset 68) and
+        /// `fundsInIds` (encoded in `settlementData = abi.encode(uint256[])`).
+        /// `sourceAddress` and `proof` are present but empty. The ABI tail
+        /// layout mirrors what `extract_funds_in_ids` traverses.
+        fn mock_funds_out(burn_id: [u8; 32], funds_in_ids: &[[u8; 32]]) -> Vec<u8> {
+            let mut d = Vec::new();
+            d.extend_from_slice(&FUNDS_OUT_SELECTOR_POOLS);
+            d.extend_from_slice(&[0u8; 32]); // recipient
+            d.extend_from_slice(&[0u8; 32]); // amount
+            d.extend_from_slice(&burn_id); // burnId @68
+            d.extend_from_slice(&[0u8; 32]); // sourceChainId
+            d.extend_from_slice(&[0u8; 32]); // destinationChainId
+            d.extend_from_slice(&u256(256)); // sourceAddress tail offset (rel byte 4)
+            d.extend_from_slice(&u256(288)); // proof tail offset
+            d.extend_from_slice(&u256(320)); // settlementData tail offset
+            d.extend_from_slice(&u256(0)); // sourceAddress length = 0
+            d.extend_from_slice(&u256(0)); // proof length = 0
+                                           // settlementData bytes = abi.encode(uint256[]) = [0x20][N][ids...]
+            let payload_len = 64 + funds_in_ids.len() * 32;
+            d.extend_from_slice(&u256(payload_len)); // settlementData length
+            d.extend_from_slice(&u256(32)); // inner array offset (0x20)
+            d.extend_from_slice(&u256(funds_in_ids.len())); // N
+            for fid in funds_in_ids {
+                d.extend_from_slice(fid);
+            }
+            d
+        }
+
+        fn transition(op_id: &str, transition_type: u16) -> TransitionSummary {
+            TransitionSummary {
+                op_id: op_id.into(),
+                transition_type,
+                total_output_amount: 0,
+                asset_output_amount: 0,
+                outputs: Vec::new(),
+                burned_asset_amount: None,
+            }
+        }
+
+        /// The validated last-transfer OpId bytes for a given hex OpId - the
+        /// authoritative burnId source (`ValidatedConsignment::last_transfer_op_id`).
+        fn op_id_bytes(op_id: &str) -> [u8; 32] {
+            hex::decode(op_id).unwrap().try_into().unwrap()
+        }
+
+        fn validated(
+            last: Option<TransitionSummary>,
+            mint_op_ids: Vec<String>,
+        ) -> ValidatedConsignment {
+            // The burnId is derived from the rgbstd-VALIDATED OpId, so mirror
+            // production: `last_transfer_op_id` carries the same OpId as the
+            // last transition (set by `read_last_transfer_witness` for a
+            // TS_TRANSFER last transition).
+            let last_transfer_op_id = last.as_ref().map(|t| op_id_bytes(&t.op_id));
+            ValidatedConsignment {
+                contract_id: "rgb:test".into(),
+                chain_net: "bc".into(),
+                witness_txids: vec![],
+                all_op_ids: last
+                    .as_ref()
+                    .map(|t| vec![t.op_id.clone()])
+                    .unwrap_or_default(),
+                mint_op_ids,
+                last_transition: last,
+                last_transfer_witness_txid: None,
+                last_transfer_witness_prevouts: None,
+                last_transfer_op_id,
+                non_mined_witness_txids: vec![],
+            }
+        }
+
+        // ---- apply_op_id_binding (override, not verify) ----
+
+        /// Writes burnId@68 = keccak256(validated OpId), overriding whatever the
+        /// bridge put there. The OpId is sourced from the rgbstd-validated
+        /// transfer (`last_transfer_op_id`), not the flat parser (audit M-02 / #93).
+        #[test]
+        fn writes_burn_id_from_validated_op_id() {
+            let cd = mock_funds_out([0xEE; 32], &[]); // bogus burnId in input
+            let v = validated(Some(transition(OP_ID, ifa::TS_TRANSFER)), vec![]);
+            let out = apply_op_id_binding(&cd, &v).unwrap();
+            assert_eq!(
+                extract_bytes32(&out, FUNDS_OUT_BURN_ID_OFFSET).unwrap(),
+                id(OP_ID)
+            );
+        }
+
+        /// Fail closed when no validated OpId was extracted (e.g. a non-Transfer
+        /// last transition): the enclave must refuse rather than fall back to a
+        /// listener- or flat-parser-supplied burnId.
+        #[test]
+        fn rejects_when_validated_op_id_missing() {
+            let cd = mock_funds_out([0xEE; 32], &[]);
+            let mut v = validated(Some(transition(OP_ID, ifa::TS_TRANSFER)), vec![]);
+            v.last_transfer_op_id = None;
+            let err = apply_op_id_binding(&cd, &v).unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("validated OpId of the release transition"),
+                "got: {err}"
+            );
+        }
+
+        /// Writes ALL mint OpIds into settlementData, overriding the bridge's set.
+        #[test]
+        fn writes_all_mint_funds_in_ids() {
+            let cd = mock_funds_out([0xEE; 32], &[[0x11; 32], [0x22; 32]]);
+            let v = validated(
+                Some(transition(OP_ID, ifa::TS_BURN)),
+                vec![MINT_A.into(), MINT_B.into()],
+            );
+            let out = apply_op_id_binding(&cd, &v).unwrap();
+            assert_eq!(
+                extract_funds_in_ids(&out).unwrap(),
+                vec![id(MINT_A), id(MINT_B)]
+            );
+        }
+
+        /// No mints in the consignment → empty fundsInIds (not an error).
+        #[test]
+        fn writes_empty_funds_in_ids_when_no_mints() {
+            let cd = mock_funds_out([0xEE; 32], &[[0x11; 32]]);
+            let v = validated(Some(transition(OP_ID, ifa::TS_BURN)), vec![]);
+            let out = apply_op_id_binding(&cd, &v).unwrap();
+            assert!(extract_funds_in_ids(&out).unwrap().is_empty());
+        }
+
+        /// Override, not verify: a fully bogus input (wrong burnId AND wrong
+        /// fundsInIds) is rewritten to the consignment's values.
+        #[test]
+        fn overrides_whatever_the_bridge_sent() {
+            let cd = mock_funds_out([0xEE; 32], &[[0xAB; 32]]);
+            let v = validated(Some(transition(OP_ID, ifa::TS_BURN)), vec![MINT_A.into()]);
+            let out = apply_op_id_binding(&cd, &v).unwrap();
+            assert_eq!(
+                extract_bytes32(&out, FUNDS_OUT_BURN_ID_OFFSET).unwrap(),
+                id(OP_ID)
+            );
+            assert_eq!(extract_funds_in_ids(&out).unwrap(), vec![id(MINT_A)]);
+        }
+
+        /// The non-OpId fields (recipient, amount) are left exactly as sent.
+        #[test]
+        fn preserves_non_op_id_fields() {
+            let mut cd = mock_funds_out([0xEE; 32], &[[0x11; 32]]);
+            cd[4..36].copy_from_slice(&u256(0xBEEF)); // recipient marker
+            cd[36..68].copy_from_slice(&u256(123_456)); // amount marker
+            let v = validated(Some(transition(OP_ID, ifa::TS_BURN)), vec![MINT_A.into()]);
+            let out = apply_op_id_binding(&cd, &v).unwrap();
+            assert_eq!(&out[4..36], &u256(0xBEEF));
+            assert_eq!(&out[36..68], &u256(123_456));
+        }
+
+        /// A mint OpId that isn't 32-byte hex can not be transformed - fail
+        /// closed. (The burnId now comes from the pre-validated
+        /// `last_transfer_op_id` bytes, so the only string-decoded OpIds left
+        /// are the `fundsInIds` mint set.)
+        #[test]
+        fn rejects_non_hex_op_id() {
+            let cd = mock_funds_out([0xEE; 32], &[]);
+            let v = validated(
+                Some(transition(OP_ID, ifa::TS_TRANSFER)),
+                vec!["not-hex".into()],
+            );
+            let err = apply_op_id_binding(&cd, &v).unwrap_err();
+            assert!(
+                err.to_string().contains("hex-decodable")
+                    || err.to_string().contains("expected 32"),
+                "expected op_id decode rejection, got: {err}"
+            );
+        }
+
+        /// Calldata too short to hold the fundsOut head is rejected.
+        #[test]
+        fn rejects_calldata_too_short() {
+            let v = validated(Some(transition(OP_ID, ifa::TS_BURN)), vec![]);
+            let err = apply_op_id_binding(&[0u8; 100], &v).unwrap_err();
+            assert!(err.to_string().contains("too short"), "got: {err}");
+        }
+
+        /// No validated release OpId to bind against -> hard error.
+        #[test]
+        fn rejects_no_transition() {
+            let cd = mock_funds_out([0xEE; 32], &[]);
+            let v = validated(None, vec![]);
+            let err = apply_op_id_binding(&cd, &v).unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("validated OpId of the release transition"),
+                "got: {err}"
+            );
+        }
+
+        // ---- settlementData ABI round-trip (writer vs reader agree) ----
+
+        #[test]
+        fn settlement_parser_round_trips() {
+            let ids = [id(MINT_A), id(MINT_B)];
+            let cd = mock_funds_out(id(OP_ID), &ids);
+            assert_eq!(extract_funds_in_ids(&cd).unwrap(), ids.to_vec());
+        }
+
+        #[test]
+        fn settlement_parser_empty() {
+            let cd = mock_funds_out(id(OP_ID), &[]);
+            assert!(extract_funds_in_ids(&cd).unwrap().is_empty());
+        }
+    }
+
+    // =========================================================================
+    // BtcRelay-agreement cross-check (#57 / #122) — `verify_btc_relay_agreement`.
+    // These exercise `proof` decoding and header comparison directly against a
+    // synthetic regtest header chain.
+    // =========================================================================
+
+    mod btc_relay {
+        use super::*;
+        use crate::networks::rgb::spv::{Checkpoint, HeaderChain, Network};
+        use bitcoin::block::{Header, Version};
+        use bitcoin::consensus::serialize;
+        use bitcoin::hashes::Hash as _;
+
+        /// Encode `n` as a big-endian 32-byte ABI word.
+        fn u256_be(n: u64) -> [u8; 32] {
+            let mut w = [0u8; 32];
+            w[24..].copy_from_slice(&n.to_be_bytes());
+            w
+        }
+
+        /// A regtest chain with a single synthetic header at height 1 (PoW is
+        /// skipped on regtest — same pattern as the `spv::chain` tests).
+        /// Returns the chain and the header's DISPLAY-order block hash — the
+        /// byte order the calldata `commitmentHash` carries.
+        fn chain_with_one_header() -> (HeaderChain, [u8; 32]) {
+            let mut chain = HeaderChain::new(
+                Network::Regtest,
+                Checkpoint {
+                    height: 0,
+                    hash: [0u8; 32],
+                    bits: 0x207fffff,
+                    time: 1_700_000_000,
+                    is_real: false,
+                },
+            );
+            let header = Header {
+                version: Version::ONE,
+                prev_blockhash: bitcoin::BlockHash::from_byte_array([0u8; 32]),
+                merkle_root: bitcoin::TxMerkleNode::from_byte_array([0xAB; 32]),
+                time: 1_700_000_001,
+                bits: bitcoin::CompactTarget::from_consensus(0x207fffff),
+                nonce: 0,
+            };
+            chain.submit_headers(1, &[serialize(&header)]).unwrap();
+            let mut display: [u8; 32] = header.block_hash().to_byte_array();
+            display.reverse();
+            (chain, display)
+        }
+
+        /// `fundsOut` calldata carrying a well-formed `proof` tail. The 8 head
+        /// slots are zero except `proofOffset` (slot 6), which points at the
+        /// tail laid out right after the head (= 256 bytes from the args
+        /// start). Tail: `[length=64][blockHeight uint256][commitmentHash]`.
+        fn calldata_with_proof(block_height: u32, commitment_display: [u8; 32]) -> Vec<u8> {
+            let mut data = Vec::new();
+            data.extend_from_slice(&FUNDS_OUT_SELECTOR_POOLS);
+            let mut head = [0u8; 8 * 32];
+            head[6 * 32..7 * 32].copy_from_slice(&u256_be(256)); // proofOffset
+            data.extend_from_slice(&head);
+            data.extend_from_slice(&u256_be(64)); // proof bytes length
+            data.extend_from_slice(&u256_be(block_height as u64)); // blockHeight
+            data.extend_from_slice(&commitment_display); // commitmentHash
+            data
+        }
+
+        #[test]
+        fn passes_on_matching_commitment() {
+            let (chain, display_hash) = chain_with_one_header();
+            let cd = calldata_with_proof(1, display_hash);
+            assert!(verify_btc_relay_agreement(&cd, &chain).is_ok());
+        }
+
+        #[test]
+        fn rejects_mismatched_commitment() {
+            let (chain, _display_hash) = chain_with_one_header();
+            let cd = calldata_with_proof(1, [0x11; 32]);
+            let err = verify_btc_relay_agreement(&cd, &chain).unwrap_err();
+            assert!(err.to_string().contains("commitmentHash"), "got: {err}");
+        }
+
+        #[test]
+        fn rejects_internal_order_commitment() {
+            // Defends the byte-order contract: feeding the INTERNAL-order hash
+            // (the un-reversed `block_hash()` bytes) must be rejected — the
+            // calldata convention is display order.
+            let (chain, mut display_hash) = chain_with_one_header();
+            display_hash.reverse(); // back to internal order
+            let cd = calldata_with_proof(1, display_hash);
+            assert!(verify_btc_relay_agreement(&cd, &chain).is_err());
+        }
+
+        #[test]
+        fn rejects_height_beyond_tip() {
+            let (chain, display_hash) = chain_with_one_header();
+            let cd = calldata_with_proof(99, display_hash);
+            let err = verify_btc_relay_agreement(&cd, &chain).unwrap_err();
+            assert!(
+                err.to_string().contains("no header at block height 99"),
+                "got: {err}"
+            );
+        }
+
+        #[test]
+        fn inert_when_proof_empty() {
+            // The current live calldata shape zero-fills the proof offset, so
+            // the decoder reads an empty `proof` and the check is a no-op.
+            let (chain, _) = chain_with_one_header();
+            let cd = mock_funds_out_calldata(1_000);
+            assert!(verify_btc_relay_agreement(&cd, &chain).is_ok());
+        }
+
+        #[test]
+        fn noop_on_non_fundsout_selector() {
+            let (chain, _) = chain_with_one_header();
+            let cd = vec![0xde, 0xad, 0xbe, 0xef]; // not the fundsOut selector
+            assert!(verify_btc_relay_agreement(&cd, &chain).is_ok());
+        }
+
+        #[test]
+        fn rejects_malformed_proof_length() {
+            let (chain, display_hash) = chain_with_one_header();
+            let mut cd = calldata_with_proof(1, display_hash);
+            // Corrupt the proof `bytes` length word (at byte 260) to a
+            // non-zero, non-64 value: a calldata that claims a proof must
+            // carry a 64-byte one.
+            cd[260..292].copy_from_slice(&u256_be(33));
+            let err = verify_btc_relay_agreement(&cd, &chain).unwrap_err();
+            assert!(err.to_string().contains("64 bytes"), "got: {err}");
+        }
+
+        #[test]
+        fn rejects_blockheight_over_u32() {
+            let (chain, display_hash) = chain_with_one_header();
+            let mut cd = calldata_with_proof(1, display_hash);
+            // Set a blockHeight word (at byte 292) that overflows u32.
+            let mut huge = [0u8; 32];
+            huge[20] = 0x01; // a bit set above the low 4 bytes
+            cd[292..324].copy_from_slice(&huge);
+            let err = verify_btc_relay_agreement(&cd, &chain).unwrap_err();
+            assert!(err.to_string().contains("u32 range"), "got: {err}");
+        }
+    }
+}

--- a/enclave/src/networks/evm/validation.rs
+++ b/enclave/src/networks/evm/validation.rs
@@ -300,10 +300,68 @@ mod tests {
         let mut destination = destination();
         destination.call_data[..4].copy_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
         with_ctx(&config(), |ctx| {
-            assert!(validate_destination(&destination, ctx)
+            let msg = validate_destination(&destination, ctx)
                 .unwrap_err()
-                .to_string()
-                .contains("unexpected calldata selector"));
+                .to_string();
+            // The error must both name the failing predicate and echo the
+            // offending selector so an operator can see WHAT was rejected.
+            assert!(
+                msg.contains("unexpected calldata selector") && msg.contains("deadbeef"),
+                "expected selector rejection echoing the selector hex, got: {msg}"
+            );
+        });
+    }
+
+    #[test]
+    fn rejects_calldata_shorter_than_selector() {
+        let mut destination = destination();
+        // 3 bytes can't carry a 4-byte selector.
+        destination.call_data = vec![0x1a, 0xd8, 0x80];
+        with_ctx(&config(), |ctx| {
+            let err = validate_destination(&destination, ctx).unwrap_err();
+            assert!(
+                err.to_string().contains("call_data too short"),
+                "expected too-short rejection, got: {err}"
+            );
+        });
+    }
+
+    #[test]
+    fn rejects_calldata_over_size_cap() {
+        // A maximally packed calldata must be rejected up-front (audit I-06 /
+        // #90), before selector dispatch or any offset extraction. Start from
+        // a valid fundsOut destination and pad the tail past the cap.
+        let mut destination = destination();
+        destination
+            .call_data
+            .resize(MAX_FUNDS_OUT_CALL_DATA_LEN + 1, 0u8);
+        with_ctx(&config(), |ctx| {
+            let err = validate_destination(&destination, ctx).unwrap_err();
+            assert!(
+                err.to_string().contains("call_data too large"),
+                "expected too-large rejection, got: {err}"
+            );
+        });
+    }
+
+    #[test]
+    fn accepts_calldata_at_size_cap() {
+        // Exactly at the cap is allowed; the selector head is preserved so
+        // dispatch still recognizes the fundsOut shape.
+        let mut destination = destination();
+        destination
+            .call_data
+            .resize(MAX_FUNDS_OUT_CALL_DATA_LEN, 0u8);
+        destination.call_data[..4].copy_from_slice(&FUNDS_OUT_SELECTOR_POOLS);
+        // The zero-padded tail may still fail the later ABI decode; assert
+        // only that it is NOT the size error.
+        with_ctx(&config(), |ctx| {
+            if let Err(e) = validate_destination(&destination, ctx) {
+                assert!(
+                    !e.to_string().contains("call_data too large"),
+                    "calldata exactly at the cap must not trip the size check, got: {e}"
+                );
+            }
         });
     }
 
@@ -316,6 +374,55 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("chain_id mismatch"));
+        });
+    }
+
+    #[test]
+    fn rejects_zero_chain_id() {
+        let mut destination = destination();
+        destination.chain_id = 0;
+        with_ctx(&config(), |ctx| {
+            assert!(validate_destination(&destination, ctx)
+                .unwrap_err()
+                .to_string()
+                .contains("chain_id must be > 0"));
+        });
+    }
+
+    #[test]
+    fn rejects_proxy_contract_mismatch() {
+        let mut destination = destination();
+        destination.proxy_contract = vec![0xBB; ADDRESS_LEN]; // pinned is 0xAA
+        with_ctx(&config(), |ctx| {
+            let err = validate_destination(&destination, ctx).unwrap_err();
+            assert!(
+                err.to_string().contains("proxy_contract mismatch"),
+                "got: {err}"
+            );
+        });
+    }
+
+    #[test]
+    fn rejects_missing_proxy_contract() {
+        let mut destination = destination();
+        destination.proxy_contract = vec![];
+        with_ctx(&config(), |ctx| {
+            assert!(validate_destination(&destination, ctx)
+                .unwrap_err()
+                .to_string()
+                .contains(&format!("proxy_contract must be {ADDRESS_LEN} bytes")));
+        });
+    }
+
+    #[test]
+    fn rejects_expired_deadline() {
+        let mut destination = destination();
+        destination.deadline = 1; // Unix timestamp 1 is long expired
+        with_ctx(&config(), |ctx| {
+            assert!(validate_destination(&destination, ctx)
+                .unwrap_err()
+                .to_string()
+                .contains("deadline expired"));
         });
     }
 

--- a/enclave/src/networks/rgb/mod.rs
+++ b/enclave/src/networks/rgb/mod.rs
@@ -305,4 +305,265 @@ mod tests {
 
         assert!(err.to_string().contains("not hex-decodable"));
     }
+
+    // =========================================================================
+    // Asset-identity binding, DESTINATION path — successor of the dropped
+    // `evm_crosscheck::asset_bind` suite (audit TEE-SE-01). Its target,
+    // `bind_asset_identity`, was removed in the networks/ split; the legs are
+    // now INLINED in `validate_destination_anchor` after
+    // `validate_consignment`, so that function is the narrowest callable
+    // unit. Driven end-to-end with the in-tree mainnet transfer fixture
+    // validated offline against a stub Esplora (the resolver only phones
+    // home for the genesis-hash chain-identity check; the fixture embeds its
+    // witness txs, registered as tentative via `add_consignment_txes`).
+    //
+    // Path asymmetry (deliberate): this path enforces the RGB_ASSET_ID pin
+    // UNCONDITIONALLY — a post-merge strengthening — whereas the source path
+    // (`validation::validate_source`) gates it on
+    // `BridgeConfig::is_configured()`; see
+    // `validation::tests::asset_bind::pin_check_skipped_when_config_unconfigured`.
+    // =========================================================================
+
+    mod asset_bind {
+        use super::*;
+        use crate::config::BridgeConfig;
+        use crate::networks::rgb::spv::{Checkpoint, HeaderChain, Network};
+        use crate::networks::rgb::validation::RgbValidator;
+        use rgbstd::containers::{ConsignmentExt, FileContent, Transfer};
+        use std::io::Cursor;
+        use std::sync::Mutex;
+
+        const TRANSFER_FIXTURE: &[u8] =
+            include_bytes!("../../../tests/fixtures/transfer_consignment.rgbc");
+
+        /// Contract id of `TRANSFER_FIXTURE`. Kept as a literal (the old
+        /// suite's `PIN`), re-derived and asserted in [`fixture_asset_id`] so
+        /// a fixture swap fails loud instead of silently retargeting every
+        /// binding test.
+        const FIXTURE_ASSET_ID: &str = "rgb:fuhLYX9G-eC8gDvf-V0XpYFH-ceSafoc-lGutAYq-~SExGU4";
+
+        /// The validated asset identity: the fixture's genesis contract id.
+        fn fixture_asset_id() -> String {
+            let t = Transfer::load(Cursor::new(TRANSFER_FIXTURE)).expect("load transfer fixture");
+            let id = t.contract_id().to_string();
+            assert_eq!(
+                id, FIXTURE_ASSET_ID,
+                "transfer fixture contract id drifted — update FIXTURE_ASSET_ID"
+            );
+            id
+        }
+
+        /// Stub Esplora serving only `GET /block-height/0` with the mainnet
+        /// genesis hash — all offline rgbstd validation of the fixture needs:
+        /// the resolver phones home only for the genesis-hash chain-identity
+        /// check, and the fixture embeds its witness txs (registered as
+        /// tentative via `add_consignment_txes`).
+        fn spawn_stub_esplora() -> String {
+            use std::io::{Read as _, Write as _};
+            use std::net::TcpListener;
+
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind stub esplora");
+            let addr = listener.local_addr().unwrap();
+            std::thread::spawn(move || {
+                for stream in listener.incoming() {
+                    let Ok(mut stream) = stream else { break };
+                    let mut buf = [0u8; 4096];
+                    let n = stream.read(&mut buf).unwrap_or(0);
+                    let req = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let first = req.lines().next().unwrap_or("").to_string();
+                    if !first.starts_with("GET /block-height/0") {
+                        let _ = stream.write_all(
+                            b"HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+                        );
+                        continue;
+                    }
+                    let body = bitcoin::constants::genesis_block(bitcoin::Network::Bitcoin)
+                        .block_hash()
+                        .to_string();
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: text/plain\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes());
+                }
+            });
+            format!("http://{addr}")
+        }
+
+        /// Fully-pinned operator config (`is_configured() == true`) with the
+        /// given RGB_ASSET_ID.
+        fn pinned_config(rgb_asset_id: &str) -> BridgeConfig {
+            BridgeConfig {
+                chain_id: 1,
+                bridge_contract: [0x11; 20],
+                rgb_asset_id: rgb_asset_id.into(),
+                gas_tx_allowed_to: None,
+                ..Default::default()
+            }
+        }
+
+        /// Fully-empty operator config — no RGB_ASSET_ID pin at all.
+        fn unconfigured_config() -> BridgeConfig {
+            BridgeConfig {
+                chain_id: 0,
+                bridge_contract: [0u8; 20],
+                rgb_asset_id: String::new(),
+                gas_tx_allowed_to: None,
+                ..Default::default()
+            }
+        }
+
+        /// A destination around the fixture consignment, hash-bound, with
+        /// deliberately garbage `psbt_bytes`: PSBT deserialization runs
+        /// strictly AFTER every asset-binding leg, so its distinctive error
+        /// is this suite's proof that the binding was traversed (a PSBT
+        /// genuinely anchored to the fixture's mainnet witness tx is not
+        /// constructible in a unit test).
+        fn fixture_destination(asset_id: &str) -> RgbDestination {
+            RgbDestination {
+                operation_idx: 0,
+                psbt_bytes: b"not-a-psbt".to_vec(),
+                psbt_output_amount: 0,
+                asset_id: asset_id.into(),
+                consignment: TRANSFER_FIXTURE.to_vec(),
+                consignment_hash: Keccak256::digest(TRANSFER_FIXTURE).to_vec(),
+            }
+        }
+
+        /// Drive `validate_destination_anchor` (the unit the binding is
+        /// inlined in) with a stub-Esplora validator.
+        fn run_validate_destination_anchor(
+            destination: &RgbDestination,
+            config: &BridgeConfig,
+        ) -> Result<()> {
+            let url = spawn_stub_esplora();
+            let validator = RgbValidator::new(url, "bitcoin").expect("validator");
+            let chain = Mutex::new(HeaderChain::new(
+                Network::Mainnet,
+                Checkpoint {
+                    height: 0,
+                    hash: [0u8; 32],
+                    bits: 0x1d00_ffff,
+                    time: 1_700_000_000,
+                    is_real: false,
+                },
+            ));
+            let ctx = ValidationContext {
+                bridge_config: config,
+                rgb_validator: Some(&validator),
+                header_chain: &chain,
+            };
+            validate_destination_anchor(destination, 0, 0, &ctx)
+        }
+
+        /// Happy path (old `binds_when_contract_id_matches_pin`): validated
+        /// contract_id == declared asset_id == pinned RGB_ASSET_ID. Every
+        /// binding leg passes and validation proceeds to the PSBT stage.
+        #[test]
+        fn binds_when_contract_id_matches_pin() {
+            let id = fixture_asset_id();
+            let err =
+                run_validate_destination_anchor(&fixture_destination(&id), &pinned_config(&id))
+                    .unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("psbt_bytes is not a valid PSBT"),
+                "expected to reach the PSBT stage past asset binding, got: {msg}"
+            );
+            assert!(
+                !msg.contains("contract_id mismatch") && !msg.contains("RGB_ASSET_ID"),
+                "asset binding must have passed, got: {msg}"
+            );
+        }
+
+        /// Old `binds_when_declared_is_empty`, semantics INVERTED by a
+        /// deliberate post-merge strengthening: the destination must declare
+        /// its asset — an empty `asset_id` fails closed before the validator
+        /// even runs, instead of binding via the pin alone. This same
+        /// rejection carries the old
+        /// `rejects_foreign_asset_even_when_declared_is_empty` guarantee:
+        /// with an empty declared id *nothing* binds, foreign or not.
+        #[test]
+        fn rejects_when_declared_is_empty() {
+            let err = run_validate_destination_anchor(
+                &fixture_destination(""),
+                &pinned_config(FIXTURE_ASSET_ID),
+            )
+            .unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("RGB destination asset_id is empty"),
+                "expected empty-declared rejection, got: {err}"
+            );
+        }
+
+        /// Old `rejects_foreign_asset_even_when_declared_is_empty`, adapted:
+        /// empty declarations are rejected up-front (previous test), so the
+        /// closest reachable form of the TEE-SE-01 funds-theft path is a
+        /// listener that *colludes* — declaring the foreign asset
+        /// consistently with the consignment. The pin must still reject it:
+        /// RGB_ASSET_ID is load-bearing regardless of what the listener says.
+        #[test]
+        fn rejects_foreign_asset_even_when_declared_agrees() {
+            let id = fixture_asset_id();
+            let err = run_validate_destination_anchor(
+                &fixture_destination(&id),
+                &pinned_config("rgb:some-other-pinned-asset"),
+            )
+            .unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("contract_id mismatch") && msg.contains("pinned RGB_ASSET_ID"),
+                "expected pin mismatch, got: {msg}"
+            );
+        }
+
+        /// Old `rejects_when_pin_absent` — semantics carry, STRENGTHENED:
+        /// this path fails closed on a missing RGB_ASSET_ID pin
+        /// UNCONDITIONALLY (no `is_configured()` gate), a deliberate
+        /// post-merge hardening. An rgb-validation-enabled enclave with no
+        /// pin must not sign a send-RGB PSBT in listener-trusting mode.
+        #[test]
+        fn rejects_when_pin_absent() {
+            let id = fixture_asset_id();
+            let err =
+                run_validate_destination_anchor(&fixture_destination(&id), &unconfigured_config())
+                    .unwrap_err();
+            assert!(
+                err.to_string().contains("asset-identity pin missing"),
+                "expected pin-missing rejection, got: {err}"
+            );
+        }
+
+        /// Old `rejects_when_declared_disagrees_with_validated`: the listener
+        /// declares a different asset than the validated identity. Fires on
+        /// the declared-vs-validated leg (which runs before the pin block).
+        #[test]
+        fn rejects_when_declared_disagrees_with_validated() {
+            let err = run_validate_destination_anchor(
+                &fixture_destination("rgb:listener-lied"),
+                &pinned_config(FIXTURE_ASSET_ID),
+            )
+            .unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("contract_id mismatch") && msg.contains("RGB destination declares"),
+                "expected declared-mismatch rejection, got: {msg}"
+            );
+        }
+
+        // Old `rejects_when_contract_id_absent`: NOT portable to this path.
+        // This path has no explicit empty-contract_id guard; the property is
+        // enforced structurally instead — `asset_id` must be non-empty and
+        // equal the validated contract_id, so an empty validated identity can
+        // never bind. It is also unreachable through the narrowest callable
+        // unit: `RgbValidator::validate_consignment` derives contract_id from
+        // the consignment's genesis (never empty for a loadable Transfer) and
+        // `ValidationContext.rgb_validator` is the concrete type, so no
+        // fabricated ValidatedConsignment can be injected. Recorded as
+        // not-feasible in the restoration report. The source path keeps an
+        // explicit (equally unreachable) guard — see
+        // `validation::validate_source`.
+    }
 }

--- a/enclave/src/networks/rgb/spv_validation.rs
+++ b/enclave/src/networks/rgb/spv_validation.rs
@@ -770,6 +770,27 @@ mod tests {
     }
 
     #[test]
+    fn rejects_overdeep_merkle_path() {
+        // A path deeper than any real block could produce is rejected before
+        // any Merkle hashing runs (audit I-06 / #90). Siblings are well-formed
+        // 32-byte hashes so the only failing predicate is the depth cap.
+        let target = synth_headers(1).into_iter().next().unwrap();
+        let chain = chain_burying(target, 5);
+        let (txid_display, _proof) = single_tx_proof(chain.header_at(1).unwrap(), 1);
+
+        let bad_proof = MerkleProofEntry {
+            txid: txid_display.to_vec(),
+            block_height: 1,
+            tx_position: 0,
+            merkle_path: vec![vec![0u8; 32]; MAX_MERKLE_PATH_DEPTH + 1],
+        };
+
+        let err = validate_spv_proofs(&chain, &[txid_display], &[bad_proof], SPV_MIN_CONFIRMATIONS)
+            .unwrap_err();
+        assert!(err.to_string().contains("too deep"), "got: {err}");
+    }
+
+    #[test]
     fn assert_chain_net_accepts_matching_pair() {
         // Literal prefixes on purpose (not derived from `ChainNet::prefix()`):
         // if an rgb-core upgrade ever changes the notation, this test must

--- a/enclave/src/networks/rgb/validation.rs
+++ b/enclave/src/networks/rgb/validation.rs
@@ -326,7 +326,14 @@ pub struct ValidatedConsignment {
 /// doesn't leak into our public surface.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransitionSummary {
-    /// Operation id (baid64).
+    /// Operation id — the 64-char lowercase hex of the 32-byte RGB OpId, as
+    /// the consignment parser yields it (verified by the fixture test). The
+    /// EVM OpId cross-check compares this as a string; the `fundsInIds`
+    /// value-binding hex-decodes it to 32 bytes
+    /// (`evm::crosscheck::decode_op_id_to_bytes32`), so the hex form is
+    /// load-bearing - not baid64. (The `burnId` is bound instead from the
+    /// rgbstd-validated [`ValidatedConsignment::last_transfer_op_id`], not this
+    /// flat-parser value - audit M-02 / #93.)
     pub op_id: String,
     /// IFA-schema transition-type id; compare against [`ifa::TS_TRANSFER`]
     /// / [`ifa::TS_BURN`] / [`ifa::TS_INFLATION`] to classify the EVM
@@ -1094,18 +1101,14 @@ mod tests {
 
         // The fixture's last transition is a Transfer (type 10000, asserted in
         // `extracts_op_ids_and_last_transition_from_transfer_fixture`).
-        let (txid, prevouts, _op_id) =
+        let (txid, prevouts, op_id) =
             read_last_transfer_witness(&transfer, ifa::TS_TRANSFER).expect("extract witness");
 
         // Every validated transfer has at least one bundle, so the txid is set.
         let txid = txid.expect("transfer fixture has a witness txid");
         // It must equal the last bundle's witness id (the bundle we bind to).
-        let expected = transfer
-            .bundles
-            .iter()
-            .last()
-            .expect("fixture has bundles")
-            .witness_id();
+        let last_bundle = transfer.bundles.iter().last().expect("fixture has bundles");
+        let expected = last_bundle.witness_id();
         assert_eq!(txid, expected);
 
         // The rgb-lib sender embeds the full witness tx for a freshly-composed
@@ -1116,6 +1119,20 @@ mod tests {
             !prevouts.is_empty(),
             "witness tx must spend at least one input"
         );
+
+        // The validated OpId (canonical burnId source, #93) must be present and
+        // equal the last bundle's last known-transition opid, read straight
+        // from the validated object - not the flat parser.
+        let op_id = op_id.expect("transfer fixture yields a validated opid");
+        let expected_opid = last_bundle
+            .bundle()
+            .known_transitions
+            .iter()
+            .last()
+            .expect("bundle has a known transition")
+            .opid
+            .to_string();
+        assert_eq!(hex::encode(op_id), expected_opid);
     }
 
     #[test]
@@ -1152,5 +1169,342 @@ mod tests {
             err.to_string().contains("rgb-consignment parse failed"),
             "expected parse-failure rejection, got: {err}"
         );
+    }
+
+    // =========================================================================
+    // Consignment-flag pins — successors of the dropped
+    // `validation::evm_crosscheck` tests `accepts_valid_consignment_hash` /
+    // `ignores_consignment_valid_flag_when_bytes_present` (+ the P0 companion
+    // `rejects_empty_consignment_even_with_valid_flag`). Their target,
+    // `validate_evm_request`'s payload gate, is now `validate_source_payload`
+    // in this file. The wire type (`proto::RgbSource`) STILL carries the
+    // host-supplied `consignment_valid: bool` (tag 1); the gate never reads
+    // it — validity comes from the bytes, never the flag.
+    // =========================================================================
+
+    /// keccak256(bytes) in the wire shape `validate_source_payload` expects.
+    fn keccak(bytes: &[u8]) -> Vec<u8> {
+        Keccak256::digest(bytes).to_vec()
+    }
+
+    /// A well-formed `RgbSource` around the in-tree mainnet transfer fixture.
+    ///
+    /// `consignment_valid` is deliberately `false`: the flag is not
+    /// authoritative, so anything that validates with this fixture also
+    /// proves a `false` flag cannot veto byte-derived validity.
+    fn fixture_source(asset_id: &str) -> RgbSource {
+        RgbSource {
+            consignment_valid: false,
+            asset_id: asset_id.into(),
+            consignment: TRANSFER_FIXTURE.to_vec(),
+            consignment_hash: keccak(TRANSFER_FIXTURE),
+            merkle_proofs: vec![],
+            commission: 0,
+        }
+    }
+
+    /// Old `accepts_valid_consignment_hash`: consignment bytes plus their
+    /// matching keccak256 pass the payload gate. `Ok` here is "past the hash
+    /// check" in full — everything after this gate in `validate_source` is
+    /// validator/SPV work, not payload shape.
+    #[test]
+    fn accepts_valid_consignment_hash() {
+        assert!(validate_source_payload(&fixture_source("rgb:any-declared-asset")).is_ok());
+    }
+
+    /// Old `ignores_consignment_valid_flag_when_bytes_present`: an identical
+    /// payload must validate identically whatever the host claims in
+    /// `consignment_valid` — the gate never reads the flag.
+    #[test]
+    fn ignores_consignment_valid_flag_when_bytes_present() {
+        let mut source = fixture_source("rgb:any-declared-asset");
+        source.consignment_valid = false;
+        assert!(validate_source_payload(&source).is_ok());
+        source.consignment_valid = true;
+        assert!(validate_source_payload(&source).is_ok());
+    }
+
+    /// Old `rejects_empty_consignment_even_with_valid_flag` (P0 regression):
+    /// a host-supplied `consignment_valid: true` with no consignment bytes
+    /// must be rejected — the flag can never substitute for the bytes.
+    #[test]
+    fn rejects_empty_consignment_even_with_valid_flag() {
+        let mut source = fixture_source("rgb:any-declared-asset");
+        source.consignment = vec![];
+        source.consignment_hash = vec![];
+        source.consignment_valid = true;
+        let err = validate_source_payload(&source).unwrap_err();
+        assert!(
+            err.to_string().contains("requires raw consignment bytes"),
+            "expected raw-bytes-required rejection, got: {err}"
+        );
+    }
+
+    /// Symmetric pin: the flag cannot rescue a wrong hash either.
+    #[test]
+    fn rejects_consignment_hash_mismatch_even_with_valid_flag() {
+        let mut source = fixture_source("rgb:any-declared-asset");
+        source.consignment_hash = vec![0xDE; 32];
+        source.consignment_valid = true;
+        let err = validate_source_payload(&source).unwrap_err();
+        assert!(
+            err.to_string().contains("consignment hash mismatch"),
+            "expected hash-mismatch rejection, got: {err}"
+        );
+    }
+
+    // =========================================================================
+    // Asset-identity binding, SOURCE path — successor of the dropped
+    // `evm_crosscheck::asset_bind` suite (audit TEE-SE-01). Its target,
+    // `bind_asset_identity`, was removed in the networks/ split; the legs are
+    // now INLINED in `validate_source` (this file) after
+    // `validate_consignment`, so the narrowest callable unit is
+    // `validate_source` itself, driven end-to-end with the in-tree mainnet
+    // fixture validated offline against a stub Esplora (the resolver only
+    // phones home for the genesis-hash chain-identity check; the fixture
+    // embeds its witness txs, which `add_consignment_txes` registers as
+    // tentative).
+    //
+    // Path asymmetry (deliberate, see each test): here the RGB_ASSET_ID pin
+    // is gated on `BridgeConfig::is_configured()`; the destination path
+    // (`validate_destination_anchor`, `networks/rgb/mod.rs`) enforces the pin
+    // unconditionally.
+    // =========================================================================
+
+    mod asset_bind {
+        use super::*;
+        use crate::config::BridgeConfig;
+        use crate::networks::rgb::spv::{Checkpoint, HeaderChain, Network};
+        use std::sync::Mutex;
+
+        /// Contract id of `TRANSFER_FIXTURE`. Kept as a literal (the old
+        /// suite's `PIN`), re-derived and asserted in [`fixture_asset_id`]
+        /// so a fixture swap fails loud instead of silently retargeting
+        /// every binding test.
+        const FIXTURE_ASSET_ID: &str = "rgb:fuhLYX9G-eC8gDvf-V0XpYFH-ceSafoc-lGutAYq-~SExGU4";
+
+        /// The validated asset identity: the fixture's genesis contract id.
+        fn fixture_asset_id() -> String {
+            let t = Transfer::load(Cursor::new(TRANSFER_FIXTURE)).expect("load transfer fixture");
+            let id = t.contract_id().to_string();
+            assert_eq!(
+                id, FIXTURE_ASSET_ID,
+                "transfer fixture contract id drifted — update FIXTURE_ASSET_ID"
+            );
+            id
+        }
+
+        /// Stub Esplora serving only `GET /block-height/0` with the mainnet
+        /// genesis hash — all offline rgbstd validation of the fixture needs:
+        /// the resolver phones home only for the genesis-hash chain-identity
+        /// check, and the fixture embeds its witness txs (registered as
+        /// tentative via `add_consignment_txes`).
+        fn spawn_stub_esplora() -> String {
+            use std::io::{Read as _, Write as _};
+            use std::net::TcpListener;
+
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind stub esplora");
+            let addr = listener.local_addr().unwrap();
+            std::thread::spawn(move || {
+                for stream in listener.incoming() {
+                    let Ok(mut stream) = stream else { break };
+                    let mut buf = [0u8; 4096];
+                    let n = stream.read(&mut buf).unwrap_or(0);
+                    let req = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let first = req.lines().next().unwrap_or("").to_string();
+                    if !first.starts_with("GET /block-height/0") {
+                        let _ = stream.write_all(
+                            b"HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+                        );
+                        continue;
+                    }
+                    let body = bitcoin::constants::genesis_block(bitcoin::Network::Bitcoin)
+                        .block_hash()
+                        .to_string();
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: text/plain\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes());
+                }
+            });
+            format!("http://{addr}")
+        }
+
+        /// Fully-pinned operator config (`is_configured() == true`) with the
+        /// given RGB_ASSET_ID.
+        fn pinned_config(rgb_asset_id: &str) -> BridgeConfig {
+            BridgeConfig {
+                chain_id: 1,
+                bridge_contract: [0x11; 20],
+                rgb_asset_id: rgb_asset_id.into(),
+                gas_tx_allowed_to: None,
+                ..Default::default()
+            }
+        }
+
+        /// Fully-empty operator config (`is_configured() == false`) — the
+        /// legacy dev/mock posture.
+        fn unconfigured_config() -> BridgeConfig {
+            BridgeConfig {
+                chain_id: 0,
+                bridge_contract: [0u8; 20],
+                rgb_asset_id: String::new(),
+                gas_tx_allowed_to: None,
+                ..Default::default()
+            }
+        }
+
+        /// Mainnet header chain whose checkpoint is stamped "now": the SPV
+        /// staleness and chain-net checks pass, so a fully-bound source
+        /// proceeds to the merkle-proof coverage check. Its distinctive
+        /// "missing merkle proofs" error is this suite's proof that every
+        /// asset-binding leg was traversed (real proofs for the fixture's
+        /// mainnet witness txs are not constructible in a unit test).
+        fn fresh_mainnet_chain() -> Mutex<HeaderChain> {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as u32;
+            Mutex::new(HeaderChain::new(
+                Network::Mainnet,
+                Checkpoint {
+                    height: 0,
+                    hash: [0u8; 32],
+                    bits: 0x1d00_ffff,
+                    time: now,
+                    is_real: false,
+                },
+            ))
+        }
+
+        /// Drive `validate_source` (the unit the binding is inlined in) with
+        /// a stub-Esplora validator and a fresh mainnet header chain.
+        fn run_validate_source(
+            source: &RgbSource,
+            config: &BridgeConfig,
+        ) -> Result<ValidatedConsignment> {
+            let url = spawn_stub_esplora();
+            let validator = RgbValidator::new(url, "bitcoin").expect("validator");
+            let chain = fresh_mainnet_chain();
+            let ctx = ValidationContext {
+                bridge_config: config,
+                rgb_validator: Some(&validator),
+                header_chain: &chain,
+            };
+            validate_source(source, &ctx)
+        }
+
+        /// Happy path (old `binds_when_contract_id_matches_pin`): validated
+        /// contract_id == declared asset_id == pinned RGB_ASSET_ID. Every
+        /// binding leg passes and validation proceeds to the SPV stage —
+        /// the failure there is *past* the binding, and specifically past
+        /// the staleness + chain-net checks too.
+        #[test]
+        fn binds_when_contract_id_matches_pin() {
+            let id = fixture_asset_id();
+            let err = run_validate_source(&fixture_source(&id), &pinned_config(&id)).unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("missing merkle proofs"),
+                "expected to reach the SPV proof-coverage stage, got: {msg}"
+            );
+            assert!(
+                !msg.contains("contract_id mismatch") && !msg.contains("RGB_ASSET_ID"),
+                "asset binding must have passed, got: {msg}"
+            );
+        }
+
+        /// Old `binds_when_declared_is_empty`, semantics INVERTED by a
+        /// deliberate post-merge strengthening: the networks/ split requires
+        /// the RGB source to declare its asset — an empty `asset_id` now
+        /// fails closed in `validate_source_payload` instead of binding via
+        /// the pin alone. This same rejection is what carries the old
+        /// `rejects_foreign_asset_even_when_declared_is_empty` guarantee:
+        /// with an empty declared id *nothing* binds, foreign or not.
+        #[test]
+        fn rejects_when_declared_is_empty() {
+            let err = run_validate_source(&fixture_source(""), &pinned_config(FIXTURE_ASSET_ID))
+                .unwrap_err();
+            assert!(
+                err.to_string().contains("RGB source asset_id is empty"),
+                "expected empty-declared rejection, got: {err}"
+            );
+        }
+
+        /// Old `rejects_foreign_asset_even_when_declared_is_empty`, adapted:
+        /// empty declarations are now rejected up-front (previous test), so
+        /// the closest reachable form of the TEE-SE-01 funds-theft path is a
+        /// listener that *colludes* — declaring the foreign asset
+        /// consistently with the consignment. The pin must still reject it:
+        /// RGB_ASSET_ID is load-bearing regardless of what the listener says.
+        #[test]
+        fn rejects_foreign_asset_even_when_declared_agrees() {
+            let id = fixture_asset_id();
+            let err = run_validate_source(
+                &fixture_source(&id),
+                &pinned_config("rgb:some-other-pinned-asset"),
+            )
+            .unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("contract_id mismatch") && msg.contains("pinned RGB_ASSET_ID"),
+                "expected pin mismatch, got: {msg}"
+            );
+        }
+
+        /// Old `rejects_when_declared_disagrees_with_validated`: the listener
+        /// declares a different asset than the validated identity. Fires on
+        /// the declared-vs-validated leg (which runs before the pin block).
+        #[test]
+        fn rejects_when_declared_disagrees_with_validated() {
+            let err = run_validate_source(
+                &fixture_source("rgb:listener-lied"),
+                &pinned_config(FIXTURE_ASSET_ID),
+            )
+            .unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("contract_id mismatch") && msg.contains("RGB source declares"),
+                "expected declared-mismatch rejection, got: {msg}"
+            );
+        }
+
+        /// Old `rejects_when_pin_absent` — the source-path ASYMMETRY: here
+        /// the pin block is gated on `BridgeConfig::is_configured()`, so a
+        /// fully-empty config skips the pin and the binding degrades to
+        /// declared == validated, proceeding to SPV (this test pins exactly
+        /// that). It does NOT fail closed here; the unconditional fail-closed
+        /// successor lives on the destination path
+        /// (`networks/rgb/mod.rs::tests::asset_bind::rejects_when_pin_absent`)
+        /// and, for this RGB→EVM direction, in the EVM destination's
+        /// `!is_configured()` rejection (`networks/evm/validation.rs`,
+        /// `not(test)`-gated, asserted at the integration layer). The inner
+        /// "pinned chain/contract but RGB_ASSET_ID is empty" branch in
+        /// `validate_source` is unreachable: `is_configured()` already
+        /// requires a non-empty RGB_ASSET_ID (audit 4th M-03 / #94).
+        #[test]
+        fn pin_check_skipped_when_config_unconfigured() {
+            let id = fixture_asset_id();
+            let err =
+                run_validate_source(&fixture_source(&id), &unconfigured_config()).unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("missing merkle proofs"),
+                "expected to reach the SPV proof-coverage stage with the pin block skipped, \
+                 got: {msg}"
+            );
+        }
+
+        // Old `rejects_when_contract_id_absent`: NOT portable to this path.
+        // The guard survives (validate_source rejects an empty validated
+        // contract_id before any binding), but it is unreachable through the
+        // narrowest callable unit: `RgbValidator::validate_consignment`
+        // derives contract_id from the consignment's genesis, which is never
+        // empty for a loadable Transfer, and `ValidationContext.rgb_validator`
+        // is the concrete type — there is no seam to inject a fabricated
+        // ValidatedConsignment. Recorded as not-feasible in the restoration
+        // report rather than weakened into a vacuous test.
     }
 }

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -605,6 +605,12 @@ fn handle_get_attested_public_key(
         EnclaveError::InvalidRequest(format!("nonce must be 32 bytes, got {}", req.nonce.len()))
     })?;
 
+    // NOTE (audit W-13): this endpoint attests over a *caller-supplied* nonce,
+    // so it can act as an oracle that mints valid attestations for arbitrary
+    // nonces. That is safe for replay accounting: the cloning handlers record a
+    // nonce only after a fully-authenticated handshake (see `handle_get_clone` /
+    // `handle_set_clone`), so an oracle-minted nonce carries no replay-guard
+    // weight on its own and cannot be used to exhaust the guard.
     let keys = ctx.state.get_keys()?;
     let public_keys = build_public_keys_response(keys, &ctx.bridge_config);
 

--- a/enclave/tests/test_clone.rs
+++ b/enclave/tests/test_clone.rs
@@ -269,6 +269,40 @@ fn clone_rejects_duplicate_requester_attestation_nonce_on_donor() {
 }
 
 #[test]
+fn clone_rejected_handshake_does_not_consume_replay_nonce() {
+    // audit W-13: the donor must record a handshake nonce only AFTER the
+    // pubkey/digest/donor-secret checks pass. A rejected (unauthenticated)
+    // handshake must not consume replay-guard capacity — otherwise anyone able
+    // to mint attestations over arbitrary nonces (the get_attested_public_key
+    // oracle) could exhaust the guard without ever knowing the cloning secret.
+    let (donor_port, donor_keys) = start_donor();
+    let requester_port = start_requester();
+
+    let init = initiate_cloning(requester_port, CLONING_SECRET, &donor_keys.evm_address);
+
+    // Tamper the cloning digest so the handshake is rejected at the digest
+    // binding — which runs *after* the point where the nonce used to be
+    // recorded.
+    let mut tampered = init.clone();
+    tampered.cloning_digest[0] ^= 0xff;
+    let err = request_get_clone(donor_port, &donor_keys.evm_address, &tampered)
+        .expect_err("tampered cloning_digest must be rejected");
+    assert!(
+        !err.message.contains("replay"),
+        "should fail on the digest binding, not the replay guard: {}",
+        err.message
+    );
+
+    // The rejected attempt must NOT have recorded its nonce: a subsequent
+    // valid handshake reusing the same attestation (same nonce) still
+    // succeeds. Pre-fix this failed on the replay guard because the doomed
+    // attempt consumed the nonce first.
+    request_get_clone(donor_port, &donor_keys.evm_address, &init).expect(
+        "valid handshake reusing the same nonce must still succeed after a rejected attempt",
+    );
+}
+
+#[test]
 fn cannot_initialize_after_entering_cloning() {
     let requester_port = start_requester();
     // Start a clone session using a throwaway donor address.

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -465,13 +465,21 @@ fn test_sign_evm_rejects_unconfigured_bridge_config() {
 // consignment amount, EVM destination validation decodes `fundsOut.amount` and
 // adds `calldata_commission`, then `validate_route_proofs` compares the two.
 
-/// Default-build coverage: `--features rgb-validation` is required to
-/// sign fundsOut at all. The cross-check fails fast with a message
-/// that names the missing feature, so a misconfigured deployment fails
-/// loud instead of silently signing against unvalidated bytes.
+/// M-01 / #61: a build without `spv` must refuse to sign any `fundsOut`,
+/// even when the request carries no merkle_proofs. Without SPV the enclave can
+/// only anchor a consignment's witness txs through the host-controlled Esplora
+/// resolver, so a fabricated anchor would otherwise be signed against. The
+/// earlier guard only fired when `merkle_proofs[]` was non-empty, letting an
+/// empty-proofs `fundsOut` slip through — this asserts that gap is closed.
+/// (`not(rgb-validation)` ⇔ `not(spv)` for any build that compiles: `spv`
+/// pulls in `rgb-validation`, and lib.rs's `compile_error!` forbids
+/// rgb-validation without spv.) On this layout the refusal fires in RGB
+/// source validation, whose message names the missing `rgb-validation`
+/// feature, so a misconfigured deployment fails loud instead of silently
+/// signing against unvalidated bytes.
 #[cfg(all(not(feature = "rgb-validation"), not(feature = "dev-mode")))]
 #[test]
-fn test_sign_evm_rejects_funds_out_in_default_build() {
+fn test_no_spv_build_refuses_funds_out_even_without_merkle_proofs() {
     let port = common::start_test_server();
 
     let init_req = EnclaveRequest {
@@ -482,8 +490,19 @@ fn test_sign_evm_rejects_funds_out_in_default_build() {
     };
     common::send_request(port, &init_req);
 
+    // A fundsOut request carrying no merkle_proofs — exactly the shape that
+    // previously bypassed the no-validation guard (M-01 / #61): the refusal
+    // must fire even when the request supplies no SPV proofs at all.
+    let req = valid_sign_evm_request(1000, 50);
+    match &req.source_network {
+        Some(SourceNetwork::RgbSource(source)) => assert!(
+            source.merkle_proofs.is_empty(),
+            "test precondition: the request must carry no merkle_proofs"
+        ),
+        other => panic!("expected RGB source, got {other:?}"),
+    }
     let sign_req = EnclaveRequest {
-        request: Some(Request::Sign(valid_sign_evm_request(1000, 50))),
+        request: Some(Request::Sign(req)),
     };
     let resp = common::send_request(port, &sign_req);
 
@@ -491,7 +510,10 @@ fn test_sign_evm_rejects_funds_out_in_default_build() {
         Some(Response::Error(e)) => {
             assert_eq!(e.code, 3);
             assert!(
-                e.message.contains("rgb-validation"),
+                e.message.contains(
+                    "RGB source validation requires the enclave to be built with \
+                     --features rgb-validation"
+                ),
                 "expected feature-gate rejection, got: {}",
                 e.message
             );
@@ -1305,10 +1327,13 @@ fn test_proxy_federation_returns_not_ready() {
 // =============================================================================
 //
 // These run through the real handler, so the production fail-closed gate in
-// `validation::evm_gas_tx` is active (the integration crate builds the lib
+// `networks::evm::gas_tx` is active (the integration crate builds the lib
 // without cfg(test)). They cover the accept path and the two drain vectors.
+// Gated on `not(dev-mode)` like the other cross-check tests: under dev-mode
+// the handler keeps the legacy opaque-digest path instead of the allowlist.
 
 /// Minimal RLP encoder for building gas-tx fixtures.
+#[cfg(not(feature = "dev-mode"))]
 fn rlp_str(bytes: &[u8]) -> Vec<u8> {
     if bytes.len() == 1 && bytes[0] < 0x80 {
         return vec![bytes[0]];
@@ -1331,6 +1356,7 @@ fn rlp_str(bytes: &[u8]) -> Vec<u8> {
     out
 }
 
+#[cfg(not(feature = "dev-mode"))]
 fn rlp_scalar(v: u64) -> Vec<u8> {
     let trimmed: Vec<u8> = v
         .to_be_bytes()
@@ -1341,6 +1367,7 @@ fn rlp_scalar(v: u64) -> Vec<u8> {
     rlp_str(&trimmed)
 }
 
+#[cfg(not(feature = "dev-mode"))]
 fn rlp_list(items: &[Vec<u8>]) -> Vec<u8> {
     let mut payload = Vec::new();
     for it in items {
@@ -1365,6 +1392,7 @@ fn rlp_list(items: &[Vec<u8>]) -> Vec<u8> {
 }
 
 /// Unsigned EIP-1559 preimage: `0x02 || rlp([chainId, nonce, maxPrio, maxFee, gas, to, value, data, accessList])`.
+#[cfg(not(feature = "dev-mode"))]
 fn eip1559_unsigned(chain_id: u64, to: &[u8; 20], value: u64) -> Vec<u8> {
     let body = rlp_list(&[
         rlp_scalar(chain_id),
@@ -1383,6 +1411,7 @@ fn eip1559_unsigned(chain_id: u64, to: &[u8; 20], value: u64) -> Vec<u8> {
 }
 
 /// `BridgeConfig` with the gas-tx destination pinned (chain_id 1, to 0xAA…).
+#[cfg(not(feature = "dev-mode"))]
 fn gas_pinned_config() -> BridgeConfig {
     BridgeConfig {
         chain_id: 1,
@@ -1393,6 +1422,7 @@ fn gas_pinned_config() -> BridgeConfig {
     }
 }
 
+#[cfg(not(feature = "dev-mode"))]
 fn init(port: u16) {
     common::send_request(
         port,
@@ -1406,6 +1436,7 @@ fn init(port: u16) {
 }
 
 #[test]
+#[cfg(not(feature = "dev-mode"))]
 fn test_gas_tx_signs_pinned_destination() {
     let port = common::start_test_server_with_config(|_| {}, gas_pinned_config());
     init(port);
@@ -1428,6 +1459,7 @@ fn test_gas_tx_signs_pinned_destination() {
 }
 
 #[test]
+#[cfg(not(feature = "dev-mode"))]
 fn test_gas_tx_rejects_opaque_digest() {
     let port = common::start_test_server_with_config(|_| {}, gas_pinned_config());
     init(port);
@@ -1457,6 +1489,7 @@ fn test_gas_tx_rejects_opaque_digest() {
 }
 
 #[test]
+#[cfg(not(feature = "dev-mode"))]
 fn test_gas_tx_rejects_drain_to_attacker() {
     let port = common::start_test_server_with_config(|_| {}, gas_pinned_config());
     init(port);


### PR DESCRIPTION
## What

The `dev` → `dev-ng` merge (`d3e9e90` + `d65189f`, the base of #133) carried every audit fix's **production logic** onto the `networks/` layout, but the conflict resolution silently dropped most of the fixes' **regression tests** and the M-01 **CI lanes**. This PR restores them, adapted to the post-refactor structure. Targets `dev-ng` so it rides #133 into `dev`.

**No production code changes** — every hunk is inside a `#[cfg(test)]` module, a `tests/` file, or `ci.yml`; `enclave/src/server.rs` only gets its W-13 explanatory comment back.

## Restored

| Area | Tests | Original fix |
|---|---|---|
| `networks/evm/crosscheck.rs` | recreated the dropped module: 8 BtcRelay-agreement tests incl. `rejects_internal_order_commitment` (the byte-order regression guard), 11 op-id binding/settlement tests (ported to the validated `last_transfer_op_id` sourcing), witnesses-confirmed pair, extractor/helper tests — 34 total | #122 (#57), #97/#101 (M-02), #118 |
| `networks/evm/validation.rs` | calldata size-cap boundary pair (at-cap accepted / over-cap rejected), selector-echo assertion, relocated selector/deadline/chain-id/proxy-pin tests | #118 (I-06), 4th M-03 |
| `networks/rgb/spv_validation.rs` | `rejects_overdeep_merkle_path` (depth cap 32) | #118 (I-06) |
| `networks/rgb/{validation,mod}.rs` | successor suites for the dropped `asset_bind` tests covering **both** inlined paths — incl. the deliberate asymmetry: source pin is `is_configured()`-gated, destination pin is unconditional; consignment-flag pins (host `consignment_valid` is never load-bearing); validated-OpId fixture assertion | TEE-SE-01, #101 |
| `tests/test_signing.rs` | 3 gas-tx allowlist e2e tests re-adapted to the external proto's `unsigned_tx` flow (they cover the real handler path, which the surviving `gas_tx.rs` unit tests don't); M-01 test renamed to `test_no_spv_build_refuses_funds_out_even_without_merkle_proofs` + explicit empty-proofs precondition | #81 (C-02), #125 (M-01) |
| `tests/test_clone.rs` | `clone_rejected_handshake_does_not_consume_replay_nonce`, restored verbatim | #129 (W-13) |
| `ci.yml` | minimal `--no-default-features` build/clippy/test lane — with `default = ["spv"]`, the `not(rgb-validation)` tests (incl. the M-01 refusal test and the PSBT roundtrip) currently run in **no** lane; `feature-guards` job asserting the `rgb-validation`-without-`spv` `compile_error!`; stale comment refresh | #125 (M-01/#61) |

The RGB-side suites drive `validate_source` / `validate_destination_anchor` end-to-end with the in-tree mainnet fixture validated fully offline (stub Esplora serving only the genesis-hash chain-identity check).

## Known gaps (documented, not restorable as-is)

- **Partial-pin rejections (4th M-03/#94)** — `is_partially_configured()` no longer exists; the successor is the `not(test)`-gated `!is_configured()` fail-closed in `networks/evm/validation.rs`, unreachable from unit tests (and integration tests can't reach it: source validation fires first without a validator). Needs an integration-level SPV harness to pin.
- **`rejects_when_contract_id_absent`** — no seam to inject an empty validated contract id through the concrete `RgbValidator`; the property holds structurally (documented in-tree).
- **`test_sign_evm_rejects_unconfigured_bridge_config`** (pre-existing on `dev-ng`) still asserts the missing-validator error rather than the original `unconfigured` message — the new source-first validation order fires the validator gate before the pin gate. Same harness follow-up as above.

## Verification

Full local matrix mirroring CI, all green: `fmt --check`, workspace build/clippy(`-D warnings`)/test (18 suites, 0 failures), `--features spv` tests, production combo `vsock,rgb-validation,spv` build+clippy, `--no-default-features` build/clippy/test (the M-01 refusal test runs in this lane), and the feature-guard inversion (`--no-default-features --features rgb-validation` fails with the expected `rgb-validation requires spv` compile error).

## Rebase note

Rebased onto `dev-ng` after #127 (fail-closed fundsOut selector guard) landed: the old `no_op_for_non_funds_out_selector` contract is superseded, so the restored test is adapted to `rejects_non_funds_out_selector` asserting the new fail-closed guard. `verify_btc_relay_agreement` keeps its documented inert-on-non-fundsOut contract, so `noop_on_non_fundsout_selector` is unchanged.
