### PR TITLE
fix(psbt): bind mint-RGB (Inflation) PSBTs to the consignment (#54)

### DIFF
--- a/enclave/src/networks/rgb/mod.rs
+++ b/enclave/src/networks/rgb/mod.rs
@@ -235,6 +235,7 @@ mod tests {
                 op_id: op_id.into(),
                 transition_type,
                 total_output_amount,
+                asset_output_amount: total_output_amount,
                 outputs: vec![],
                 burned_asset_amount,
             }),

--- a/enclave/src/networks/rgb/psbt_validation.rs
+++ b/enclave/src/networks/rgb/psbt_validation.rs
@@ -84,7 +84,8 @@ pub fn validate_psbt_bytes(psbt_bytes: &[u8]) -> Result<()> {
 ///
 /// Enforces, fail-closed:
 ///   1. The consignment's last transition is an IFA `Transfer`
-///      (`ifa::TS_TRANSFER`) — the pools-mode send shape.
+///      (`ifa::TS_TRANSFER`, the pools-mode send shape) or an IFA
+///      `Inflation` (`ifa::TS_INFLATION`, the mint-RGB shape — #54).
 ///   2. **Identity bind:** `psbt.unsigned_tx.compute_txid()` equals the
 ///      consignment's last witness txid. A segwit txid commits to every
 ///      non-witness field (all inputs, all outputs incl. the commitment
@@ -98,10 +99,11 @@ pub fn validate_psbt_bytes(psbt_bytes: &[u8]) -> Result<()> {
 ///   4. **Sighash guard:** refuse any input requesting a sighash other than
 ///      ALL / taproot-DEFAULT, so a host can't splice our signature into a
 ///      different tx (ANYONECANPAY / SINGLE / NONE).
-///   5. **Amount bind (coarse):** the transfer's `total_output_amount` must
-///      cover the net amount credited by the source side (`source_amount`
-///      minus `source_commission`). This does not yet verify which output is
-///      the recipient leg (issue #58).
+///   5. **Amount bind (coarse):** the transition's `asset_output_amount`
+///      (the `OS_ASSET`-typed allocations only — for a mint, excluding the
+///      `OS_INFLATION` allowance outputs) must cover the net amount credited
+///      by the source side (`source_amount` minus `source_commission`). This
+///      does not yet verify which output is the recipient leg (issue #58).
 #[cfg(feature = "rgb-validation")]
 pub fn validate_psbt_anchors_transition(
     psbt: &Psbt,
@@ -116,11 +118,13 @@ pub fn validate_psbt_anchors_transition(
             "send-RGB PSBT requires a consignment with at least one transition".into(),
         )
     })?;
-    if last.transition_type != ifa::TS_TRANSFER {
+    if !matches!(last.transition_type, ifa::TS_TRANSFER | ifa::TS_INFLATION) {
         return Err(EnclaveError::CrossCheck(format!(
-            "send-RGB PSBT requires a Transfer transition (last transition_type = {}, want {})",
+            "send-RGB PSBT requires a Transfer or Inflation transition (last transition_type = \
+             {}, want {} or {})",
             last.transition_type,
-            ifa::TS_TRANSFER
+            ifa::TS_TRANSFER,
+            ifa::TS_INFLATION
         )));
     }
 
@@ -128,7 +132,7 @@ pub fn validate_psbt_anchors_transition(
     // (a non-segwit input's scriptSig would change the txid post-signing).
     let expected = validated.last_transfer_witness_txid.ok_or_else(|| {
         EnclaveError::CrossCheck(
-            "consignment carries no witness txid for its Transfer transition — \
+            "consignment carries no witness txid for its last transition — \
              cannot anchor the PSBT"
                 .into(),
         )
@@ -172,11 +176,15 @@ pub fn validate_psbt_anchors_transition(
     }
 
     let net_credited = source_amount.saturating_sub(source_commission);
-    if last.total_output_amount < net_credited {
+    // `asset_output_amount`, not `total_output_amount`: only `OS_ASSET`-typed
+    // allocations carry asset units. For a Transfer the two are equal; for an
+    // Inflation the total also counts `OS_INFLATION` allowance outputs (mint
+    // *capacity*), which must not cover the credited amount (#54).
+    if last.asset_output_amount < net_credited {
         return Err(EnclaveError::CrossCheck(format!(
-            "send-RGB amount mismatch: consignment total_output_amount ({}) < net credited \
+            "send-RGB amount mismatch: consignment asset_output_amount ({}) < net credited \
              (source_amount {} - source_commission {} = {})",
-            last.total_output_amount, source_amount, source_commission, net_credited
+            last.asset_output_amount, source_amount, source_commission, net_credited
         )));
     }
 
@@ -381,6 +389,8 @@ mod tests {
                 op_id: "transfer-op".into(),
                 transition_type: ifa::TS_TRANSFER,
                 total_output_amount,
+                // Transfers move only OS_ASSET, so the two sums are equal.
+                asset_output_amount: total_output_amount,
                 outputs: vec![],
                 burned_asset_amount: None,
             }
@@ -480,6 +490,40 @@ mod tests {
             assert!(validate_psbt_anchors_transition(&psbt, &validated, 1_000, 0).is_ok());
         }
 
+        /// #54: the mint-RGB shape — an IFA Inflation last transition — binds
+        /// through the same anchor path as the pools-mode Transfer.
+        #[test]
+        fn accepts_inflation_shape() {
+            let psbt = psbt_with_two_inputs();
+            let mut validated = validated_for(&psbt, 1_000);
+            validated.last_transition.as_mut().unwrap().transition_type = ifa::TS_INFLATION;
+            assert!(validate_psbt_anchors_transition(&psbt, &validated, 1_000, 0).is_ok());
+        }
+
+        /// #54: for a mint, only `OS_ASSET`-typed outputs (the actually
+        /// minted units) may cover the credited amount — the `OS_INFLATION`
+        /// allowance (mint capacity) counted in `total_output_amount` must
+        /// not.
+        #[test]
+        fn inflation_allowance_does_not_cover_credited_amount() {
+            let psbt = psbt_with_two_inputs();
+            let mut validated = validated_for(&psbt, 1_000);
+            {
+                let last = validated.last_transition.as_mut().unwrap();
+                last.transition_type = ifa::TS_INFLATION;
+                // Minted 999 units; a large allowance rides along in the
+                // total. Net credited is 1_000 — must be rejected on the
+                // asset sum, not covered by the allowance-inflated total.
+                last.asset_output_amount = 999;
+                last.total_output_amount = 1_000_000;
+            }
+            let err = validate_psbt_anchors_transition(&psbt, &validated, 1_000, 0).unwrap_err();
+            assert!(
+                err.to_string().contains("asset_output_amount (999)"),
+                "expected asset-amount rejection, got: {err}"
+            );
+        }
+
         #[test]
         fn rejects_non_transfer_transition() {
             let psbt = psbt_with_two_inputs();
@@ -487,8 +531,9 @@ mod tests {
             validated.last_transition.as_mut().unwrap().transition_type = ifa::TS_BURN;
             let err = validate_psbt_anchors_transition(&psbt, &validated, 1_000, 0).unwrap_err();
             assert!(
-                err.to_string().contains("requires a Transfer transition"),
-                "expected Transfer-required rejection, got: {err}"
+                err.to_string()
+                    .contains("requires a Transfer or Inflation transition"),
+                "expected Transfer/Inflation-required rejection, got: {err}"
             );
         }
 

--- a/enclave/src/networks/rgb/validation.rs
+++ b/enclave/src/networks/rgb/validation.rs
@@ -172,6 +172,15 @@ pub mod ifa {
     /// `OS_ASSET` (the regular fungible asset allocation type). The
     /// associated value is a strict-encoded `rgbstd::Amount` (u64).
     pub const MS_BURNED_ASSET: u16 = 1001;
+
+    /// IFA fungible assignment type for regular asset ownership
+    /// (`assetOwner`) — the allocations that actually carry asset units.
+    pub const OS_ASSET: u16 = 4000;
+    /// IFA fungible assignment type carrying the remaining right-to-mint
+    /// (`inflationAllowance`). Its `amount` is mint *capacity*, not asset
+    /// units — summing it together with `OS_ASSET` would let an inflation
+    /// consignment claim allowance as minted value (#54).
+    pub const OS_INFLATION: u16 = 4010;
 }
 
 /// Resolve the **trusted** strict type-system the validator must pin a
@@ -328,6 +337,13 @@ pub struct TransitionSummary {
     /// outputs; for a Burn this is **zero** because burns have no output
     /// assignments — the destroyed amount lives in [`Self::burned_asset_amount`].
     pub total_output_amount: u64,
+    /// Sum of the fungible amounts on `OS_ASSET`-typed output assignments
+    /// only — the allocations that actually carry asset units. For a
+    /// Transfer this equals [`Self::total_output_amount`] (transfers move
+    /// only `OS_ASSET`); for an Inflation (mint) it is the freshly minted
+    /// value, **excluding** the `OS_INFLATION` allowance outputs, whose
+    /// amounts are remaining mint capacity, not asset units (#54).
+    pub asset_output_amount: u64,
     /// Concrete output assignments, each tagged with a destination seal
     /// and an amount. Empty for Burn transitions.
     pub outputs: Vec<TransitionOutput>,
@@ -486,13 +502,15 @@ impl RgbValidator {
         // PSBT path. We extract the last bundle's witness txid (and, when the
         // bundle embeds the full tx, its input prevouts) so the PSBT
         // cross-check can prove the PSBT being signed IS this witness
-        // transaction. Gated on the last transition being a Transfer: the
-        // bind is only meaningful for the pools-mode send shape, and the
-        // consistency check inside reads the parsed transition type to ensure
-        // the txid and the transition come from the same witness.
+        // transaction. Gated on the last transition being a Transfer (the
+        // pools-mode send shape) or an Inflation (the mint-RGB shape, #54);
+        // the consistency check inside reads the parsed transition type to
+        // ensure the txid and the transition come from the same witness.
         let (last_transfer_witness_txid, last_transfer_witness_prevouts, last_transfer_op_id) =
             match last_transition {
-                Some(ref last) if last.transition_type == ifa::TS_TRANSFER => {
+                Some(ref last)
+                    if matches!(last.transition_type, ifa::TS_TRANSFER | ifa::TS_INFLATION) =>
+                {
                     read_last_transfer_witness(&transfer, last.transition_type)?
                 }
                 _ => (None, None, None),
@@ -757,6 +775,23 @@ fn transition_summary(t: &TransitionInfo) -> Result<TransitionSummary> {
                 })
             })?;
 
+    // Asset units only: `OS_ASSET`-typed allocations. An Inflation (mint)
+    // transition also carries `OS_INFLATION` allowance outputs whose amounts
+    // are remaining mint *capacity* — counting those as minted value would
+    // let a mint consignment cover an EVM lock it never minted for (#54).
+    let asset_output_amount: u64 = t
+        .fungible_allocations
+        .iter()
+        .filter(|a: &&FungibleAllocation| a.assignment_type == ifa::OS_ASSET)
+        .try_fold(0u64, |acc, a: &FungibleAllocation| {
+            acc.checked_add(a.total).ok_or_else(|| {
+                EnclaveError::CrossCheck(format!(
+                    "consignment transition asset_output_amount overflow (op_id {})",
+                    t.op_id
+                ))
+            })
+        })?;
+
     let outputs: Result<Vec<TransitionOutput>> = t
         .fungible_allocations
         .iter()
@@ -767,6 +802,7 @@ fn transition_summary(t: &TransitionInfo) -> Result<TransitionSummary> {
         op_id: t.op_id.clone(),
         transition_type: t.transition_type,
         total_output_amount,
+        asset_output_amount,
         outputs: outputs?,
         // Filled by `read_last_transition_burned_asset` if the
         // transition is a burn; the parser doesn't expose metadata so
@@ -886,6 +922,52 @@ mod tests {
     fn rejects_unknown_network() {
         let err = RgbValidator::new("http://localhost:1".to_string(), "foonet").unwrap_err();
         assert!(err.to_string().contains("unknown bitcoin network"));
+    }
+
+    /// #54: `asset_output_amount` must count only `OS_ASSET`-typed
+    /// allocations. An inflation (mint) transition also carries
+    /// `OS_INFLATION` allowance outputs whose amounts are remaining mint
+    /// capacity — counting them as minted value would let a mint consignment
+    /// cover an EVM lock it never minted for.
+    #[test]
+    fn transition_summary_excludes_inflation_allowance_from_asset_amount() {
+        let alloc = |assignment_type: u16, amount: u64| FungibleAllocation {
+            assignment_type,
+            entries: vec![FungibleEntry {
+                amount,
+                seal: SealInfo::Revealed {
+                    txid: None,
+                    vout: 0,
+                },
+            }],
+            total: amount,
+        };
+        let info = TransitionInfo {
+            op_id: "mint-op".into(),
+            transition_type: ifa::TS_INFLATION,
+            input_count: 1,
+            fungible_allocations: vec![
+                alloc(ifa::OS_ASSET, 500),
+                // Remaining right-to-mint: must NOT count as asset units.
+                alloc(ifa::OS_INFLATION, 1_000_000),
+            ],
+        };
+
+        let summary = transition_summary(&info).expect("summary");
+        assert_eq!(summary.asset_output_amount, 500);
+        assert_eq!(summary.total_output_amount, 1_000_500);
+    }
+
+    /// For a Transfer everything is `OS_ASSET`, so the two sums agree — the
+    /// invariant the PSBT amount bind relies on when it switched from
+    /// `total_output_amount` to `asset_output_amount` (#54).
+    #[test]
+    fn transfer_fixture_asset_amount_equals_total() {
+        let (_, _, last_transition) =
+            extract_transition_summary(TRANSFER_FIXTURE).expect("transfer parse");
+        let last = last_transition.expect("transfer has a last transition");
+        assert_eq!(last.transition_type, ifa::TS_TRANSFER);
+        assert_eq!(last.asset_output_amount, last.total_output_amount);
     }
 
     #[test]


### PR DESCRIPTION
## What

Closes the mint-shape gap in the PSBT↔consignment binding (#54, P1): the #79 anchor bind covered only the pools-mode Transfer shape, and an EVM-lock → RGB-mint consignment (last transition = IFA `TS_INFLATION`) was refused outright on the send-RGB PSBT path. This PR lets the mint shape through **with full binding** — same fail-closed anchor checks (witness-txid identity, prevout canary, sighash guard, amount bind).

## The load-bearing detail: allowance ≠ value

An Inflation transition carries both `OS_ASSET` allocations (the freshly minted units) and `OS_INFLATION` allocations (the remaining right-to-mint). Counting the allowance as minted value would let a mint consignment cover an EVM lock it never minted for. So:

- `TransitionSummary` gains **`asset_output_amount`** — the sum over `OS_ASSET`-typed allocations only (schema constants `OS_ASSET=4000` / `OS_INFLATION=4010` sourced from the canonical `rgb-schemas` crate, like the existing `TS_*` ids).
- The PSBT amount bind switches from `total_output_amount` to `asset_output_amount`. For Transfers the two are identical (transfers move only `OS_ASSET` — pinned by a fixture test), so **the Transfer path's behavior is unchanged**.
- The fundsOut (RGB→EVM) path deliberately keeps `total_output_amount` — for its Transfer-only shape the sums are equal, and the strict per-federation-seal binding there is #58's tracked scope.

## Invariants

- Fail-closed preserved: Burn (and any other) last transition still rejected on this path; missing witness txid still rejected; the rgbstd-vs-parser transition-type cross-assert inside `read_last_transfer_witness` applies to the mint shape unchanged.
- No listener-trusted input added; dev-mode gating untouched; feature graph untouched.
- Behavior *widened* only for `TS_INFLATION` (previously fail-closed-rejected) — reviewers should confirm the mint flow is ready for this on the listener side; until the listener sends mint consignments, nothing changes operationally.

## Tests

`transition_summary` OS_INFLATION-exclusion, Transfer `asset==total` invariant on the mainnet fixture, inflation-shape anchor accept, allowance-must-not-cover-credited rejection. Full local matrix green (18 workspace suites, minimal lane, clippy `-D warnings` both lanes, fmt).

## Known gap

No mint/inflation consignment fixture exists in-tree, so the rgbstd-level extraction for a real mint bundle is exercised only via the type-parametric code path shared with Transfers (the parser-level filtering is unit-tested with synthetic `TransitionInfo`s). A mint fixture (from the rgb-lib test harness, like the existing transfer fixture) would close that — happy to add it when one is available.
