### PR TITLE
feat(config): separate FUNDS_IN_CONTRACT pin for the FundsIn lookup

### DIFF
--- a/enclave/src/config.rs
+++ b/enclave/src/config.rs
@@ -58,6 +58,13 @@ pub struct BridgeConfig {
     /// plain-BTC signing when unset. Bounds the blast radius of the plain-BTC
     /// path independently of the destination allowlist.
     pub btc_max_total_sats: u64,
+    /// Address expected to emit `FundsIn`/`BridgeFundsIn` (env
+    /// `FUNDS_IN_CONTRACT`). Falls back to `bridge_contract` when unset, so
+    /// single-contract deployments are unaffected. Needed where the deposit
+    /// event is emitted by the bridge *entry* contract while `BRIDGE_CONTRACT`
+    /// pins the MultisigProxy for the EVM signing cross-check — one pin cannot
+    /// serve both lookups.
+    pub funds_in_contract: [u8; 20],
 }
 
 impl BridgeConfig {
@@ -100,6 +107,12 @@ impl BridgeConfig {
             .and_then(|s| s.parse::<u64>().ok())
             .unwrap_or(0);
 
+        // Separate FundsIn event-emitter pin; defaults to `bridge_contract`.
+        let funds_in_contract = std::env::var("FUNDS_IN_CONTRACT")
+            .ok()
+            .and_then(|s| parse_eth_address(&s).ok())
+            .unwrap_or(bridge_contract);
+
         Self {
             chain_id,
             bridge_contract,
@@ -107,6 +120,7 @@ impl BridgeConfig {
             gas_tx_allowed_to,
             btc_allowed_scripts,
             btc_max_total_sats,
+            funds_in_contract,
         }
     }
 

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -286,7 +286,9 @@ fn handle_sign(ctx: &ServerContext, req: SignRequest) -> Result<EnclaveResponse>
         })?;
         crate::networks::evm::evm_event::verify_funds_in_event(
             &**client,
-            &ctx.bridge_config.bridge_contract,
+            // FundsIn is emitted by the bridge entry contract, which may differ
+            // from the MultisigProxy pinned in BRIDGE_CONTRACT (see config.rs).
+            &ctx.bridge_config.funds_in_contract,
             ctx.evm_rpc_config.min_confirmations,
             &tx_hash,
             destination.operation_idx,


### PR DESCRIPTION
The enclave uses a single BRIDGE_CONTRACT pin both to bind the EVM signing cross-check (which must pin the MultisigProxy) and to locate the FundsIn/ BridgeFundsIn deposit log. Where the deposit event is emitted by a separate bridge *entry* contract, one pin cannot serve both and the FundsIn lookup finds no log.

Add an optional FUNDS_IN_CONTRACT env that pins the FundsIn event emitter independently; it falls back to bridge_contract when unset, so existing single-contract deployments are unaffected.