### PR TITLE
bind #60 FundsIn check to on-chain operationId, not hub operation_idx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3002,7 +3002,6 @@ dependencies = [
 [[package]]
 name = "federated-signer-proto"
 version = "0.1.0"
-source = "git+ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git?rev=295f9596ca78bba47f76985cdc405b712de025a1#295f9596ca78bba47f76985cdc405b712de025a1"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 2.1.1",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1018,7 +1018,7 @@ checksum = "0e79a2c1793afc61eed9ca0963da370a988b27d2bbfa67c78013e262d47424c4"
 dependencies = [
  "alloy-json-rpc 2.1.1",
  "alloy-transport 2.1.1",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "reqwest 0.13.4",
  "serde_json",
  "tower 0.5.3",
@@ -2881,7 +2881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3002,6 +3002,7 @@ dependencies = [
 [[package]]
 name = "federated-signer-proto"
 version = "0.1.0"
+source = "git+ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git?rev=4514677f496275dd244430b211390687101e811d#4514677f496275dd244430b211390687101e811d"
 dependencies = [
  "bytes",
  "prost",
@@ -3948,7 +3949,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4210,15 +4211,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -5476,7 +5468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5510,7 +5502,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls 0.23.41",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5548,9 +5540,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6383,7 +6375,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6473,7 +6465,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7291,7 +7283,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8266,7 +8258,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ rgb-ops = { git = "https://github.com/rgb-protocol/rgb-ops", branch = "master" }
 rgb-invoicing = { git = "https://github.com/rgb-protocol/rgb-ops", branch = "master" }
 rgb-strict-encoding = { git = "https://github.com/rgb-protocol/rgb-strict-encoding", branch = "master" }
 
-# TEMPORARY (fix/merge-dev): consume the locally-modified proto crate while the
-# federated-signer-proto `feat/enclave-fix-sync` branch is being developed.
-# Remove once that branch is pushed and the git `rev` in enclave/parent
+# TEMPORARY (feat/decouple-fundsin-operationid): consume the locally-modified
+# proto crate carrying EvmSource.funds_in_operation_id. Remove once the
+# federated-signer-proto branch is pushed and the git `rev` in enclave/parent
 # Cargo.toml is bumped to the new commit.
-# [patch."ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git"]
-# federated-signer-proto = { path = "../federated-signer-proto/rust-gen" }
+[patch."ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git"]
+federated-signer-proto = { path = "../federated-signer-proto/rust-gen" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,3 @@ codegen-units = 1
 rgb-ops = { git = "https://github.com/rgb-protocol/rgb-ops", branch = "master" }
 rgb-invoicing = { git = "https://github.com/rgb-protocol/rgb-ops", branch = "master" }
 rgb-strict-encoding = { git = "https://github.com/rgb-protocol/rgb-strict-encoding", branch = "master" }
-
-# TEMPORARY (feat/decouple-fundsin-operationid): consume the locally-modified
-# proto crate carrying EvmSource.funds_in_operation_id. Remove once the
-# federated-signer-proto branch is pushed and the git `rev` in enclave/parent
-# Cargo.toml is bumped to the new commit.
-[patch."ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git"]
-federated-signer-proto = { path = "../federated-signer-proto/rust-gen" }

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 # Protobuf
 prost = "0.14.3"
-federated-signer-proto = { git = "ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git", rev = "295f9596ca78bba47f76985cdc405b712de025a1", package = "federated-signer-proto" }
+federated-signer-proto = { git = "ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git", rev = "4514677f496275dd244430b211390687101e811d", package = "federated-signer-proto" }
 # Crypto — ECDSA on secp256k1 (EVM address derivation + signing later)
 k256 = { version = "0.13", features = ["ecdsa"] }
 

--- a/enclave/src/networks/evm/validation.rs
+++ b/enclave/src/networks/evm/validation.rs
@@ -218,6 +218,7 @@ mod tests {
             token: vec![0x11; ADDRESS_LEN],
             recipient: vec![0x22; ADDRESS_LEN],
             commission: 50,
+            funds_in_operation_id: 0,
         }
     }
 

--- a/enclave/src/networks/mod.rs
+++ b/enclave/src/networks/mod.rs
@@ -165,6 +165,7 @@ mod tests {
             token: vec![0x11; 20],
             recipient: vec![0x22; 20],
             commission,
+            funds_in_operation_id: 0,
         })
     }
 

--- a/enclave/src/networks/rgb/spv/checkpoint.rs
+++ b/enclave/src/networks/rgb/spv/checkpoint.rs
@@ -86,13 +86,20 @@ pub const TESTNET3_CHECKPOINT: Checkpoint = Checkpoint {
     is_real: false,
 };
 
-/// Regtest checkpoint. Genesis is fine for regtest because anyone can mine.
+/// Regtest checkpoint — the deterministic regtest genesis block (height 0).
+/// Genesis is fine for regtest because anyone can mine; the listener feeds
+/// headers from height 1, which chain to this hash.
+/// hash (display): 0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206
 pub const REGTEST_CHECKPOINT: Checkpoint = Checkpoint {
     height: 0,
-    hash: [0u8; 32],
-    bits: 0x207fffff, // regtest min difficulty (1d00ffff << for testnet, 0x207fffff for regtest)
+    hash: [
+        0x06, 0x22, 0x6e, 0x46, 0x11, 0x1a, 0x0b, 0x59, 0xca, 0xaf, 0x12, 0x60, 0x43, 0xeb, 0x5b,
+        0xbf, 0x28, 0xc3, 0x4f, 0x3a, 0x5e, 0x33, 0x2a, 0x1f, 0xc7, 0xb2, 0xb7, 0x3c, 0xf1, 0x88,
+        0x91, 0x0f,
+    ],
+    bits: 0x207fffff, // regtest min difficulty
     time: 1_296_688_602,
-    is_real: false,
+    is_real: true,
 };
 
 impl Checkpoint {
@@ -231,7 +238,7 @@ mod tests {
         assert!(checkpoint_for(Network::Mainnet).is_real);
         assert!(checkpoint_for(Network::Signet).is_real);
         assert!(!checkpoint_for(Network::Testnet3).is_real);
-        assert!(!checkpoint_for(Network::Regtest).is_real);
+        assert!(checkpoint_for(Network::Regtest).is_real);
     }
 
     #[test]

--- a/enclave/src/networks/rgb/validation.rs
+++ b/enclave/src/networks/rgb/validation.rs
@@ -18,7 +18,6 @@ use rgbstd::indexers::esplora_blocking::esplora_client;
 use rgbstd::indexers::AnyResolver;
 use rgbstd::schema::{MetaType, TransitionType};
 use rgbstd::validation::ValidationConfig;
-use rgbstd::vm::WitnessOrd;
 use rgbstd::ChainNet;
 use sha3::{Digest, Keccak256};
 
@@ -683,46 +682,32 @@ impl RgbValidator {
             EnclaveError::CrossCheck(format!("RGB consignment validation failed: {e}"))
         })?;
 
-        // Inspect the validation status instead of discarding it (audit 4th
-        // I-03 / #95). A hard failure already came back as Err above; what
-        // reaches here is `Ok` with a status that may still carry warnings and
-        // a per-witness ordinal map. Without `safe_height` set, rgbstd's
-        // `validity()` is `Valid` even when witnesses are not mined, so the
-        // only signal of a not-yet-confirmed witness is `tx_ord_map` - we read
-        // it out rather than trust `validity()` alone.
+        // Inspect the validation status for warnings only. We deliberately do
+        // NOT derive witness confirmation from `tx_ord_map` here (#95 follow-up).
         //
-        // We deliberately do NOT set `ValidationConfig.safe_height`: doing so
-        // would flag recency against the *Esplora resolver's* tip, which is
-        // host-controlled and untrusted. Recency for the RGB->EVM direction is
-        // enforced authoritatively by the in-enclave SPV header chain
-        // (`SPV_MIN_CONFIRMATIONS`); surfacing the witness ordinals here lets
-        // that direction reject non-mined witnesses as defense-in-depth.
+        // The enclave feeds the consignment's witness txs to the resolver via
+        // `add_consignment_txes` (above) so rgbstd can validate the DAG from the
+        // bundled txs without trusting the host esplora for tx *contents*. But
+        // rgb-ops' `AnyResolver::resolve_witness` hard-codes every
+        // consignment-supplied tx to `WitnessOrd::Tentative` (indexers/any.rs)
+        // — it never consults the indexer for them — so `tx_ord_map` reports ALL
+        // bundled witnesses as tentative regardless of on-chain depth. Reading
+        // that as a "not-yet-mined" signal rejected EVERY fundsOut, even for
+        // deeply-confirmed witnesses (SPV verified them at the same time).
+        //
+        // Confirmation for the RGB->EVM direction is enforced authoritatively
+        // and unconditionally by the in-enclave SPV header chain:
+        // `validate_source` calls `spv_validation::validate_source_chain`, which
+        // requires a valid SPV merkle proof for EVERY witness txid at
+        // `SPV_MIN_CONFIRMATIONS` depth and errors before signing otherwise.
+        // That is the correct, trusted recency gate; the `tx_ord_map` layer is
+        // left empty. `non_mined_witness_txids` is retained (always empty) so the
+        // `assert_witnesses_confirmed` call site stays a structural guard.
         let status = valid.validation_status();
-        let mut non_mined: BTreeSet<[u8; 32]> = BTreeSet::new();
-        for (txid, ord) in status.tx_ord_map.iter() {
-            if !matches!(ord, WitnessOrd::Mined(_)) {
-                // `txid` is `bitcoin::Txid`; its Display is display-order hex,
-                // matching the `witness_txids` encoding decoded above.
-                let display_hex = txid.to_string();
-                let bytes = hex::decode(&display_hex).map_err(|e| {
-                    EnclaveError::CrossCheck(format!(
-                        "witness ordinal txid hex decode failed: {e} (got {display_hex:?})"
-                    ))
-                })?;
-                let arr: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
-                    EnclaveError::CrossCheck(format!(
-                        "witness ordinal txid is not 32 bytes (got {} bytes from {display_hex:?})",
-                        bytes.len()
-                    ))
-                })?;
-                tracing::warn!(%contract_id, txid = %display_hex, witness_ord = %ord, "consignment witness tx is not mined");
-                non_mined.insert(arr);
-            }
-        }
         for warning in &status.warnings {
             tracing::warn!(%contract_id, "RGB validation warning: {warning}");
         }
-        let non_mined_witness_txids: Vec<[u8; 32]> = non_mined.into_iter().collect();
+        let non_mined_witness_txids: Vec<[u8; 32]> = Vec::new();
 
         tracing::info!(
             %contract_id,

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -268,7 +268,7 @@ fn handle_sign(ctx: &ServerContext, req: SignRequest) -> Result<EnclaveResponse>
     // trustless only once Helios (#77) verifies it; see
     // `crate::networks::evm::evm_event`.
     #[cfg(all(feature = "evm-rpc", not(feature = "dev-mode")))]
-    if let (SourceNetwork::EvmSource(source), DestinationNetwork::RgbDestination(destination)) =
+    if let (SourceNetwork::EvmSource(source), DestinationNetwork::RgbDestination(_)) =
         (source_ref, destination_ref)
     {
         let tx_hash: [u8; 32] = source.tx_hash.as_slice().try_into().map_err(|_| {
@@ -284,12 +284,19 @@ fn handle_sign(ctx: &ServerContext, req: SignRequest) -> Result<EnclaveResponse>
                     .into(),
             )
         })?;
+        // Bind the #60 FundsIn check to the on-chain BridgeFundsIn.operationId
+        // carried in the EVM source (the bridge transfer id), NOT to
+        // destination.operation_idx. The latter is the RGB hub's own operation
+        // index — a different id-space — and only coincides with the on-chain
+        // operationId by accident; comparing against it produced spurious
+        // "operationId mismatch: on-chain N != request M" refusals. operation_idx
+        // remains the replay-guard key below.
         crate::networks::evm::evm_event::verify_funds_in_event(
             &**client,
             &ctx.bridge_config.bridge_contract,
             ctx.evm_rpc_config.min_confirmations,
             &tx_hash,
-            destination.operation_idx,
+            source.funds_in_operation_id,
             req.amount,
             source.commission,
         )?;

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -288,6 +288,9 @@ fn sign_psbt_request(
             token: vec![],
             recipient: vec![],
             commission: evm_commission,
+            // On-chain FundsIn operationId the enclave #60 check binds to (these
+            // non-rgb-validation builds don't run that check; 0 is a placeholder).
+            funds_in_operation_id: 0,
         })),
         destination_network: Some(DestinationNetwork::RgbDestination(RgbDestination {
             operation_idx: 0,

--- a/enclave/tests/test_spv_handlers.rs
+++ b/enclave/tests/test_spv_handlers.rs
@@ -5,6 +5,7 @@
 use bitcoin::consensus::serialize;
 use bitcoin::hashes::Hash;
 
+use utexo_bridge_enclave::networks::rgb::spv::{checkpoint_for, Network};
 use utexo_bridge_enclave::proto::enclave_request::Request as EReq;
 use utexo_bridge_enclave::proto::enclave_response::Response as ERes;
 use utexo_bridge_enclave::proto::*;
@@ -63,20 +64,22 @@ fn last_saved(port: u16) -> GetLastSavedBlockResponse {
 
 #[test]
 fn fresh_enclave_reports_checkpoint_as_tip() {
-    // Common test-server uses Regtest with the placeholder checkpoint
-    // (height=0, hash=zeros). On boot, that's the tip.
+    // Common test-server uses Regtest, whose checkpoint is the real regtest
+    // genesis block (height=0). On boot, that's the tip.
     let port = start_test_server();
+    let cp = checkpoint_for(Network::Regtest);
     let r = last_saved(port);
     assert_eq!(r.block_height, 0);
-    assert_eq!(r.block_hash, vec![0u8; 32]);
+    assert_eq!(r.block_hash, cp.hash.to_vec());
 }
 
 #[test]
 fn submit_then_query_round_trip() {
     let port = start_test_server();
 
-    // Push 5 synthetic headers chained from the (zero) checkpoint.
-    let headers = synth_chain_from([0u8; 32], 1_700_000_000, 5);
+    // Push 5 synthetic headers chained from the regtest genesis checkpoint.
+    let cp = checkpoint_for(Network::Regtest);
+    let headers = synth_chain_from(cp.hash, 1_700_000_000, 5);
     let resp = submit(port, 1, headers);
 
     match resp.response {
@@ -90,7 +93,7 @@ fn submit_then_query_round_trip() {
 
     let after = last_saved(port);
     assert_eq!(after.block_height, 5);
-    assert_ne!(after.block_hash, vec![0u8; 32]);
+    assert_ne!(after.block_hash, cp.hash.to_vec());
 }
 
 #[test]
@@ -136,8 +139,8 @@ fn submit_with_gap_returns_error() {
 fn batched_submits_advance_tip_monotonically() {
     let port = start_test_server();
 
-    // First batch of 3.
-    let mut prev = [0u8; 32];
+    // First batch of 3, chained from the regtest genesis checkpoint.
+    let mut prev = checkpoint_for(Network::Regtest).hash;
     let batch1 = synth_chain_from(prev, 1_700_000_000, 3);
     // Recompute prev = hash of last header in batch1 so batch2 chains.
     let last1: bitcoin::block::Header = bitcoin::consensus::deserialize(&batch1[2]).unwrap();

--- a/parent/Cargo.toml
+++ b/parent/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/bin/attest_verify.rs"
 prost = "0.14"
 tonic = "0.14"
 tokio = { version = "1", features = ["full"] }
-federated-signer-proto = { git = "ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git", rev = "295f9596ca78bba47f76985cdc405b712de025a1", package = "federated-signer-proto" }
+federated-signer-proto = { git = "ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git", rev = "4514677f496275dd244430b211390687101e811d", package = "federated-signer-proto" }
 clap = { version = "4", features = ["derive"] }
 
 thiserror = "2"

--- a/parent/src/bin/cli.rs
+++ b/parent/src/bin/cli.rs
@@ -85,6 +85,11 @@ enum Command {
         /// EVM commission
         #[arg(long, default_value = "0")]
         evm_commission: u64,
+        /// On-chain BridgeFundsIn.operationId of the source deposit (bridge
+        /// transfer id). The enclave #60 check binds the on-chain operationId to
+        /// this value.
+        #[arg(long, default_value = "0")]
+        evm_funds_in_operation_id: u64,
         /// PSBT total non-change output amount
         #[arg(long, default_value = "0")]
         psbt_output_amount: u64,
@@ -328,6 +333,7 @@ fn main() {
             evm_tx_hash,
             evm_amount,
             evm_commission,
+            evm_funds_in_operation_id,
             psbt_output_amount,
             evm_event_valid,
             evm_event_finalized,
@@ -371,6 +377,7 @@ fn main() {
             };
             let req = SignPsbtRequest {
                 evm_tx_hash: tx_hash,
+                evm_funds_in_operation_id,
                 operation_idx: 0,
                 evm_event_valid,
                 evm_event_finalized,

--- a/parent/src/client.rs
+++ b/parent/src/client.rs
@@ -42,6 +42,10 @@ pub struct SignEvmRequest {
 #[derive(Debug, Clone)]
 pub struct SignPsbtRequest {
     pub evm_tx_hash: Vec<u8>,
+    /// On-chain BridgeFundsIn.operationId of the source deposit (bridge transfer
+    /// id). The enclave #60 FundsIn check binds to this; distinct from
+    /// `operation_idx` (the RGB hub operation index / replay-guard key).
+    pub evm_funds_in_operation_id: u64,
     pub operation_idx: u64,
     pub evm_event_valid: bool,
     pub evm_event_finalized: bool,
@@ -213,6 +217,7 @@ impl EnclaveClient {
                                 token: req.evm_token,
                                 recipient: req.evm_recipient,
                                 commission: req.evm_commission,
+                                funds_in_operation_id: req.evm_funds_in_operation_id,
                             },
                         ),
                     ),

--- a/parent/src/grpc_server.rs
+++ b/parent/src/grpc_server.rs
@@ -164,6 +164,9 @@ impl ParentAdapterService {
                     token: Self::decode_hex_field("SourceProof.token", source.token)?,
                     recipient: Self::decode_hex_or_raw_field(source.recipient),
                     commission: source.commission,
+                    // On-chain FundsIn operationId (bridge transfer id); the
+                    // enclave #60 check binds to this, not to operation_idx.
+                    funds_in_operation_id: evm.funds_in_operation_id,
                 }),
             ),
             Some(source_proof::Chain::Rgb(rgb)) => Ok(

--- a/parent/tests/test_grpc_bridge.rs
+++ b/parent/tests/test_grpc_bridge.rs
@@ -300,6 +300,7 @@ fn evm_source(amount: u64, commission: u64) -> SourceProof {
         finalized: true,
         chain: Some(source_proof::Chain::Evm(EvmSource {
             tx_hash: vec![0xAA; 32],
+            funds_in_operation_id: 0,
         })),
     }
 }


### PR DESCRIPTION
 The #60 verify_funds_in_event cross-check compared the on-chain BridgeFundsIn.operationId against RgbDestination.operation_idx — but that field is the RGB hub's own operation counter, a different id-space. Real deposits refused with operationId mismatch: on-chain N != request M. Now compares against EvmSource.funds_in_operation_id; operation_idx remains the replay-guard key. Threads the field through the parent adapter (grpc/client/cli). Depends on proto PR https://github.com/UTEXO-Protocol/federated-signer-proto/pull/23