### PR TITLE
panic at boot when a release rgb-validation build isn't fully pinned (C-01)

### DIFF
--- a/enclave/src/config.rs
+++ b/enclave/src/config.rs
@@ -143,6 +143,57 @@ impl BridgeConfig {
             || !self.rgb_asset_id.is_empty();
         any && !self.is_configured()
     }
+
+    /// The reason this config is not production-ready, or `None` when all three
+    /// pins (chain, contract, asset) are set. Pure and build-profile-agnostic so
+    /// it is directly unit-testable; [`assert_configured_in_release`](Self::assert_configured_in_release)
+    /// layers the debug/test exemptions and the `rgb-validation`-only scope on top.
+    pub fn production_readiness_error(&self) -> Option<String> {
+        if self.is_configured() {
+            return None;
+        }
+        let detail = if self.is_partially_configured() {
+            "PARTIALLY set (some but not all of EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID \
+             are set)"
+        } else {
+            "unset (none of EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID are set)"
+        };
+        Some(format!(
+            "bridge config is {detail}. A release rgb-validation (bridge-signing) enclave must \
+             pin all three so every signing path is authorised against operator pins; without \
+             them it would boot and fail closed on every bridge request. Set all three env vars, \
+             or build without rgb-validation for a non-signing enclave."
+        ))
+    }
+
+    /// Refuse to START a production bridge-signing build that isn't fully pinned
+    /// (audit C-01 systemic: no single explicit fail-closed production policy).
+    ///
+    /// A release `rgb-validation` build reaches every bridge-signing path, and
+    /// each already fails closed *per request* when [`is_configured`](Self::is_configured)
+    /// is false (see `networks::evm::validation::validate_destination` and
+    /// `networks::rgb::validate_destination_anchor`). But a per-request refusal
+    /// is only visible to whoever reads the rejected response or the enclave
+    /// logs - which an operator does not watch on a production host. Fail at
+    /// BOOT instead, the same way a placeholder SPV checkpoint does
+    /// ([`crate::networks::rgb::spv::Checkpoint::assert_real_in_release`]): a
+    /// misconfigured or partially-pinned production enclave never becomes
+    /// reachable, rather than starting and silently rejecting every signature.
+    ///
+    /// Exemptions mirror `assert_real_in_release`: debug builds, tests, and the
+    /// local-E2E `allow-seed-import` feature may run unpinned. A minimal
+    /// (non-`rgb-validation`) build has no bridge-signing path to protect and
+    /// always passes.
+    pub fn assert_configured_in_release(&self) -> std::result::Result<(), String> {
+        if cfg!(debug_assertions) || cfg!(test) || cfg!(feature = "allow-seed-import") {
+            return Ok(());
+        }
+        #[cfg(feature = "rgb-validation")]
+        if let Some(msg) = self.production_readiness_error() {
+            return Err(msg);
+        }
+        Ok(())
+    }
 }
 
 /// Parse `0xABCD…` (40 hex chars) or bare 40-hex into 20 bytes.
@@ -399,6 +450,47 @@ mod tests {
         };
         assert!(!c.is_configured());
         assert!(c.is_partially_configured());
+    }
+
+    #[test]
+    fn production_readiness_error_none_when_configured() {
+        let c = BridgeConfig {
+            chain_id: 1,
+            bridge_contract: [1u8; 20],
+            rgb_asset_id: "rgb:asset".into(),
+            ..Default::default()
+        };
+        assert!(c.production_readiness_error().is_none());
+    }
+
+    #[test]
+    fn production_readiness_error_flags_unset() {
+        let msg = BridgeConfig::default()
+            .production_readiness_error()
+            .expect("a fully-empty config is not production-ready");
+        assert!(msg.contains("unset"), "got: {msg}");
+    }
+
+    #[test]
+    fn production_readiness_error_flags_partial() {
+        // chain_id set, contract + asset still empty: a botched pin.
+        let c = BridgeConfig {
+            chain_id: 1,
+            ..Default::default()
+        };
+        let msg = c
+            .production_readiness_error()
+            .expect("a partial config is not production-ready");
+        assert!(msg.contains("PARTIALLY"), "got: {msg}");
+    }
+
+    #[test]
+    fn assert_configured_in_release_exempts_test_builds() {
+        // cfg!(test) short-circuits the boot gate, so even a fully-empty config
+        // passes under test - the panic only fires in a production-shaped build.
+        assert!(BridgeConfig::default()
+            .assert_configured_in_release()
+            .is_ok());
     }
 
     #[test]

--- a/enclave/src/main.rs
+++ b/enclave/src/main.rs
@@ -48,21 +48,33 @@ fn main() {
         );
     } else if bridge_config.is_partially_configured() {
         // Some-but-not-all pin fields set: a botched production config. SignEvm
-        // fails closed on this (audit 4th M-03 / #94); warn loudly at boot so
-        // the operator sees it before the first rejected request.
+        // fails closed on this (audit 4th M-03 / #94); log it before the boot
+        // gate below turns it fatal in a production build.
         tracing::error!(
             chain_id = bridge_config.chain_id,
             bridge_contract = %hex::encode(bridge_config.bridge_contract),
             rgb_asset_id = %bridge_config.rgb_asset_id,
-            "bridge config PARTIALLY set — EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID must all \
+            "bridge config PARTIALLY set - EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID must all \
              be set (non-zero) or all unset; SignEvm will refuse to sign with this ambiguous pin"
         );
     } else {
         tracing::warn!(
-            "bridge config unconfigured (EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID unset) — \
+            "bridge config unconfigured (EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID unset) - \
              SignEvm cross-check will fall back to legacy behaviour and the attestation bundle \
              will commit to empty values"
         );
+    }
+
+    // Fail-closed at BOOT for a production bridge-signing build (audit C-01
+    // systemic). A per-request refusal (evm::validation / rgb anchor) and the
+    // logs above are not enough: an operator does not tail enclave logs on a
+    // prod host, so an unconfigured or partially-pinned release enclave would
+    // start and silently reject every bridge signature. A release
+    // rgb-validation build that is not fully pinned must never become
+    // reachable. Mirrors the placeholder-checkpoint boot check below; debug /
+    // test / allow-seed-import builds are exempt.
+    if let Err(msg) = bridge_config.assert_configured_in_release() {
+        panic!("{msg}");
     }
 
     // Donor-side cloning secret. Optional: only required for enclaves that


### PR DESCRIPTION
A release rgb-validation enclave that boots unconfigured or partially configured previously only logged a warning, then rejected every bridge signature per-request — invisible to an operator who doesn't tail prod logs.

Add BridgeConfig::assert_configured_in_release() and panic at boot instead, mirroring Checkpoint::assert_real_in_release(). Debug/test/allow-seed-import builds are exempt.