### PR TITLE
test: audit:test coverage (TI-1, TC-1, TC-2, TP-1, TA-3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,18 @@ jobs:
       - name: Test (--features evm-rpc)
         run: cargo test -p utexo-bridge-enclave --features evm-rpc
 
+      # Mock-attestation integration suite. The cloning handshake and attested
+      # public-key tests (enclave/tests/test_clone.rs, test_attested_pubkey.rs)
+      # are file-gated on `mock-attestation` + `allow-seed-import` — the mock
+      # path skips NSM/COSE/cert-chain but still enforces the pubkey, digest,
+      # nonce, and PCR bindings those tests assert. Without this step those
+      # suites (donor PCR-mismatch / wire-pubkey binding, attested-bundle
+      # parity) compile to nothing and never run. Debug profile only: the
+      # release compile_error guard for these dev features is asserted
+      # separately by the `release-guards` job.
+      - name: Test (mock-attestation integration — cloning + attestation)
+        run: cargo test -p utexo-bridge-enclave --features mock-attestation,allow-seed-import
+
       # Trustless Helios path (#77) - EXPERIMENTAL, default-OFF, NOT in the
       # shipped EIF. Compile + clippy only: a live light-client sync needs real
       # execution + consensus RPCs, unavailable in CI (the predicate itself is

--- a/attestation-verify/src/lib.rs
+++ b/attestation-verify/src/lib.rs
@@ -171,6 +171,22 @@ pub fn build_mock_document(
     mock::build_mock_document(nonce, public_key, user_data)
 }
 
+/// Build a mock attestation document with caller-specified PCRs.
+///
+/// Like [`build_mock_document`] but lets a test set PCR0/1/2, so it can mint a
+/// peer document whose measurement does *not* match a verifier's expected PCRs
+/// and exercise the PCR-binding rejection path (e.g. the cloning donor refusing
+/// a PCR-mismatched peer). Test-only.
+#[cfg(feature = "mock")]
+pub fn build_mock_document_with_pcrs(
+    nonce: &[u8; 32],
+    public_key: Option<&[u8]>,
+    user_data: Option<&[u8]>,
+    pcrs: &ExpectedPcrs,
+) -> Result<Vec<u8>> {
+    mock::build_mock_document_with_pcrs(nonce, public_key, user_data, pcrs)
+}
+
 // ----------------------------------------------------------------------------
 // Shared helpers
 // ----------------------------------------------------------------------------
@@ -804,10 +820,19 @@ mod mock {
         public_key: Option<&[u8]>,
         user_data: Option<&[u8]>,
     ) -> Result<Vec<u8>> {
+        build_mock_document_with_pcrs(nonce, public_key, user_data, &ExpectedPcrs::zero())
+    }
+
+    pub(super) fn build_mock_document_with_pcrs(
+        nonce: &[u8; 32],
+        public_key: Option<&[u8]>,
+        user_data: Option<&[u8]>,
+        expected: &ExpectedPcrs,
+    ) -> Result<Vec<u8>> {
         let mut pcrs = HashMap::new();
-        pcrs.insert(0, vec![0u8; 48]);
-        pcrs.insert(1, vec![0u8; 48]);
-        pcrs.insert(2, vec![0u8; 48]);
+        pcrs.insert(0, expected.pcr0.to_vec());
+        pcrs.insert(1, expected.pcr1.to_vec());
+        pcrs.insert(2, expected.pcr2.to_vec());
 
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/enclave/tests/test_attested_pubkey.rs
+++ b/enclave/tests/test_attested_pubkey.rs
@@ -181,3 +181,117 @@ fn attested_pubkey_wrong_expected_nonce_fails_verify() {
         attestation_verify::VerifyError::Attestation(_)
     ));
 }
+
+/// Same field bytes as `canonical_bundle`, but without the u32-BE length
+/// prefixes — a deliberately non-canonical framing used to prove the enclave's
+/// specific serialization (not merely the field contents) is what the
+/// attestation commits to.
+fn naive_concat(keys: &PublicKeysResponse) -> Vec<u8> {
+    let chain_id_bytes = keys.chain_id.to_be_bytes();
+    let parts: [&[u8]; 12] = [
+        &keys.evm_address,
+        &keys.btc_compressed_pub,
+        keys.btc_xpub.as_bytes(),
+        &keys.master_fingerprint,
+        keys.account_xpub_vanilla.as_bytes(),
+        keys.account_xpub_colored.as_bytes(),
+        &keys.evm_uncompressed_pub,
+        &chain_id_bytes,
+        &keys.bridge_contract,
+        keys.rgb_asset_id.as_bytes(),
+        &keys.evm_gas_tx_uncompressed_pub,
+        &keys.evm_gas_tx_address,
+    ];
+    let mut out = Vec::new();
+    for p in parts {
+        out.extend_from_slice(p);
+    }
+    out
+}
+
+/// TA-3 (#111): the attestation bundle the enclave builds must verify with the
+/// `attestation-verify` crate *without any adaptation*, and any tampering with
+/// the committed key bundle — including a differently-serialized copy of the
+/// same fields — must be rejected. This pins the canonical-serialization parity
+/// between the enclave's bundle serializer and the verifier's commitment check.
+#[test]
+fn attested_bundle_verifies_unmodified_and_tampering_is_rejected() {
+    let port = start_test_server();
+    initialize(port);
+
+    let nonce = [0x3cu8; 32];
+    let resp = request_attested(port, &nonce);
+    let public_keys = resp.public_keys.clone().expect("public_keys present");
+
+    // (1) Accepted unmodified: the enclave-built doc verifies as-is, and its
+    // NSM-bound user_data equals sha256 of the canonical bundle — i.e. the
+    // enclave's serialization matches the verifier's byte-for-byte.
+    let verified = attestation_verify::verify_mock_attestation(
+        &resp.attestation_doc,
+        &attestation_verify::ExpectedPcrs::zero(),
+        Some(&nonce),
+    )
+    .expect("enclave-built bundle verifies without adaptation");
+
+    let good_commitment: [u8; 32] = Sha256::digest(canonical_bundle(&public_keys)).into();
+    assert_eq!(
+        verified.user_data.as_deref(),
+        Some(good_commitment.as_slice()),
+        "canonical-serialization parity: attested user_data == sha256(canonical_bundle)"
+    );
+
+    // (2) Tampered bundle rejected: flipping a single byte of any committed
+    // field yields a commitment that no longer matches the attested user_data.
+    let mut tampered = public_keys.clone();
+    tampered.evm_address[0] ^= 0x01;
+    let tampered_commitment: [u8; 32] = Sha256::digest(canonical_bundle(&tampered)).into();
+    assert_ne!(
+        verified.user_data.as_deref(),
+        Some(tampered_commitment.as_slice()),
+        "a tampered key bundle must not match the attested commitment"
+    );
+
+    // (3) Re-serialized bundle rejected: the length-prefixed framing is
+    // load-bearing. Concatenating the *same* field bytes without the u32 length
+    // prefixes is a different serialization that hashes differently, so it
+    // cannot be substituted for the canonical bundle.
+    let reserialized_commitment: [u8; 32] = Sha256::digest(naive_concat(&public_keys)).into();
+    assert_ne!(
+        verified.user_data.as_deref(),
+        Some(reserialized_commitment.as_slice()),
+        "a non-canonical re-serialization of the same fields must not verify"
+    );
+}
+
+/// TA-3 (#111): corrupting the raw attestation bytes must fail verification
+/// outright (CBOR integrity), independent of the key-bundle commitment check.
+#[test]
+fn attested_doc_corruption_fails_verification() {
+    let port = start_test_server();
+    initialize(port);
+
+    let nonce = [0x7eu8; 32];
+    let resp = request_attested(port, &nonce);
+
+    // Sanity: the untouched doc verifies.
+    attestation_verify::verify_mock_attestation(
+        &resp.attestation_doc,
+        &attestation_verify::ExpectedPcrs::zero(),
+        Some(&nonce),
+    )
+    .expect("baseline doc verifies");
+
+    // Truncating the CBOR document leaves an incomplete value that cannot be
+    // decoded — the verifier rejects it.
+    let truncated = &resp.attestation_doc[..resp.attestation_doc.len() / 2];
+    let err = attestation_verify::verify_mock_attestation(
+        truncated,
+        &attestation_verify::ExpectedPcrs::zero(),
+        Some(&nonce),
+    )
+    .expect_err("truncated attestation doc must be rejected");
+    assert!(matches!(
+        err,
+        attestation_verify::VerifyError::Attestation(_)
+    ));
+}

--- a/enclave/tests/test_clone.rs
+++ b/enclave/tests/test_clone.rs
@@ -330,3 +330,103 @@ fn cannot_initialize_after_entering_cloning() {
         other => panic!("expected Error, got {:?}", other),
     }
 }
+
+// ---- audit test coverage: attestation binding on the donor ----
+
+#[test]
+fn clone_donor_rejects_wire_pubkey_not_matching_attestation() {
+    // TC-2 (#107): the parent relays (encryption_pubkey, cloning_digest,
+    // requester_attestation) to the donor. The X25519 pubkey inside the
+    // NSM-signed requester attestation is authoritative; the plaintext
+    // `encryption_pubkey` on the wire is not. A malicious parent could swap the
+    // wire pubkey for one it controls to intercept the sealed seed. The donor
+    // must bind the two (handle_get_clone step 3) and abort on any mismatch.
+    let (donor_port, donor_keys) = start_donor();
+    let requester_port = start_requester();
+
+    let init = initiate_cloning(requester_port, CLONING_SECRET, &donor_keys.evm_address);
+
+    // Tamper only the wire pubkey; leave the attestation (which binds the real
+    // ephemeral pubkey) untouched. Any well-formed 32-byte key that is not the
+    // attested one exercises the binding check.
+    let mut tampered = init.clone();
+    tampered.encryption_pubkey = vec![0x77u8; 32];
+    assert_ne!(
+        tampered.encryption_pubkey, init.encryption_pubkey,
+        "the tampered wire pubkey must differ from the attested one"
+    );
+
+    let err = request_get_clone(donor_port, &donor_keys.evm_address, &tampered)
+        .expect_err("donor must abort when wire pubkey != attested pubkey");
+    assert!(
+        err.message.contains("pubkey mismatch") || err.message.contains("does not match"),
+        "expected a pubkey-binding rejection, got: {}",
+        err.message
+    );
+
+    // Legitimate peer (wire == attested) still succeeds. This also proves the
+    // rejected attempt aborted at the pubkey binding (which runs before the
+    // replay guard records the nonce), so reusing the same attestation is fine.
+    let clone = request_get_clone(donor_port, &donor_keys.evm_address, &init)
+        .expect("legitimate handshake (wire == attested) must succeed");
+    assert_eq!(clone.donor_pubkey.len(), 32);
+    assert_eq!(clone.encrypted_seed.len(), 64 + 16); // seed + Poly1305 tag
+    assert!(!clone.donor_attestation.is_empty());
+}
+
+#[test]
+fn clone_donor_refuses_pcr_mismatched_peer_but_accepts_matching_peer() {
+    // TC-1 (#106): the cloning donor must refuse to seal its seed to a peer
+    // whose PCR0/PCR1 do not match the donor's own measurement -- even when the
+    // handshake otherwise carries a valid attestation, the correct encryption
+    // pubkey, and a correctly-authenticated cloning digest. A PCR-equal peer is
+    // accepted in the SAME run to prove the rejection is PCR-specific, not a
+    // blanket failure.
+    let (donor_port, donor_keys) = start_donor();
+
+    // ---- 1. PCR-mismatched peer: donor must refuse to seal ----
+    let bad_requester_port = start_requester();
+    let bad_init = initiate_cloning(bad_requester_port, CLONING_SECRET, &donor_keys.evm_address);
+
+    // In mock mode the donor's own PCRs (get_own_pcrs) are all-zero, so a
+    // non-zero PCR0/PCR1 is a genuine measurement mismatch. Keep the real
+    // encryption-pubkey + cloning-digest bindings so the request can only fail
+    // on the PCR check (handle_get_clone step 2, which runs first), not on the
+    // pubkey/digest binding.
+    let mismatched_pcrs =
+        attestation_verify::ExpectedPcrs::new([0x11u8; 48], [0x22u8; 48], [0u8; 48]);
+    let mismatched_attestation = attestation_verify::build_mock_document_with_pcrs(
+        &[0x99u8; 32], // arbitrary fresh nonce; donor verifies with expected_nonce = None
+        Some(&bad_init.encryption_pubkey),
+        Some(&bad_init.cloning_digest),
+        &mismatched_pcrs,
+    )
+    .expect("build mismatched-PCR mock doc");
+
+    let mut tampered = bad_init.clone();
+    tampered.requester_attestation = mismatched_attestation;
+
+    let err = request_get_clone(donor_port, &donor_keys.evm_address, &tampered)
+        .expect_err("donor must refuse to seal to a PCR-mismatched peer");
+    assert!(
+        err.message.contains("PCR"),
+        "expected a PCR-mismatch rejection, got: {}",
+        err.message
+    );
+    // request_get_clone returned Err -> no GetCloneResponse, so no encrypted
+    // seed was ever produced or transmitted to the mismatched peer.
+
+    // ---- 2. PCR-equal peer: donor accepts and seals in the SAME run ----
+    let good_requester_port = start_requester();
+    let good_init = initiate_cloning(good_requester_port, CLONING_SECRET, &donor_keys.evm_address);
+    let clone = request_get_clone(donor_port, &donor_keys.evm_address, &good_init)
+        .expect("donor must seal to a PCR-matching peer");
+    assert_eq!(clone.encrypted_seed.len(), 64 + 16); // seed + Poly1305 tag
+    assert_eq!(clone.donor_pubkey.len(), 32);
+
+    // The matching peer can actually unseal it -> proves a real clone, not just
+    // a well-formed-looking response.
+    request_set_clone(good_requester_port, &clone).expect("SetClone should succeed");
+    let good_keys = get_public_keys(good_requester_port);
+    assert_eq!(good_keys.evm_address, donor_keys.evm_address);
+}

--- a/enclave/tests/test_keygen.rs
+++ b/enclave/tests/test_keygen.rs
@@ -153,3 +153,123 @@ fn deterministic_seed_import() {
     assert_eq!(init1.btc_compressed_pub, init2.btc_compressed_pub);
     assert_eq!(init1.btc_xpub, init2.btc_xpub);
 }
+
+// A canonical BIP-39 test vector — a stable, non-secret mnemonic used to
+// exercise the caller-supplied-mnemonic import path.
+const TEST_MNEMONIC: &str =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+/// TI-1 (#112) — Production build (default `cargo test`, `allow-seed-import`
+/// OFF): an `InitializeKey` carrying a caller-supplied seed OR mnemonic must be
+/// REJECTED. The gate is the compile-time `#[cfg(not(feature =
+/// "allow-seed-import"))]` arm in `handle_initialize` (server.rs), which returns
+/// `EnclaveError::InvalidRequest` -> `Response::Error`. Because the rejection
+/// happens before any state mutation, a subsequent OS-entropy init (empty seed
+/// + empty mnemonic) on the same server must still succeed.
+///
+/// The dev-mode acceptance counterpart is
+/// `dev_build_accepts_caller_supplied_seed_and_mnemonic` below; CI must run both
+/// feature profiles (the gate is compile-time, so the two directions cannot be
+/// exercised in one build).
+#[test]
+#[cfg(not(feature = "allow-seed-import"))]
+fn production_build_rejects_caller_supplied_seed_and_mnemonic() {
+    let port = common::start_test_server();
+
+    // Caller-supplied raw seed -> rejected.
+    let seed_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![7u8; 64],
+            mnemonic: String::new(),
+        })),
+    };
+    let seed_resp = common::send_request(port, &seed_req);
+    match &seed_resp.response {
+        Some(Response::Error(e)) => {
+            eprintln!("--- production rejects seed import ---");
+            eprintln!("  error: code={} message=\"{}\"", e.code, e.message);
+            assert!(
+                e.message.contains("not allowed"),
+                "expected a 'not allowed' rejection, got: {}",
+                e.message
+            );
+        }
+        other => panic!("production build must reject seed import, got {:?}", other),
+    }
+
+    // Caller-supplied mnemonic -> rejected.
+    let mnemonic_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+            mnemonic: TEST_MNEMONIC.into(),
+        })),
+    };
+    let mnemonic_resp = common::send_request(port, &mnemonic_req);
+    match &mnemonic_resp.response {
+        Some(Response::Error(e)) => assert!(
+            e.message.contains("not allowed"),
+            "expected a 'not allowed' rejection, got: {}",
+            e.message
+        ),
+        other => panic!(
+            "production build must reject mnemonic import, got {:?}",
+            other
+        ),
+    }
+
+    // The rejected imports must not have consumed initialization: a plain
+    // OS-entropy init on the same server still succeeds.
+    let entropy_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+            mnemonic: String::new(),
+        })),
+    };
+    let entropy_resp = common::send_request(port, &entropy_req);
+    assert!(
+        matches!(&entropy_resp.response, Some(Response::InitializeKey(_))),
+        "OS-entropy init after a rejected import must still succeed, got {:?}",
+        entropy_resp.response
+    );
+}
+
+/// TI-1 (#112) — Dev build (`cargo test ... --features allow-seed-import`, debug
+/// profile): the SAME `InitializeKey` call that production rejects is ACCEPTED.
+/// The `#[cfg(feature = "allow-seed-import")]` arm of `handle_initialize`
+/// installs the caller's seed / mnemonic and returns `Response::InitializeKey`.
+/// Each import uses a fresh server (init is one-shot).
+#[test]
+#[cfg(feature = "allow-seed-import")]
+fn dev_build_accepts_caller_supplied_seed_and_mnemonic() {
+    // Caller-supplied raw seed -> accepted.
+    let port_seed = common::start_test_server();
+    let seed_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![7u8; 64],
+            mnemonic: String::new(),
+        })),
+    };
+    let seed_resp = common::send_request(port_seed, &seed_req);
+    let seed_init = match &seed_resp.response {
+        Some(Response::InitializeKey(r)) => r,
+        other => panic!("dev build must accept seed import, got {:?}", other),
+    };
+    assert_eq!(seed_init.evm_address.len(), 20);
+    assert_eq!(seed_init.btc_compressed_pub.len(), 33);
+    assert!(seed_init.btc_xpub.starts_with("xpub"));
+
+    // Caller-supplied mnemonic -> accepted (fresh server; init is one-shot).
+    let port_mnemonic = common::start_test_server();
+    let mnemonic_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+            mnemonic: TEST_MNEMONIC.into(),
+        })),
+    };
+    let mnemonic_resp = common::send_request(port_mnemonic, &mnemonic_req);
+    assert!(
+        matches!(&mnemonic_resp.response, Some(Response::InitializeKey(_))),
+        "dev build must accept mnemonic import, got {:?}",
+        mnemonic_resp.response
+    );
+}

--- a/enclave/tests/test_signing.rs
+++ b/enclave/tests/test_signing.rs
@@ -778,6 +778,64 @@ fn test_sign_psbt_rejects_missing_evm_source_hash() {
     }
 }
 
+// TP-1 / M-01 (#69, PR #102): a length-VALID but all-ZERO evm_tx_hash must not
+// be read as a "vanilla mode" signal. The closed bypass inferred "plain BTC,
+// skip every bridge predicate" from a blank/empty evm_tx_hash; now a SignPsbt
+// (EvmSource + RgbDestination) runs the bridge cross-checks unconditionally and
+// fails closed when no consignment binds the PSBT. Companion to
+// `test_sign_psbt_rejects_missing_evm_source_hash` (which covers the zero-LENGTH
+// hash, rejected earlier at the 32-byte length check): a 32-byte all-zero hash
+// clears that length gate, so the request must be caught by the unconditional
+// consignment binding instead of slipping onto a vanilla signing path.
+#[cfg(feature = "rgb-validation")]
+#[test]
+#[cfg(not(feature = "dev-mode"))]
+fn test_sign_psbt_zero_evm_hash_is_bridge_mode_not_vanilla() {
+    let port = common::start_test_server();
+
+    let init_req = EnclaveRequest {
+        request: Some(Request::InitializeKey(InitializeKeyRequest {
+            seed: vec![],
+            mnemonic: String::new(),
+        })),
+    };
+    common::send_request(port, &init_req);
+
+    // All-zero 32-byte hash: passes the length check (unlike the empty-hash
+    // sibling test) but is the exact "looks like no tx" shape the removed
+    // vanilla-inference keyed on. The RgbDestination carries no consignment, so
+    // bridge mode must fail closed — never sign this as a vanilla PSBT.
+    let sign_req = EnclaveRequest {
+        request: Some(Request::Sign(sign_psbt_request(
+            vec![0u8; 32],
+            false,
+            false,
+            1000,
+            0,
+            minimal_valid_psbt_bytes(),
+            500,
+        ))),
+    };
+    let resp = common::send_request(port, &sign_req);
+
+    match &resp.response {
+        Some(Response::Error(e)) => {
+            assert_eq!(e.code, 3, "bridge cross-check failures use code 3");
+            // Bridge mode ran and rejected the missing consignment binding —
+            // the zeroed hash did NOT route the request onto the vanilla path.
+            assert!(
+                e.message.contains("consignment"),
+                "expected a consignment-binding rejection (bridge mode), got: {}",
+                e.message
+            );
+        }
+        other => panic!(
+            "zero-hash SignPsbt must fail closed in bridge mode, never sign: {:?}",
+            other
+        ),
+    }
+}
+
 // =============================================================================
 // Plain-BTC signing (SignBtc): structural input guard + pinned allowlist + cap
 // =============================================================================


### PR DESCRIPTION
Adds the missing test coverage flagged by the `audit: test` issues, and wires the mock-attestation suite into CI so those tests actually run.

## New tests

| Issue | Test | What it proves |
|---|---|---|
| TI-1 (#112) | `production_build_rejects_caller_supplied_seed_and_mnemonic` / `dev_build_accepts_caller_supplied_seed_and_mnemonic` | Production build rejects a caller-supplied seed/mnemonic on `InitializeKey`; the `allow-seed-import` dev build accepts them. |
| TC-1 (#106) | `clone_donor_refuses_pcr_mismatched_peer_but_accepts_matching_peer` | The cloning donor refuses to seal to a PCR-mismatched peer and accepts a PCR-matching peer in the same run. |
| TC-2 (#107) | `clone_donor_rejects_wire_pubkey_not_matching_attestation` | The donor aborts when the wire pubkey ≠ the attested pubkey. |
| TP-1 (#108) | `test_sign_psbt_zero_evm_hash_is_bridge_mode_not_vanilla` | A length-valid all-zero `evm_tx_hash` stays in bridge mode and fails closed — no vanilla bypass. |
| TA-3 (#111) | `attested_bundle_verifies_unmodified_and_tampering_is_rejected`, `attested_doc_corruption_fails_verification` | The attested bundle verifies unmodified; a tampered/re-serialized bundle and a corrupted doc are rejected. |

## Supporting changes

- `attestation-verify`: add a mock-only `build_mock_document_with_pcrs` so TC-1 can mint a non-zero-PCR peer document (the existing builder hardcodes zero PCRs). `build_mock_document` now delegates to it with zero PCRs — behaviour-preserving.
- **CI**: add a `mock-attestation,allow-seed-import` test step. The cloning and attested-pubkey suites are file-gated on those features, so **they were never executed by CI before** — this makes the new (and pre-existing) suites run.

## Already covered — no new test

- TH-1 (#109) and TH-2 (#110) are already covered at the only feasible faithful level by the retarget epoch-start unit tests in `spv/chain.rs` (`th1_epoch_start_resolves_at_first_boundary_above_aligned_checkpoint`, `th2_misaligned_checkpoint_wedges_at_first_boundary`) plus the checkpoint-alignment tests. A server-path mainnet boundary crossing is infeasible: synthetic headers cannot satisfy real mainnet PoW, and the test harness is hardcoded to Regtest (which skips retargeting).

## Verification

`fmt` + `clippy -D warnings` clean. Tests pass under `mock-attestation,allow-seed-import`, `spv`, and `--no-default-features`. The `evm-rpc` combo was not built locally (toolchain limit); TP-1's rejection fires in the shared consignment-binding path that runs before the evm-rpc block, so it holds there too (CI covers it).