### PR TITLE
feat(psbt): fee-rate sanity check vs the enclave's own Esplora estimate (#55)

### DIFF
--- a/enclave/src/networks/rgb/mod.rs
+++ b/enclave/src/networks/rgb/mod.rs
@@ -212,7 +212,14 @@ pub fn validate_destination_anchor(
         &validated,
         source_amount,
         source_commission,
-    )
+    )?;
+
+    // Fee-rate sanity (#55), after the pure anchor checks so the (cached)
+    // Esplora round-trip is the last thing that can reject. Fail-closed when
+    // the estimate is unavailable: the host controls the Esplora egress, so
+    // "no estimate → skip" would let the host disable the check.
+    let recommended = validator.recommended_fee_rate_sat_vb()?;
+    psbt_validation::check_psbt_fee_rate(&psbt, recommended)
 }
 
 #[cfg(all(test, feature = "rgb-validation"))]

--- a/enclave/src/networks/rgb/psbt_validation.rs
+++ b/enclave/src/networks/rgb/psbt_validation.rs
@@ -232,8 +232,13 @@ pub fn check_psbt_fee_rate(psbt: &Psbt, recommended_sat_vb: f64) -> Result<()> {
     }
     let rate = fee.to_sat() as f64 / vsize as f64;
     let limit = FEE_RATE_HEADROOM * recommended_sat_vb;
-    // `!(a <= b)` instead of `a > b`: NaN must reject, never pass.
-    if !(rate <= limit) {
+    // `partial_cmp` (not `a > b`): an incomparable (NaN) rate or limit must
+    // reject, never pass.
+    let within_limit = matches!(
+        rate.partial_cmp(&limit),
+        Some(std::cmp::Ordering::Less | std::cmp::Ordering::Equal)
+    );
+    if !within_limit {
         return Err(EnclaveError::CrossCheck(format!(
             "send-RGB PSBT fee rate too high: {rate:.2} sat/vB > {FEE_RATE_HEADROOM}x the \
              recommended {recommended_sat_vb:.2} sat/vB — refusing to burn bridge BTC as fees"

--- a/enclave/src/networks/rgb/psbt_validation.rs
+++ b/enclave/src/networks/rgb/psbt_validation.rs
@@ -197,6 +197,51 @@ pub fn validate_psbt_anchors_transition(
     Ok(())
 }
 
+/// Maximum multiple of the recommended fee rate a send-RGB PSBT may pay
+/// (#55). Compile-time (PCR-attested), deliberately not host-tunable: an
+/// env knob would let the operator's host neutralize the check. 3x absorbs
+/// fee-market movement within the estimate's TTL plus the unsigned-vsize
+/// overestimate (see [`check_psbt_fee_rate`]).
+#[cfg(feature = "rgb-validation")]
+const FEE_RATE_HEADROOM: f64 = 3.0;
+
+/// Fee-rate sanity check for send-RGB PSBTs (#55): the implied fee rate must
+/// not exceed [`FEE_RATE_HEADROOM`] x the enclave-fetched recommendation.
+/// Without this, a compromised host could burn bridge BTC as miner fees on an
+/// otherwise fully-validated PSBT (the anchor bind pins inputs and the
+/// commitment output, but the fee is whatever the outputs leave behind).
+///
+/// Fail-closed on every degenerate shape: `Psbt::fee()` errors (missing
+/// `witness_utxo`/`non_witness_utxo`, value overflow) reject, a zero-vsize tx
+/// rejects, and the comparison is written so a NaN rate rejects. The rate is
+/// computed over `unsigned_tx.vsize()`, which is smaller than the final
+/// witness-carrying vsize — the implied rate is therefore an OVERestimate,
+/// i.e. conservative in the rejecting direction; the headroom absorbs it.
+#[cfg(feature = "rgb-validation")]
+pub fn check_psbt_fee_rate(psbt: &Psbt, recommended_sat_vb: f64) -> Result<()> {
+    let fee = psbt.fee().map_err(|e| {
+        EnclaveError::CrossCheck(format!(
+            "cannot compute PSBT fee (every input needs witness_utxo or non_witness_utxo): {e}"
+        ))
+    })?;
+    let vsize = psbt.unsigned_tx.vsize();
+    if vsize == 0 {
+        return Err(EnclaveError::CrossCheck(
+            "PSBT unsigned tx has zero vsize — cannot bound its fee rate".into(),
+        ));
+    }
+    let rate = fee.to_sat() as f64 / vsize as f64;
+    let limit = FEE_RATE_HEADROOM * recommended_sat_vb;
+    // `!(a <= b)` instead of `a > b`: NaN must reject, never pass.
+    if !(rate <= limit) {
+        return Err(EnclaveError::CrossCheck(format!(
+            "send-RGB PSBT fee rate too high: {rate:.2} sat/vB > {FEE_RATE_HEADROOM}x the \
+             recommended {recommended_sat_vb:.2} sat/vB — refusing to burn bridge BTC as fees"
+        )));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -348,6 +393,88 @@ mod tests {
     // =========================================================================
     // send-RGB anchoring — `validate_psbt_anchors_transition`
     // =========================================================================
+    #[cfg(feature = "rgb-validation")]
+    mod fee_rate {
+        use super::*;
+
+        /// One segwit-ish input carrying `witness_utxo` of `input_sats`, one
+        /// output of `output_sats` — so `Psbt::fee()` = input − output.
+        fn psbt_with_fee(input_sats: u64, output_sats: u64) -> Psbt {
+            let unsigned_tx = Transaction {
+                version: bitcoin::transaction::Version(2),
+                lock_time: bitcoin::absolute::LockTime::ZERO,
+                input: vec![TxIn {
+                    previous_output: OutPoint {
+                        txid: Txid::from_raw_hash(bitcoin::hashes::sha256d::Hash::from_byte_array(
+                            [0x11; 32],
+                        )),
+                        vout: 0,
+                    },
+                    script_sig: ScriptBuf::new(),
+                    sequence: Sequence::MAX,
+                    witness: Witness::new(),
+                }],
+                output: vec![TxOut {
+                    value: Amount::from_sat(output_sats),
+                    script_pubkey: ScriptBuf::new(),
+                }],
+            };
+            let mut psbt = Psbt::from_unsigned_tx(unsigned_tx).expect("from_unsigned_tx");
+            psbt.inputs[0].witness_utxo = Some(TxOut {
+                value: Amount::from_sat(input_sats),
+                script_pubkey: ScriptBuf::new(),
+            });
+            psbt
+        }
+
+        #[test]
+        fn accepts_fee_rate_at_headroom() {
+            // rate == FEE_RATE_HEADROOM × recommended must pass (boundary is
+            // inclusive: reject only strictly above the cap).
+            let recommended = 10.0;
+            let vsize = psbt_with_fee(100_000, 100_000).unsigned_tx.vsize() as u64;
+            let fee_at_cap = (FEE_RATE_HEADROOM * recommended) as u64 * vsize;
+            let psbt = psbt_with_fee(100_000, 100_000 - fee_at_cap);
+            assert!(check_psbt_fee_rate(&psbt, recommended).is_ok());
+        }
+
+        #[test]
+        fn rejects_fee_rate_above_headroom() {
+            // One extra sat/vB above the cap → reject; nothing else about the
+            // PSBT is wrong, so the error must be the fee-rate one.
+            let recommended = 10.0;
+            let vsize = psbt_with_fee(100_000, 100_000).unsigned_tx.vsize() as u64;
+            let fee_over_cap = ((FEE_RATE_HEADROOM * recommended) as u64 + 1) * vsize;
+            let psbt = psbt_with_fee(100_000, 100_000 - fee_over_cap);
+            let err = check_psbt_fee_rate(&psbt, recommended).unwrap_err();
+            assert!(
+                err.to_string().contains("fee rate too high"),
+                "expected fee-rate rejection, got: {err}"
+            );
+        }
+
+        #[test]
+        fn rejects_psbt_without_utxo_data() {
+            // No witness_utxo/non_witness_utxo → the fee is uncomputable and
+            // the check must fail closed, not skip.
+            let psbt = Psbt::deserialize(&minimal_valid_psbt_bytes()).unwrap();
+            let err = check_psbt_fee_rate(&psbt, 10.0).unwrap_err();
+            assert!(
+                err.to_string().contains("cannot compute PSBT fee"),
+                "expected uncomputable-fee rejection, got: {err}"
+            );
+        }
+
+        #[test]
+        fn rejects_nan_recommendation() {
+            // A NaN limit must reject (the comparison is written as
+            // `!(rate <= limit)` so NaN can never pass). The recommendation
+            // is validated upstream, but the check must not rely on that.
+            let psbt = psbt_with_fee(100_000, 99_000);
+            assert!(check_psbt_fee_rate(&psbt, f64::NAN).is_err());
+        }
+    }
+
     #[cfg(feature = "rgb-validation")]
     mod anchor {
         use super::*;

--- a/enclave/src/networks/rgb/validation.rs
+++ b/enclave/src/networks/rgb/validation.rs
@@ -388,11 +388,29 @@ pub enum OutputSeal {
     Confidential { secret_seal: String },
 }
 
+/// Hard cap on any single blocking Esplora HTTP call (connect + read), in
+/// seconds. The Esplora egress runs through the host-controlled vsock proxy,
+/// and these calls happen *on the signing path* — without a timeout a stalled
+/// host pins the worker thread indefinitely (audit final I-03 / #87).
+/// Compile-time (PCR-attested), deliberately not host-tunable.
+const ESPLORA_HTTP_TIMEOUT_SECS: u64 = 30;
+
+/// How long a fetched fee estimate stays fresh (#55). Fee markets move on
+/// block cadence, so a minute of staleness is immaterial while keeping the
+/// sign-path from hitting Esplora on every request.
+const FEE_ESTIMATE_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Confirmation target (blocks) used for the recommended fee rate (#55).
+const FEE_ESTIMATE_TARGET: u16 = 6;
+
 /// Validates RGB consignments using rgbstd and an Esplora-backed resolver.
 #[derive(Debug)]
 pub struct RgbValidator {
     esplora_url: String,
     chain_net: ChainNet,
+    /// Cached `(fetched_at, sat/vB)` recommended fee rate (#55), guarded for
+    /// the multi-threaded worker pool. `None` until the first fetch.
+    fee_estimate_cache: std::sync::Mutex<Option<(std::time::Instant, f64)>>,
 }
 
 impl RgbValidator {
@@ -417,7 +435,64 @@ impl RgbValidator {
         Ok(Self {
             esplora_url,
             chain_net,
+            fee_estimate_cache: std::sync::Mutex::new(None),
         })
+    }
+
+    /// Recommended fee rate (sat/vB) from the enclave's own Esplora egress,
+    /// for the send-RGB PSBT fee-rate sanity check (#55). Fetches
+    /// `/fee-estimates` (confirmation target [`FEE_ESTIMATE_TARGET`], falling
+    /// back to the nearest available target) with a [`FEE_ESTIMATE_TTL`]
+    /// cache. FAIL-CLOSED on any fetch/shape problem: the host controls the
+    /// Esplora egress, so treating "estimate unavailable" as "skip the check"
+    /// would let the host disable the check by blocking the endpoint.
+    pub fn recommended_fee_rate_sat_vb(&self) -> Result<f64> {
+        let now = std::time::Instant::now();
+        let mut cache = self
+            .fee_estimate_cache
+            .lock()
+            .map_err(|e| EnclaveError::Internal(format!("fee-estimate cache poisoned: {e}")))?;
+        if let Some((fetched_at, rate)) = *cache {
+            if now.duration_since(fetched_at) < FEE_ESTIMATE_TTL {
+                return Ok(rate);
+            }
+        }
+
+        let client = esplora_client::Builder::new(&self.esplora_url)
+            .timeout(ESPLORA_HTTP_TIMEOUT_SECS)
+            .build_blocking();
+        let estimates = client.get_fee_estimates().map_err(|e| {
+            EnclaveError::CrossCheck(format!(
+                "fee-estimate fetch failed — refusing to sign a send-RGB PSBT without a \
+                 fee-rate sanity bound (#55): {e}"
+            ))
+        })?;
+
+        // Exact target if present, else the nearest available one.
+        let rate = estimates
+            .get(&FEE_ESTIMATE_TARGET)
+            .copied()
+            .or_else(|| {
+                estimates
+                    .iter()
+                    .min_by_key(|(t, _)| t.abs_diff(FEE_ESTIMATE_TARGET))
+                    .map(|(_, r)| *r)
+            })
+            .ok_or_else(|| {
+                EnclaveError::CrossCheck(
+                    "fee-estimate response carried no targets — refusing to sign a send-RGB \
+                     PSBT without a fee-rate sanity bound (#55)"
+                        .into(),
+                )
+            })?;
+        if !rate.is_finite() || rate <= 0.0 {
+            return Err(EnclaveError::CrossCheck(format!(
+                "fee-estimate response is not a positive finite rate: {rate}"
+            )));
+        }
+
+        *cache = Some((now, rate));
+        Ok(rate)
     }
 
     /// Validate raw consignment bytes. Returns extracted data on success,
@@ -915,6 +990,99 @@ mod tests {
         assert!(
             err.to_string().contains("deserialization failed"),
             "expected deserialization error, got: {err}"
+        );
+    }
+
+    /// Stub Esplora answering only `GET /fee-estimates`, with a per-request
+    /// body sequence (later requests get the last body). Returns the URL.
+    fn spawn_fee_stub(bodies: Vec<&'static str>) -> String {
+        use std::io::{Read as _, Write as _};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind fee stub");
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let mut served = 0usize;
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { break };
+                let mut buf = [0u8; 2048];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let first = String::from_utf8_lossy(&buf[..n])
+                    .lines()
+                    .next()
+                    .unwrap_or_default()
+                    .to_string();
+                let resp = if first.starts_with("GET /fee-estimates") {
+                    let body = bodies[served.min(bodies.len() - 1)];
+                    served += 1;
+                    format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    )
+                } else {
+                    "HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                        .to_string()
+                };
+                let _ = stream.write_all(resp.as_bytes());
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    #[test]
+    fn fee_estimate_uses_exact_target_and_caches() {
+        // First fetch returns target-6's rate; the second call must be served
+        // from the 60s cache (the stub would answer 99.0 if re-queried).
+        let url = spawn_fee_stub(vec![r#"{"1":50.0,"6":20.0,"25":5.0}"#, r#"{"6":99.0}"#]);
+        let v = RgbValidator::new(url, "bitcoin").unwrap();
+        assert_eq!(v.recommended_fee_rate_sat_vb().unwrap(), 20.0);
+        assert_eq!(
+            v.recommended_fee_rate_sat_vb().unwrap(),
+            20.0,
+            "second call must hit the cache, not the stub"
+        );
+    }
+
+    #[test]
+    fn fee_estimate_falls_back_to_nearest_target() {
+        // No target 6: nearest is 1 (|6-1| = 5) over 25 (|6-25| = 19).
+        let url = spawn_fee_stub(vec![r#"{"1":50.0,"25":5.0}"#]);
+        let v = RgbValidator::new(url, "bitcoin").unwrap();
+        assert_eq!(v.recommended_fee_rate_sat_vb().unwrap(), 50.0);
+    }
+
+    #[test]
+    fn fee_estimate_rejects_empty_response() {
+        let url = spawn_fee_stub(vec![r#"{}"#]);
+        let v = RgbValidator::new(url, "bitcoin").unwrap();
+        let err = v.recommended_fee_rate_sat_vb().unwrap_err();
+        assert!(
+            err.to_string().contains("no targets"),
+            "expected empty-estimates rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn fee_estimate_rejects_non_positive_rate() {
+        let url = spawn_fee_stub(vec![r#"{"6":0.0}"#]);
+        let v = RgbValidator::new(url, "bitcoin").unwrap();
+        let err = v.recommended_fee_rate_sat_vb().unwrap_err();
+        assert!(
+            err.to_string().contains("not a positive finite rate"),
+            "expected non-positive rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn fee_estimate_fails_closed_when_unreachable() {
+        // Nothing listening: the fetch error must propagate as a refusal, not
+        // a skip — the host controls this egress (#55).
+        let v = RgbValidator::new("http://127.0.0.1:1".into(), "bitcoin").unwrap();
+        let err = v.recommended_fee_rate_sat_vb().unwrap_err();
+        assert!(
+            err.to_string().contains("refusing to sign"),
+            "expected fail-closed fetch error, got: {err}"
         );
     }
 


### PR DESCRIPTION
## What

Closes the fee-drain gap on the send-RGB PSBT path (#55, P2 hardening): the anchor bind (#79) pins the inputs and the commitment output, but **the fee is whatever the outputs leave behind** — a compromised host could burn bridge BTC as miner fees on an otherwise fully-validated PSBT.

`validate_destination_anchor` now rejects any PSBT whose implied fee rate (`fee / unsigned-tx vsize`) exceeds **3× the recommended rate** fetched from the enclave's *own* Esplora egress (`/fee-estimates`, 6-block target with nearest-target fallback, 60s cache, 30s HTTP timeout). The check runs after the pure anchor checks, so the (cached) network round-trip is the last thing that can reject.

**Stacked on #146** (`fix/54-inflation-psbt-bind`) — both touch `psbt_validation.rs`/`validation.rs`; merge #146 first and this retargets automatically.

## Policy choices (reviewers: this is the part to push back on)

| Decision | Rationale |
|---|---|
| Headroom = compile-time `3.0×`, not env-tunable | An env knob would let the operator's host neutralize the check; compile-time keeps it PCR-attested. 3× absorbs fee-market movement within the cache TTL plus the unsigned-vsize overestimate (unsigned vsize < final witness vsize ⇒ implied rate errs toward rejecting). |
| Estimate unavailable ⇒ **refuse to sign** | The host controls the Esplora egress. "No estimate → skip" would let the host disable the check by blocking one endpoint. Esplora is already load-bearing for consignment validation on this path, so this adds no new liveness dependency. |
| All degenerate shapes fail closed | Uncomputable fee (missing `witness_utxo`/`non_witness_utxo`, value overflow), zero vsize, empty/non-positive/non-finite estimates, NaN comparisons — all reject. |

## Invariants

- No new listener-trusted input: the estimate comes from the enclave's own egress, never the request.
- Anchor checks, asset pins, hash checks untouched; dev-mode dispatch unchanged (the whole anchor path is already dev-mode-bypassed upstream).
- Feature graph unchanged (`check_psbt_fee_rate` and the estimate plumbing are `rgb-validation`-gated like their call site).

## Tests

Boundary (exactly-at-3× passes, one sat/vB above rejects), uncomputable-fee rejection, NaN rejection, and stub-Esplora plumbing tests (exact-target selection, nearest-target fallback, cache hit on second call, empty map / non-positive rate / unreachable endpoint all fail closed). Full local matrix green: 18 workspace suites, minimal `--no-default-features` lane, clippy `-D warnings` both lanes, fmt, M-01 feature-guard inversion.

## Known limitation

The wiring (`validate_destination_anchor` → fee check) has no end-to-end test on this branch — that needs the full stub-consignment harness that lands with #144/#145; the unit tests cover both halves of the seam. Happy to add the wiring test once those merge.
