### PR TITLE
fix(enclave): final-report hardening quick wins (I-02, I-03, W-01, W-11, #65)

### DIFF
--- a/docs/tee-spec.md
+++ b/docs/tee-spec.md
@@ -60,6 +60,14 @@ threat model by construction. Entropy comes from the NSM RNG (actor table
 above). Should host-time-independence ever be required, the remediation path
 is NSM-attested time or external time anchoring (tracked under #123 / W-11).
 
+**No batch signing path (audit W-03):** the enclave builds and signs exactly
+one digest shape — the single-call `BridgeOperation` EIP-712 struct
+(`sign_request_digest`). There is no `executeBatch` digest builder, and the
+typehash separation between the single-call struct and the on-chain batch
+struct means a signature produced here can never authorize a batch execution.
+Aligning or removing `executeBatch`/`_buildBatchDigest` on the contract side
+is tracked with the contracts team (#123 / W-03).
+
 ## 3. Architecture
 
 The signer is three crates plus the external infrastructure it touches.

--- a/docs/tee-spec.md
+++ b/docs/tee-spec.md
@@ -47,6 +47,19 @@ Internet -- orchestrator -- EC2 parent (UNTRUSTED) -- vsock -- Nitro Enclave (TR
 root CA, the correctness of *this* enclave code, and the correctness of the RGB
 / SPV validation libraries. (Parent spec Sec 6.2, Sec 6.3.)
 
+**Wall-clock and entropy assumptions (audit W-11):** three gates read
+`SystemTime::now()` — the request `deadline` check (EVM destination
+validation), the SPV chain-staleness check, and the `submit_headers` rate
+limit. Inside a Nitro enclave the wall clock is hypervisor-provided
+(kvm-clock); no NSM-attested time source is in use. The accepted assumption is
+that the AWS hypervisor is trusted for *coarse* time — consistent with the
+model above, where the same hypervisor is already trusted for isolation and
+attestation itself. The parent host cannot skew the enclave clock through any
+interface this code exposes; a hypervisor-level adversary is outside the
+threat model by construction. Entropy comes from the NSM RNG (actor table
+above). Should host-time-independence ever be required, the remediation path
+is NSM-attested time or external time anchoring (tracked under #123 / W-11).
+
 ## 3. Architecture
 
 The signer is three crates plus the external infrastructure it touches.

--- a/enclave/src/networks/evm/crosscheck.rs
+++ b/enclave/src/networks/evm/crosscheck.rs
@@ -926,6 +926,116 @@ mod tests {
             let cd = mock_funds_out(id(OP_ID), &[]);
             assert!(extract_funds_in_ids(&cd).unwrap().is_empty());
         }
+
+        /// #65: the rewritten calldata is what gets signed and later decoded
+        /// on-chain — starting from a canonical alloy encoding, the binding
+        /// output must (a) still ABI-decode, (b) carry exactly the
+        /// enclave-authored burnId and fundsInIds, and (c) remain canonical
+        /// (re-encoding the decoded call reproduces the rewritten bytes).
+        #[test]
+        fn binding_output_stays_canonical_abi() {
+            use crate::networks::evm::validation::fundsOutCall;
+            use alloy_primitives::{Address, Bytes, U256};
+            use alloy_sol_types::SolCall;
+
+            let cd = fundsOutCall {
+                recipient: Address::from([0x11; 20]),
+                amount: U256::from(1_000u64),
+                burnId: U256::from(7u64), // listener-supplied, must be overwritten
+                sourceChainId: U256::from(5u64),
+                destinationChainId: U256::from(6u64),
+                sourceAddress: "rgb-src".to_string(),
+                proof: Bytes::from(vec![0xCC; 64]),
+                settlementData: Bytes::new(),
+            }
+            .abi_encode();
+
+            let validated = validated(
+                Some(transition(OP_ID, ifa::TS_TRANSFER)),
+                vec![MINT_A.into(), MINT_B.into()],
+            );
+            let out = apply_op_id_binding(&cd, &validated).unwrap();
+
+            let decoded = fundsOutCall::abi_decode_validate(&out)
+                .expect("binding output must remain ABI-decodable");
+            assert_eq!(decoded.burnId, U256::from_be_bytes(id(OP_ID)));
+            assert_eq!(decoded.recipient, Address::from([0x11; 20]));
+            assert_eq!(decoded.proof, Bytes::from(vec![0xCC; 64]));
+            assert_eq!(
+                extract_funds_in_ids(&out).unwrap(),
+                vec![id(MINT_A), id(MINT_B)]
+            );
+            assert_eq!(
+                decoded.abi_encode(),
+                out,
+                "binding output must be a canonical encoding"
+            );
+        }
+    }
+
+    // =========================================================================
+    // #65 — pin the hand-derived rewrite offsets to the alloy-derived ABI
+    // layout so the constants cannot silently drift from the real encoding.
+    // =========================================================================
+
+    mod abi_layout {
+        use super::*;
+        use crate::networks::evm::validation::fundsOutCall;
+        use alloy_primitives::{Address, Bytes, U256};
+        use alloy_sol_types::SolCall;
+
+        fn marker_calldata() -> Vec<u8> {
+            fundsOutCall {
+                recipient: Address::from([0x11; 20]),
+                amount: U256::from(0xA1A2_A3A4u64),
+                burnId: U256::from_be_bytes([0xBB; 32]),
+                sourceChainId: U256::from(5u64),
+                destinationChainId: U256::from(6u64),
+                sourceAddress: "rgb-src".to_string(),
+                proof: Bytes::from(vec![0xCC; 64]),
+                settlementData: Bytes::from(vec![0xDD; 32]),
+            }
+            .abi_encode()
+        }
+
+        #[test]
+        fn amount_offset_matches_abi_layout() {
+            let cd = marker_calldata();
+            assert_eq!(
+                extract_uint256_as_u64(&cd, FUNDS_OUT_AMOUNT_OFFSET).unwrap(),
+                0xA1A2_A3A4
+            );
+        }
+
+        #[test]
+        fn burn_id_offset_matches_abi_layout() {
+            let cd = marker_calldata();
+            assert_eq!(
+                extract_bytes32(&cd, FUNDS_OUT_BURN_ID_OFFSET).unwrap(),
+                [0xBB; 32]
+            );
+        }
+
+        #[test]
+        fn proof_head_offset_matches_abi_layout() {
+            let cd = marker_calldata();
+            let proof_rel = read_u256_as_usize(&cd, FUNDS_OUT_PROOF_HEAD_OFFSET).unwrap();
+            let len = read_u256_as_usize(&cd, 4 + proof_rel).unwrap();
+            assert_eq!(len, 64);
+            assert_eq!(
+                &cd[4 + proof_rel + 32..4 + proof_rel + 32 + 64],
+                &[0xCC; 64][..]
+            );
+        }
+
+        #[test]
+        fn settlement_data_head_offset_matches_abi_layout() {
+            let cd = marker_calldata();
+            let sd_rel = read_u256_as_usize(&cd, FUNDS_OUT_SETTLEMENT_DATA_HEAD_OFFSET).unwrap();
+            let len = read_u256_as_usize(&cd, 4 + sd_rel).unwrap();
+            assert_eq!(len, 32);
+            assert_eq!(&cd[4 + sd_rel + 32..4 + sd_rel + 32 + 32], &[0xDD; 32][..]);
+        }
     }
 
     // =========================================================================

--- a/enclave/src/networks/evm/signing.rs
+++ b/enclave/src/networks/evm/signing.rs
@@ -80,16 +80,23 @@ pub fn build_evm_domain(req: &EvmDestination) -> Result<Eip712Domain> {
 
 /// Build the EIP-712 digest matching MultisigProxy._buildDigest():
 ///   keccak256(abi.encode(_BRIDGE_OP_TYPEHASH, selector, keccak256(callData), nonce, deadline))
+///
+/// Fallible on short calldata (audit final I-02): this used to `assert!`,
+/// which with `panic = "abort"` took down the whole enclave. The validation
+/// layer rejects `< 4` bytes in production builds, but dev-mode bypasses that
+/// check, so the guard here must be an error, not an abort.
 pub fn sign_request_digest(
     domain: &Eip712Domain,
     call_data: &[u8],
     nonce: u64,
     deadline: u64,
-) -> [u8; HASH_LEN] {
-    assert!(
-        call_data.len() >= 4,
-        "call_data must contain at least a 4-byte selector"
-    );
+) -> Result<[u8; HASH_LEN]> {
+    if call_data.len() < 4 {
+        return Err(EnclaveError::CrossCheck(format!(
+            "call_data must contain at least a 4-byte selector, got {} bytes",
+            call_data.len()
+        )));
+    }
 
     let struct_hash = {
         let type_hash = Keccak256::digest(BRIDGE_OP_TYPE_HASH_STR.as_bytes());
@@ -118,7 +125,7 @@ pub fn sign_request_digest(
     buf.extend_from_slice(&domain_separator);
     buf.extend_from_slice(&struct_hash);
 
-    Keccak256::digest(&buf).into()
+    Ok(Keccak256::digest(&buf).into())
 }
 
 /// ABI-encode a u64 as a uint256 (HASH_LEN bytes, big-endian, right-aligned).
@@ -189,8 +196,8 @@ mod tests {
              0000000000000000000000000000000000000000000000000000000000000064",
         )
         .unwrap();
-        let digest1 = sign_request_digest(&domain, &call_data, 0, 1_700_000_000);
-        let digest2 = sign_request_digest(&domain, &call_data, 0, 1_700_000_000);
+        let digest1 = sign_request_digest(&domain, &call_data, 0, 1_700_000_000).unwrap();
+        let digest2 = sign_request_digest(&domain, &call_data, 0, 1_700_000_000).unwrap();
         assert_eq!(digest1, digest2);
         assert_ne!(digest1, [0u8; HASH_LEN]);
     }
@@ -204,21 +211,26 @@ mod tests {
             verifying_contract: [0u8; 20],
         };
         let call_data = decode("aabbccdd").unwrap();
-        let d1 = sign_request_digest(&domain, &call_data, 0, 1_700_000_000);
-        let d2 = sign_request_digest(&domain, &call_data, 1, 1_700_000_000);
+        let d1 = sign_request_digest(&domain, &call_data, 0, 1_700_000_000).unwrap();
+        let d2 = sign_request_digest(&domain, &call_data, 1, 1_700_000_000).unwrap();
         assert_ne!(d1, d2);
     }
 
     #[test]
-    #[should_panic(expected = "call_data must contain at least a 4-byte selector")]
-    fn test_short_call_data_panics() {
+    fn test_short_call_data_rejected() {
+        // audit final I-02: short calldata must yield an error, never an
+        // abort — with `panic = "abort"` the old assert! killed the enclave.
         let domain = Eip712Domain {
             name: "MultisigProxy".to_string(),
             version: "1".to_string(),
             chain_id: 1,
             verifying_contract: [0u8; 20],
         };
-        sign_request_digest(&domain, &[0xAA, 0xBB], 0, 1_000);
+        let err = sign_request_digest(&domain, &[0xAA, 0xBB], 0, 1_000).unwrap_err();
+        assert!(
+            err.to_string().contains("at least a 4-byte selector"),
+            "expected short-calldata rejection, got: {err}"
+        );
     }
 
     #[test]
@@ -278,7 +290,7 @@ mod tests {
         digest_buf.extend_from_slice(&expected_struct_hash);
         let expected_digest: [u8; HASH_LEN] = Keccak256::digest(&digest_buf).into();
 
-        let actual_digest = sign_request_digest(&domain, &call_data, nonce, deadline);
+        let actual_digest = sign_request_digest(&domain, &call_data, nonce, deadline).unwrap();
         assert_eq!(actual_digest, expected_digest);
     }
 

--- a/enclave/src/networks/evm/validation.rs
+++ b/enclave/src/networks/evm/validation.rs
@@ -171,8 +171,24 @@ pub fn validate_destination(
 }
 
 fn parse_proof_from_calldata(call_data: &[u8]) -> Result<RouteProof> {
-    let decoded = fundsOutCall::abi_decode(call_data)
+    // Canonical-encoding enforcement (audit W-01 residual, #123): the ABI
+    // decoder is deliberately layout-permissive — overlapping or out-of-order
+    // dynamic tails and trailing junk all decode fine (`abi_decode_validate`
+    // only validates the decoded *values*). Re-encoding the decoded call and
+    // requiring byte equality pins the input to the one canonical layout.
+    // This matters because the calldata bytes are later partially rewritten
+    // by fixed offset (`apply_op_id_binding`), so every byte must sit exactly
+    // where the canonical layout puts it — and what the enclave signs must
+    // decode on-chain to exactly what it validated.
+    let decoded = fundsOutCall::abi_decode_validate(call_data)
         .map_err(|e| EnclaveError::CrossCheck(format!("invalid fundsOut calldata: {e}")))?;
+    if decoded.abi_encode() != call_data {
+        return Err(EnclaveError::CrossCheck(
+            "non-canonical fundsOut calldata encoding: re-encoding the decoded call does not \
+             reproduce the input bytes"
+                .into(),
+        ));
+    }
     let amount: u64 = decoded
         .amount
         .try_into()
@@ -469,5 +485,69 @@ mod tests {
                 .to_string()
                 .contains("exceeds u64 range"));
         });
+    }
+
+    /// The hand-pinned selector constant and the alloy-derived ABI selector
+    /// must never drift apart (#65): the whitelist gates on the constant while
+    /// decode/encode use the `sol!` type.
+    #[test]
+    fn funds_out_selector_matches_abi_derived_selector() {
+        assert_eq!(FUNDS_OUT_SELECTOR_POOLS, fundsOutCall::SELECTOR);
+    }
+
+    /// Canonical calldata with non-empty dynamic tails — the baseline the two
+    /// non-canonical rejection tests below tamper with.
+    fn funds_out_calldata_with_tails(amount: u64) -> Vec<u8> {
+        fundsOutCall {
+            recipient: Address::from([0x22; ADDRESS_LEN]),
+            amount: U256::from(amount),
+            burnId: U256::from(7u64),
+            sourceChainId: U256::from(1u64),
+            destinationChainId: U256::from(1u64),
+            sourceAddress: "rgb-src".to_string(),
+            proof: Bytes::from(vec![0xCC; 64]),
+            settlementData: Bytes::from(vec![0xDD; 32]),
+        }
+        .abi_encode()
+    }
+
+    #[test]
+    fn accepts_canonical_calldata_with_dynamic_tails() {
+        let cd = funds_out_calldata_with_tails(1_234);
+        let proof = parse_proof_from_calldata(&cd).expect("canonical encoding must parse");
+        assert_eq!(proof.amount, 1_234);
+    }
+
+    /// audit W-01 residual (#123): the ABI decoder accepts trailing junk
+    /// after the last dynamic tail; the canonical re-encode check must not.
+    /// The calldata is later partially rewritten by byte offset
+    /// (`apply_op_id_binding`), so every byte must sit exactly where the
+    /// canonical layout puts it.
+    #[test]
+    fn rejects_calldata_with_trailing_junk() {
+        let mut cd = funds_out_calldata_with_tails(1_234);
+        cd.extend_from_slice(&[0u8; 32]);
+        let err = parse_proof_from_calldata(&cd).unwrap_err();
+        assert!(
+            err.to_string().contains("non-canonical fundsOut calldata"),
+            "expected canonical-encoding rejection, got: {err}"
+        );
+    }
+
+    /// audit W-01 residual (#123): two dynamic-arg head words pointing at the
+    /// same tail decode fine but are not a canonical encoding.
+    #[test]
+    fn rejects_calldata_with_overlapping_dynamic_tails() {
+        let mut cd = funds_out_calldata_with_tails(1_234);
+        // Head words (selector included in the byte positions): arg 7
+        // (`proof`) offset word at bytes 196..228, arg 8 (`settlementData`)
+        // offset word at bytes 228..260. Point settlementData at proof's tail.
+        let proof_offset_word: [u8; 32] = cd[196..228].try_into().unwrap();
+        cd[228..260].copy_from_slice(&proof_offset_word);
+        let err = parse_proof_from_calldata(&cd).unwrap_err();
+        assert!(
+            err.to_string().contains("non-canonical fundsOut calldata"),
+            "expected canonical-encoding rejection of overlapping tails, got: {err}"
+        );
     }
 }

--- a/enclave/src/networks/rgb/validation.rs
+++ b/enclave/src/networks/rgb/validation.rs
@@ -397,8 +397,10 @@ pub enum OutputSeal {
 
 /// Hard cap on any single blocking Esplora HTTP call (connect + read), in
 /// seconds. The Esplora egress runs through the host-controlled vsock proxy,
-/// and these calls happen *on the signing path* — without a timeout a stalled
-/// host pins the worker thread indefinitely (audit final I-03 / #87).
+/// and consignment validation happens *on the signing path* — without a
+/// timeout a stalled host pins the worker thread indefinitely (audit final
+/// I-03 / #87). Aligned with `conn.rs`'s `TOTAL_REQUEST_TIMEOUT` so a single
+/// stalled egress call cannot outlive its enclosing request budget.
 /// Compile-time (PCR-attested), deliberately not host-tunable.
 const ESPLORA_HTTP_TIMEOUT_SECS: u64 = 30;
 
@@ -418,6 +420,9 @@ pub struct RgbValidator {
     /// Cached `(fetched_at, sat/vB)` recommended fee rate (#55), guarded for
     /// the multi-threaded worker pool. `None` until the first fetch.
     fee_estimate_cache: std::sync::Mutex<Option<(std::time::Instant, f64)>>,
+    /// Per-request HTTP timeout, [`ESPLORA_HTTP_TIMEOUT_SECS`] in production.
+    /// Overridable only from tests (no env / host input reaches it).
+    http_timeout_secs: u64,
 }
 
 impl RgbValidator {
@@ -443,7 +448,16 @@ impl RgbValidator {
             esplora_url,
             chain_net,
             fee_estimate_cache: std::sync::Mutex::new(None),
+            http_timeout_secs: ESPLORA_HTTP_TIMEOUT_SECS,
         })
+    }
+
+    /// Shrink the HTTP timeout so the stalled-host test doesn't wait the
+    /// production budget. Test-only by construction.
+    #[cfg(test)]
+    fn with_http_timeout(mut self, secs: u64) -> Self {
+        self.http_timeout_secs = secs;
+        self
     }
 
     /// Recommended fee rate (sat/vB) from the enclave's own Esplora egress,
@@ -466,7 +480,7 @@ impl RgbValidator {
         }
 
         let client = esplora_client::Builder::new(&self.esplora_url)
-            .timeout(ESPLORA_HTTP_TIMEOUT_SECS)
+            .timeout(self.http_timeout_secs)
             .build_blocking();
         let estimates = client.get_fee_estimates().map_err(|e| {
             EnclaveError::CrossCheck(format!(
@@ -598,8 +612,14 @@ impl RgbValidator {
                 _ => (None, None, None),
             };
 
-        // 2. Create an Esplora-backed resolver.
-        let builder = esplora_client::Builder::new(&self.esplora_url);
+        // 2. Create an Esplora-backed resolver. The `.timeout()` is
+        // load-bearing: this is a blocking call on the signing path through
+        // the host-controlled vsock proxy (audit final I-03 / #87). Transport
+        // errors (incl. timeouts) propagate immediately — esplora-client only
+        // retries on 429/5xx status codes — so one stalled call costs at most
+        // the timeout, never an unbounded hang.
+        let builder =
+            esplora_client::Builder::new(&self.esplora_url).timeout(self.http_timeout_secs);
         let mut resolver = AnyResolver::esplora_blocking(builder).map_err(|e| {
             tracing::error!(esplora_url = %self.esplora_url, "esplora resolver creation failed: {e}");
             EnclaveError::CrossCheck(format!("esplora resolver creation failed: {e}"))
@@ -1090,6 +1110,41 @@ mod tests {
         assert!(
             err.to_string().contains("refusing to sign"),
             "expected fail-closed fetch error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn stalled_esplora_times_out_instead_of_hanging() {
+        // audit final I-03 / #87: consignment validation makes blocking HTTP
+        // calls through the host-controlled vsock proxy. A host that accepts
+        // the connection and never responds must cost at most the HTTP
+        // timeout — pre-fix this call hung the worker thread forever.
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind stalled stub");
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            // Accept and hold every connection open without ever writing a
+            // byte; keeping the streams alive prevents an early RST that
+            // would fail fast for the wrong reason.
+            let mut held = Vec::new();
+            for stream in listener.incoming() {
+                let Ok(stream) = stream else { break };
+                held.push(stream);
+            }
+        });
+
+        let validator = RgbValidator::new(format!("http://{addr}"), "bitcoin")
+            .unwrap()
+            .with_http_timeout(2);
+        let start = std::time::Instant::now();
+        let err = validator
+            .validate_consignment(TRANSFER_FIXTURE)
+            .unwrap_err();
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < std::time::Duration::from_secs(60),
+            "stalled Esplora must be bounded by the HTTP timeout, took {elapsed:?}: {err}"
         );
     }
 

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -641,11 +641,12 @@ fn handle_get_attested_public_key(
 }
 
 fn handle_sign_evm(ctx: &ServerContext, req: EvmDestination) -> Result<EnclaveResponse> {
-    // TODO: confirm domain name/version with contract team
+    // Domain name/version are pinned to the deployed MultisigProxy and
+    // regression-guarded by `test_domain_separator_matches_deployed_contract`.
     let domain = build_evm_domain(&req)?;
 
     let domain_sep = domain.separator_hash();
-    let digest = sign_request_digest(&domain, &req.call_data, req.nonce, req.deadline);
+    let digest = sign_request_digest(&domain, &req.call_data, req.nonce, req.deadline)?;
 
     tracing::info!(
         domain_name = %domain.name,


### PR DESCRIPTION
## What

Five small, self-contained hardening items from the Oxorio **final report** (umbrella issues #123/#124, audit issues #87/#65). No behavioral change for canonical inputs; every touched decision point stays fail-closed.

**Stacked on #144** (it extends the test modules #144 restores) — merge #144 first; this PR then retargets to `dev-ng` automatically.

| Item | Finding | Change |
|---|---|---|
| Esplora HTTP timeout | final I-03 / #87 | The blocking Esplora calls on the signing path had **no timeout** — a stalled host vsock-proxy pinned the worker thread forever (`conn.rs` bounds only the inbound socket). Now bounded by a 30s compile-time const aligned with `TOTAL_REQUEST_TIMEOUT`. Transport errors don't retry (esplora-client retries only 429/5xx), so one stalled call costs at most the timeout. Regression test with a stalled stub listener. |
| Fallible digest guard | final I-02 | `sign_request_digest` had `assert!(call_data.len() >= 4)` — with `panic = "abort"` that takes down the **whole enclave**, and dev-mode builds bypass the validation-layer length guard that would otherwise protect it. Now returns `Result`. |
| Canonical calldata encoding | W-01 residual (#123) | The ABI decoder is layout-permissive: trailing junk, overlapping/out-of-order dynamic tails all decode fine (`abi_decode_validate` only validates decoded *values*). `parse_proof_from_calldata` now requires decode→re-encode byte equality, pinning the input to the one canonical layout. This matters because the calldata is later rewritten by fixed byte offset (`apply_op_id_binding`) and what the enclave signs must decode on-chain to exactly what it validated. Regression tests: trailing junk, overlapping tails. |
| Wall-clock trust model | W-11 (#123) | `docs/tee-spec.md` now documents the wall-clock + entropy assumptions: the three `SystemTime::now()` gates (deadline, SPV staleness, header-rate), hypervisor-provided kvm-clock, why host-level time skew is out of reach through this code's interfaces, and the NSM-attested-time remediation path if ever needed. |
| ABI-layout known-answer tests | #65 | The hand-derived rewrite offsets (`36/68/196/228`) and the pinned selector constant are now regression-locked against the alloy-derived ABI layout (alloy-encode with markers → assert each offset extracts that field). Plus: the op-id-binding rewrite output must stay canonical and ABI-decodable (what gets signed must decode on-chain). Removed the stale "confirm domain name/version" TODO — the domain separator is already regression-pinned to the deployed contract. |

## Invariants

- Fail-closed everywhere touched: short calldata → error (previously abort), non-canonical encoding → reject, stalled Esplora → bounded error.
- No new listener-trusted input; timeout and headroom are compile-time (PCR-attested), not host-tunable (test-only override is `#[cfg(test)]`).
- Dev-mode bypass scope unchanged; feature graph unchanged.

## Verification

Full local matrix green: workspace build/clippy(`-D warnings`)/test (18 suites), `--no-default-features` build/clippy/test, feature-guard inversion (`rgb-validation` without `spv` fails with the expected `compile_error!`), `fmt --check`.

Remaining scope of the touched findings is documented on the issues: #87 keeps only the I-08 typed-client narrowing (deferred — design pends the multi-protocol forwarder consumers in #134/#136), #65 keeps only the contract-derived full-digest vector (needs a vector from the contract side).
