### PR TITLE
feat(enclave): unify the production security posture into one attested policy (C-01)

### DIFF
--- a/attestation-verify/src/lib.rs
+++ b/attestation-verify/src/lib.rs
@@ -22,6 +22,11 @@ use std::collections::HashMap;
 
 use thiserror::Error;
 
+pub mod policy;
+pub use policy::{
+    AttestationMode, AttestedPolicy, BtcDataSource, EvmDataSource, POLICY_COMMITMENT_V1,
+};
+
 // ----------------------------------------------------------------------------
 // Public types
 // ----------------------------------------------------------------------------

--- a/attestation-verify/src/policy.rs
+++ b/attestation-verify/src/policy.rs
@@ -128,21 +128,32 @@ impl AttestedPolicy {
 mod tests {
     use super::*;
 
-    fn production() -> AttestedPolicy {
+    /// Parametrized production policy so each test varies exactly one field.
+    fn prod(
+        vanilla: bool,
+        evm: EvmDataSource,
+        chain_id: u64,
+        contract: u8,
+        asset: &str,
+    ) -> AttestedPolicy {
         AttestedPolicy::Production {
-            allow_vanilla_psbt: false,
+            allow_vanilla_psbt: vanilla,
             attestation: AttestationMode::Real,
-            evm_source: EvmDataSource::RawRpc,
+            evm_source: evm,
             btc_source: BtcDataSource::SpvVerified,
-            chain_id: 1,
-            bridge_contract: [0x11; 20],
-            rgb_asset_id: "rgb:asset".into(),
+            chain_id,
+            bridge_contract: [contract; 20],
+            rgb_asset_id: asset.into(),
         }
+    }
+
+    fn base() -> AttestedPolicy {
+        prod(false, EvmDataSource::RawRpc, 1, 0x11, "rgb:asset")
     }
 
     #[test]
     fn every_encoding_starts_with_the_version_tag() {
-        assert_eq!(production().to_bytes()[0], POLICY_COMMITMENT_V1);
+        assert_eq!(base().to_bytes()[0], POLICY_COMMITMENT_V1);
         assert_eq!(
             AttestedPolicy::Development.to_bytes()[0],
             POLICY_COMMITMENT_V1
@@ -151,69 +162,22 @@ mod tests {
 
     #[test]
     fn production_and_development_never_collide() {
-        assert_ne!(
-            production().to_bytes(),
-            AttestedPolicy::Development.to_bytes()
-        );
+        assert_ne!(base().to_bytes(), AttestedPolicy::Development.to_bytes());
     }
 
     #[test]
     fn every_posture_field_changes_the_bytes() {
-        let base = production().to_bytes();
-        let mut cases = Vec::new();
-
-        if let AttestedPolicy::Production { .. } = production() {
-            cases.push(AttestedPolicy::Production {
-                allow_vanilla_psbt: true,
-                attestation: AttestationMode::Real,
-                evm_source: EvmDataSource::RawRpc,
-                btc_source: BtcDataSource::SpvVerified,
-                chain_id: 1,
-                bridge_contract: [0x11; 20],
-                rgb_asset_id: "rgb:asset".into(),
-            });
-            cases.push(AttestedPolicy::Production {
-                allow_vanilla_psbt: false,
-                attestation: AttestationMode::Real,
-                evm_source: EvmDataSource::HeliosVerified,
-                btc_source: BtcDataSource::SpvVerified,
-                chain_id: 1,
-                bridge_contract: [0x11; 20],
-                rgb_asset_id: "rgb:asset".into(),
-            });
-            cases.push(AttestedPolicy::Production {
-                allow_vanilla_psbt: false,
-                attestation: AttestationMode::Real,
-                evm_source: EvmDataSource::RawRpc,
-                btc_source: BtcDataSource::SpvVerified,
-                chain_id: 2,
-                bridge_contract: [0x11; 20],
-                rgb_asset_id: "rgb:asset".into(),
-            });
-            cases.push(AttestedPolicy::Production {
-                allow_vanilla_psbt: false,
-                attestation: AttestationMode::Real,
-                evm_source: EvmDataSource::RawRpc,
-                btc_source: BtcDataSource::SpvVerified,
-                chain_id: 1,
-                bridge_contract: [0x22; 20],
-                rgb_asset_id: "rgb:asset".into(),
-            });
-            cases.push(AttestedPolicy::Production {
-                allow_vanilla_psbt: false,
-                attestation: AttestationMode::Real,
-                evm_source: EvmDataSource::RawRpc,
-                btc_source: BtcDataSource::SpvVerified,
-                chain_id: 1,
-                bridge_contract: [0x11; 20],
-                rgb_asset_id: "rgb:other".into(),
-            });
-        }
-
+        let cases = [
+            prod(true, EvmDataSource::RawRpc, 1, 0x11, "rgb:asset"),
+            prod(false, EvmDataSource::HeliosVerified, 1, 0x11, "rgb:asset"),
+            prod(false, EvmDataSource::RawRpc, 2, 0x11, "rgb:asset"),
+            prod(false, EvmDataSource::RawRpc, 1, 0x22, "rgb:asset"),
+            prod(false, EvmDataSource::RawRpc, 1, 0x11, "rgb:other"),
+        ];
         for c in cases {
             assert_ne!(
                 c.to_bytes(),
-                base,
+                base().to_bytes(),
                 "posture change must alter the commitment"
             );
         }
@@ -223,15 +187,8 @@ mod tests {
     fn asset_is_length_prefixed_not_ambiguous() {
         // The u32 length prefix means a longer asset id can never be confused
         // with a shorter one that happens to share a prefix.
-        let with_asset = |id: &str| AttestedPolicy::Production {
-            allow_vanilla_psbt: false,
-            attestation: AttestationMode::Real,
-            evm_source: EvmDataSource::RawRpc,
-            btc_source: BtcDataSource::SpvVerified,
-            chain_id: 1,
-            bridge_contract: [0x11; 20],
-            rgb_asset_id: id.into(),
-        };
-        assert_ne!(with_asset("ab").to_bytes(), with_asset("abc").to_bytes());
+        let a = prod(false, EvmDataSource::RawRpc, 1, 0x11, "ab");
+        let b = prod(false, EvmDataSource::RawRpc, 1, 0x11, "abc");
+        assert_ne!(a.to_bytes(), b.to_bytes());
     }
 }

--- a/attestation-verify/src/policy.rs
+++ b/attestation-verify/src/policy.rs
@@ -1,0 +1,237 @@
+//! Canonical encoding of the enclave's attested security policy (audit C-01).
+//!
+//! The enclave has ONE explicit security posture, resolved once at boot, that a
+//! verifier can check as a single value. That posture is serialized here and
+//! folded into the attestation `user_data` commitment alongside the public-key
+//! bundle (see `enclave/src/server.rs::handle_get_attested_public_key`).
+//!
+//! This module is the SINGLE source of truth for that serialization so the
+//! enclave (which commits it) and every verifier (the parent `attest-verify`
+//! CLI, the cloning peer check) produce byte-identical bytes. Both sides build
+//! an [`AttestedPolicy`] and call [`AttestedPolicy::to_bytes`]; if the enclave's
+//! committed posture differs from the one the verifier expects, the `user_data`
+//! hash will not match and verification fails.
+//!
+//! WIRE CONTRACT: the discriminants and field order below are load-bearing.
+//! Never renumber an existing variant or reorder fields — bump
+//! [`POLICY_COMMITMENT_V1`] and add a new arm to evolve the format.
+
+/// Version tag prepended to every policy commitment. Lets a verifier reject a
+/// document produced by an enclave speaking a different policy-encoding version
+/// instead of silently mis-hashing it.
+pub const POLICY_COMMITMENT_V1: u8 = 1;
+
+/// Where the enclave gets the EVM `FundsIn` deposit evidence it verifies before
+/// signing an EVM->RGB bridge PSBT. Attested so a verifier can tell a trustless
+/// deployment (Helios) apart from a host-relayed one (raw RPC) — the shipped
+/// image currently uses [`RawRpc`](EvmDataSource::RawRpc).
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EvmDataSource {
+    /// No in-enclave EVM verification compiled in (`evm-rpc` off). Bridge
+    /// EVM->RGB signing fails closed per request.
+    Disabled = 0,
+    /// Host-relayed JSON-RPC (`evm-rpc`): treated as evidence, verified
+    /// fail-closed, but NOT trustless — the host relays the responses.
+    RawRpc = 1,
+    /// Helios light client (`helios`): the RPC is cryptographically verified
+    /// against a pinned weak-subjectivity checkpoint before use (trustless).
+    HeliosVerified = 2,
+}
+
+/// Where the enclave gets the Bitcoin anchor evidence for RGB consignment
+/// witness txs. Only the SPV-verified source is safe (audit M-01 / #61), so a
+/// production build always reports [`SpvVerified`](BtcDataSource::SpvVerified).
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BtcDataSource {
+    /// Witness txids re-anchored against the enclave's own PoW-verified header
+    /// chain (`spv`), not the host-controlled Esplora resolver.
+    SpvVerified = 1,
+}
+
+/// Whether the attestation root of trust is a real NSM device or the zero-PCR
+/// mock. Mock is a `compile_error!` in release builds, so a production policy is
+/// always [`Real`](AttestationMode::Real); the value is committed anyway so the
+/// posture stands alone as one attested value.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AttestationMode {
+    Mock = 0,
+    Real = 1,
+}
+
+/// The enclave's whole security posture in commitment form.
+///
+/// [`Production`](AttestedPolicy::Production) is the fail-closed bridge-signing
+/// posture: fully pinned, real attestation, SPV-anchored, with an explicit EVM
+/// data source. Anything else — a debug build, a dev feature, an unpinned or
+/// non-bridge build — is [`Development`](AttestedPolicy::Development), which a
+/// verifier of a production enclave must reject.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AttestedPolicy {
+    Production {
+        allow_vanilla_psbt: bool,
+        attestation: AttestationMode,
+        evm_source: EvmDataSource,
+        btc_source: BtcDataSource,
+        chain_id: u64,
+        bridge_contract: [u8; 20],
+        rgb_asset_id: String,
+    },
+    Development,
+}
+
+impl AttestedPolicy {
+    /// Deterministic, length-prefixed encoding folded into attestation
+    /// `user_data`. Layout (see the WIRE CONTRACT note in the module docs):
+    ///
+    /// ```text
+    /// [POLICY_COMMITMENT_V1]
+    /// Production:  [0x01][allow_vanilla u8][attestation u8][evm_source u8]
+    ///              [btc_source u8][chain_id u64 BE][bridge_contract 20]
+    ///              [len(asset) u32 BE][asset bytes]
+    /// Development: [0x00]
+    /// ```
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.push(POLICY_COMMITMENT_V1);
+        match self {
+            AttestedPolicy::Production {
+                allow_vanilla_psbt,
+                attestation,
+                evm_source,
+                btc_source,
+                chain_id,
+                bridge_contract,
+                rgb_asset_id,
+            } => {
+                out.push(0x01);
+                out.push(*allow_vanilla_psbt as u8);
+                out.push(*attestation as u8);
+                out.push(*evm_source as u8);
+                out.push(*btc_source as u8);
+                out.extend_from_slice(&chain_id.to_be_bytes());
+                out.extend_from_slice(bridge_contract);
+                out.extend_from_slice(&(rgb_asset_id.len() as u32).to_be_bytes());
+                out.extend_from_slice(rgb_asset_id.as_bytes());
+            }
+            AttestedPolicy::Development => {
+                out.push(0x00);
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn production() -> AttestedPolicy {
+        AttestedPolicy::Production {
+            allow_vanilla_psbt: false,
+            attestation: AttestationMode::Real,
+            evm_source: EvmDataSource::RawRpc,
+            btc_source: BtcDataSource::SpvVerified,
+            chain_id: 1,
+            bridge_contract: [0x11; 20],
+            rgb_asset_id: "rgb:asset".into(),
+        }
+    }
+
+    #[test]
+    fn every_encoding_starts_with_the_version_tag() {
+        assert_eq!(production().to_bytes()[0], POLICY_COMMITMENT_V1);
+        assert_eq!(
+            AttestedPolicy::Development.to_bytes()[0],
+            POLICY_COMMITMENT_V1
+        );
+    }
+
+    #[test]
+    fn production_and_development_never_collide() {
+        assert_ne!(
+            production().to_bytes(),
+            AttestedPolicy::Development.to_bytes()
+        );
+    }
+
+    #[test]
+    fn every_posture_field_changes_the_bytes() {
+        let base = production().to_bytes();
+        let mut cases = Vec::new();
+
+        if let AttestedPolicy::Production { .. } = production() {
+            cases.push(AttestedPolicy::Production {
+                allow_vanilla_psbt: true,
+                attestation: AttestationMode::Real,
+                evm_source: EvmDataSource::RawRpc,
+                btc_source: BtcDataSource::SpvVerified,
+                chain_id: 1,
+                bridge_contract: [0x11; 20],
+                rgb_asset_id: "rgb:asset".into(),
+            });
+            cases.push(AttestedPolicy::Production {
+                allow_vanilla_psbt: false,
+                attestation: AttestationMode::Real,
+                evm_source: EvmDataSource::HeliosVerified,
+                btc_source: BtcDataSource::SpvVerified,
+                chain_id: 1,
+                bridge_contract: [0x11; 20],
+                rgb_asset_id: "rgb:asset".into(),
+            });
+            cases.push(AttestedPolicy::Production {
+                allow_vanilla_psbt: false,
+                attestation: AttestationMode::Real,
+                evm_source: EvmDataSource::RawRpc,
+                btc_source: BtcDataSource::SpvVerified,
+                chain_id: 2,
+                bridge_contract: [0x11; 20],
+                rgb_asset_id: "rgb:asset".into(),
+            });
+            cases.push(AttestedPolicy::Production {
+                allow_vanilla_psbt: false,
+                attestation: AttestationMode::Real,
+                evm_source: EvmDataSource::RawRpc,
+                btc_source: BtcDataSource::SpvVerified,
+                chain_id: 1,
+                bridge_contract: [0x22; 20],
+                rgb_asset_id: "rgb:asset".into(),
+            });
+            cases.push(AttestedPolicy::Production {
+                allow_vanilla_psbt: false,
+                attestation: AttestationMode::Real,
+                evm_source: EvmDataSource::RawRpc,
+                btc_source: BtcDataSource::SpvVerified,
+                chain_id: 1,
+                bridge_contract: [0x11; 20],
+                rgb_asset_id: "rgb:other".into(),
+            });
+        }
+
+        for c in cases {
+            assert_ne!(
+                c.to_bytes(),
+                base,
+                "posture change must alter the commitment"
+            );
+        }
+    }
+
+    #[test]
+    fn asset_is_length_prefixed_not_ambiguous() {
+        // The u32 length prefix means a longer asset id can never be confused
+        // with a shorter one that happens to share a prefix.
+        let with_asset = |id: &str| AttestedPolicy::Production {
+            allow_vanilla_psbt: false,
+            attestation: AttestationMode::Real,
+            evm_source: EvmDataSource::RawRpc,
+            btc_source: BtcDataSource::SpvVerified,
+            chain_id: 1,
+            bridge_contract: [0x11; 20],
+            rgb_asset_id: id.into(),
+        };
+        assert_ne!(with_asset("ab").to_bytes(), with_asset("abc").to_bytes());
+    }
+}

--- a/docs/pubkey-attestation.md
+++ b/docs/pubkey-attestation.md
@@ -11,8 +11,14 @@ After successful verification, the verifier knows:
 
 > "AWS Nitro hardware (which I trust like a TLS root CA) certifies that, at
 > time T (within nonce-freshness), an enclave running code with PCR0=X,
-> PCR1=Y, PCR2=Z produced public key K, and the full key bundle B
-> commits to user_data."
+> PCR1=Y, PCR2=Z produced public key K, and the full key bundle B **plus the
+> enclave's resolved security policy P** commit to user_data."
+
+The security policy `P` (audit C-01) is the enclave's single, explicit posture —
+signing modes, the chain/contract/asset pins, the attestation mode, and the
+allowed data sources — resolved once at boot. Committing it into `user_data`
+lets a verifier check the whole posture as one attested value instead of
+inferring it from build flags or configuration guesses.
 
 The chain of trust is:
 
@@ -37,13 +43,14 @@ verifier                                 parent gRPC                      enclav
    │                                          │                                 │ 4. NSM produces COSE_Sign1 doc
    │                                          │                                 │    binding {nonce,
    │                                          │                                 │            public_key=evm_uncompressed_pub,
-   │                                          │                                 │            user_data=sha256(bundle)}
+   │                                          │                                 │            user_data=sha256(bundle || policy)}
    │                                          │                                 │    to PCR0/1/2
    │                                          │ ◀── (public_keys, doc) ─────────│
    │ ◀── AttestedPublicKeyResponse ───────────│                                 │
    │                                                                            │
    │ 5. Verify chain → AWS root, COSE sig, validity, PCRs, nonce equal,
-   │    public_key == evm_uncompressed_pub, user_data == sha256(bundle).        │
+   │    public_key == evm_uncompressed_pub,
+   │    user_data == sha256(bundle || expected_policy).                         │
 ```
 
 ## Bindings
@@ -51,16 +58,17 @@ verifier                                 parent gRPC                      enclav
 The NSM attestation document carries two caller-controlled fields. The enclave
 populates them as:
 
-| NSM field    | Bound value                                                                    |
-|--------------|--------------------------------------------------------------------------------|
-| `public_key` | `evm_uncompressed_pub` — the bridge's primary signing key (64 bytes, X\|\|Y) |
-| `user_data`  | `sha256(canonical_bundle)` — 32-byte commitment over the full key bundle      |
-| `nonce`      | the 32-byte nonce supplied by the verifier                                    |
+| NSM field    | Bound value                                                                                 |
+|--------------|---------------------------------------------------------------------------------------------|
+| `public_key` | `evm_uncompressed_pub` — the bridge's primary signing key (64 bytes, X\|\|Y)              |
+| `user_data`  | `sha256(canonical_bundle \|\| policy_commitment)` — 32-byte commitment over the key bundle *and* the resolved security policy |
+| `nonce`      | the 32-byte nonce supplied by the verifier                                                 |
 
 A lightweight verifier can stop at `public_key` (e.g. an EVM contract that
 only cares about the signing address). A thorough verifier rebuilds the
-canonical bundle and checks `user_data` to confirm the BTC keys, xpubs, and
-fingerprint were not swapped by the parent host process.
+canonical bundle **and the expected security policy** and checks `user_data` to
+confirm the BTC keys, xpubs, and fingerprint were not swapped by the parent host
+process *and* that the enclave's posture matches what was expected.
 
 ### Canonical bundle encoding
 
@@ -94,7 +102,38 @@ The verifier MUST use the same field set, the same order, and the same
 length-prefix encoding. The reference encoder is `canonical_pubkey_bundle`
 in [`enclave/src/server.rs`](../enclave/src/server.rs) and the reference
 decoder/checker is `canonical_bundle` in
-[`parent/src/bin/attest_verify.rs`](../parent/src/bin/attest_verify.rs).
+[`parent/src/attest_verify.rs`](../parent/src/attest_verify.rs).
+
+### Security policy commitment (audit C-01)
+
+The canonical bundle above is followed by the enclave's resolved security
+policy, and `user_data = sha256(canonical_bundle || policy_commitment)`. The
+policy is the single source of truth for the enclave's posture — resolved once
+at boot in [`enclave/src/policy.rs`](../enclave/src/policy.rs) and serialized by
+[`attestation-verify/src/policy.rs`](../attestation-verify/src/policy.rs), which
+both the enclave and every verifier share so the bytes are identical.
+
+```
+policy_commitment =
+    u8(POLICY_COMMITMENT_V1 = 1)                    // version tag
+    // Production (release, fully-pinned bridge signer):
+    u8(0x01)                                        // production discriminant
+    u8(allow_vanilla_psbt)                          // plain-BTC path enabled?
+    u8(attestation_mode)                            // 1 = real NSM (0 = mock)
+    u8(evm_source)                                  // 0 disabled | 1 raw-rpc | 2 helios
+    u8(btc_source)                                  // 1 = SPV-verified
+    chain_id_be8 || bridge_contract(20)
+    u32_be(len(rgb_asset_id)) || rgb_asset_id_utf8
+    // Development (debug/test/dev-feature/non-bridge/unpinned build):
+    u8(0x00)                                        // development discriminant
+```
+
+A production enclave commits the full production tuple; a dev/mock enclave
+commits just `[version, 0x00]`. Because the posture flags (`allow_vanilla_psbt`,
+`evm_source`, …) are not on the wire, a verifier reconstructs the **expected**
+policy and requires the commitment to match — so an enclave that shipped with a
+downgraded posture (vanilla signing on, raw instead of Helios-verified RPC, a
+dev build) fails verification rather than being silently trusted.
 
 ## Where the expected PCRs come from
 
@@ -131,24 +170,36 @@ Given `(public_keys_bundle, attestation_doc, nonce_sent, expected_pcrs)`:
    bytewise.
 6. Nonce check: `doc.nonce == nonce_sent`.
 7. Pubkey check: `doc.public_key == public_keys_bundle.evm_uncompressed_pub`.
-8. Commitment check: `doc.user_data == sha256(canonical_bundle(public_keys_bundle))`.
+8. Commitment check: build the expected policy (from the expected posture +
+   the wire pins) and confirm
+   `doc.user_data == sha256(canonical_bundle(public_keys_bundle) || expected_policy)`.
 
 If all eight checks pass, the bridge's EVM address (`keccak256(evm_uncompressed_pub)[12..]`)
-is bound to the running TEE measurement.
+is bound to the running TEE measurement *and* the enclave's attested posture
+equals the expected production policy.
 
 ## Verification recipe (with `attest-verify`)
 
 The `attest-verify` CLI in this repo runs the full recipe.
 
 ```bash
-# Production verification (against a real Nitro enclave)
+# Production verification (against a real Nitro enclave). By default it expects a
+# production policy with plain-BTC signing DISABLED and the raw-RPC EVM data
+# source (what the shipped image uses).
 attest-verify \
     --endpoint http://parent.example:50051 \
     --pcr0 <96-hex-chars> \
     --pcr1 <96-hex-chars> \
     --pcr2 <96-hex-chars>
 
-# Dev / CI verification (against an enclave built with --features mock-attestation)
+# Require the trustless Helios data source (fails if the enclave is only on raw
+# RPC), and/or expect the plain-BTC path enabled:
+attest-verify --endpoint http://parent.example:50051 \
+    --pcr0 <..> --pcr1 <..> --pcr2 <..> \
+    --expect-evm-source helios --expect-vanilla-psbt
+
+# Dev / CI verification (against an enclave built with --features mock-attestation).
+# --mock implies the expected policy is Development.
 attest-verify --endpoint http://127.0.0.1:50051 --mock
 ```
 
@@ -177,6 +228,11 @@ Defended:
 - **BTC key / xpub swap** — `user_data` commits to the full bundle. A parent
   cannot change one field of `PublicKeysResponse` without breaking the
   commitment match.
+- **Posture downgrade (audit C-01)** — `user_data` also commits to the resolved
+  security policy (signing modes, pins, attestation mode, data sources). An
+  enclave that shipped with a weaker posture than expected — plain-BTC signing
+  enabled, a raw instead of Helios-verified EVM source, or a dev build — fails
+  the commitment match against the verifier's expected policy.
 - **Fork to a different enclave image** — PCR mismatch on verify.
 - **Stale code (vulnerable image)** — operator publishes accepted PCRs;
   outdated images won't match.
@@ -194,7 +250,10 @@ NOT defended (out of scope for attestation):
 - Parent gRPC handler: [`parent/src/grpc_server.rs`](../parent/src/grpc_server.rs)
   (`attested_public_key`).
 - Verifier crate: [`attestation-verify/src/lib.rs`](../attestation-verify/src/lib.rs).
+- Verifier library (`verify_attested_pubkey`, `ExpectedPolicy`): [`parent/src/attest_verify.rs`](../parent/src/attest_verify.rs).
 - CLI binary: [`parent/src/bin/attest_verify.rs`](../parent/src/bin/attest_verify.rs).
+- Security policy (audit C-01): resolved in [`enclave/src/policy.rs`](../enclave/src/policy.rs);
+  shared canonical encoding in [`attestation-verify/src/policy.rs`](../attestation-verify/src/policy.rs).
 - Wire definitions:
   - Enclave wire: [`proto/enclave.proto`](../proto/enclave.proto)
     (`GetAttestedPublicKeyRequest`/`Response`).

--- a/enclave/src/config.rs
+++ b/enclave/src/config.rs
@@ -158,6 +158,17 @@ impl BridgeConfig {
         any && !self.is_configured()
     }
 
+    /// Whether the plain-BTC (vanilla / create_utxo) signing path is authorised:
+    /// both the output allowlist and the total-value cap must be operator-set.
+    /// This is the single predicate the boot-time [`crate::policy::SecurityPolicy`]
+    /// records as `allow_vanilla_psbt` and that
+    /// `networks::rgb::btc_crosscheck::validate_btc_request` enforces per request
+    /// (they MUST agree — an enclave that attests `allow_vanilla_psbt = true` must
+    /// actually accept the path, and vice versa).
+    pub fn allows_vanilla_btc(&self) -> bool {
+        !self.btc_allowed_scripts.is_empty() && self.btc_max_total_sats != 0
+    }
+
     /// The reason this config is not production-ready, or `None` when all three
     /// pins (chain, contract, asset) are set. Pure and build-profile-agnostic so
     /// it is directly unit-testable; [`assert_configured_in_release`](Self::assert_configured_in_release)

--- a/enclave/src/config.rs
+++ b/enclave/src/config.rs
@@ -49,9 +49,9 @@ pub struct BridgeConfig {
     /// toward (e.g. the bridge's own change/UTXO-management scripts). Empty =
     /// unset; a production (`rgb-validation`) build refuses plain-BTC signing
     /// when unset. Like the gas-tx destination pin (`GAS_TX_ALLOWED_TO`), this
-    /// is an operational signing-policy pin, NOT part of `is_configured()` or
-    /// the attested identity bundle — see the C-01 systemic follow-up for
-    /// attesting it.
+    /// is an operational signing-policy pin, NOT part of `is_configured()`.
+    /// Whether the path is enabled at all ([`allows_vanilla_btc`](Self::allows_vanilla_btc))
+    /// IS attested, as `allow_vanilla_psbt` in the security policy (C-01).
     pub btc_allowed_scripts: Vec<Vec<u8>>,
     /// Operator-pinned cap (sats) on the **total** output value of a plain-BTC
     /// PSBT (`BTC_MAX_TOTAL_SATS`). `0` = unset; a production build refuses
@@ -167,57 +167,6 @@ impl BridgeConfig {
     /// actually accept the path, and vice versa).
     pub fn allows_vanilla_btc(&self) -> bool {
         !self.btc_allowed_scripts.is_empty() && self.btc_max_total_sats != 0
-    }
-
-    /// The reason this config is not production-ready, or `None` when all three
-    /// pins (chain, contract, asset) are set. Pure and build-profile-agnostic so
-    /// it is directly unit-testable; [`assert_configured_in_release`](Self::assert_configured_in_release)
-    /// layers the debug/test exemptions and the `rgb-validation`-only scope on top.
-    pub fn production_readiness_error(&self) -> Option<String> {
-        if self.is_configured() {
-            return None;
-        }
-        let detail = if self.is_partially_configured() {
-            "PARTIALLY set (some but not all of EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID \
-             are set)"
-        } else {
-            "unset (none of EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID are set)"
-        };
-        Some(format!(
-            "bridge config is {detail}. A release rgb-validation (bridge-signing) enclave must \
-             pin all three so every signing path is authorised against operator pins; without \
-             them it would boot and fail closed on every bridge request. Set all three env vars, \
-             or build without rgb-validation for a non-signing enclave."
-        ))
-    }
-
-    /// Refuse to START a production bridge-signing build that isn't fully pinned
-    /// (audit C-01 systemic: no single explicit fail-closed production policy).
-    ///
-    /// A release `rgb-validation` build reaches every bridge-signing path, and
-    /// each already fails closed *per request* when [`is_configured`](Self::is_configured)
-    /// is false (see `networks::evm::validation::validate_destination` and
-    /// `networks::rgb::validate_destination_anchor`). But a per-request refusal
-    /// is only visible to whoever reads the rejected response or the enclave
-    /// logs - which an operator does not watch on a production host. Fail at
-    /// BOOT instead, the same way a placeholder SPV checkpoint does
-    /// ([`crate::networks::rgb::spv::Checkpoint::assert_real_in_release`]): a
-    /// misconfigured or partially-pinned production enclave never becomes
-    /// reachable, rather than starting and silently rejecting every signature.
-    ///
-    /// Exemptions mirror `assert_real_in_release`: debug builds, tests, and the
-    /// local-E2E `allow-seed-import` feature may run unpinned. A minimal
-    /// (non-`rgb-validation`) build has no bridge-signing path to protect and
-    /// always passes.
-    pub fn assert_configured_in_release(&self) -> std::result::Result<(), String> {
-        if cfg!(debug_assertions) || cfg!(test) || cfg!(feature = "allow-seed-import") {
-            return Ok(());
-        }
-        #[cfg(feature = "rgb-validation")]
-        if let Some(msg) = self.production_readiness_error() {
-            return Err(msg);
-        }
-        Ok(())
     }
 }
 
@@ -475,47 +424,6 @@ mod tests {
         };
         assert!(!c.is_configured());
         assert!(c.is_partially_configured());
-    }
-
-    #[test]
-    fn production_readiness_error_none_when_configured() {
-        let c = BridgeConfig {
-            chain_id: 1,
-            bridge_contract: [1u8; 20],
-            rgb_asset_id: "rgb:asset".into(),
-            ..Default::default()
-        };
-        assert!(c.production_readiness_error().is_none());
-    }
-
-    #[test]
-    fn production_readiness_error_flags_unset() {
-        let msg = BridgeConfig::default()
-            .production_readiness_error()
-            .expect("a fully-empty config is not production-ready");
-        assert!(msg.contains("unset"), "got: {msg}");
-    }
-
-    #[test]
-    fn production_readiness_error_flags_partial() {
-        // chain_id set, contract + asset still empty: a botched pin.
-        let c = BridgeConfig {
-            chain_id: 1,
-            ..Default::default()
-        };
-        let msg = c
-            .production_readiness_error()
-            .expect("a partial config is not production-ready");
-        assert!(msg.contains("PARTIALLY"), "got: {msg}");
-    }
-
-    #[test]
-    fn assert_configured_in_release_exempts_test_builds() {
-        // cfg!(test) short-circuits the boot gate, so even a fully-empty config
-        // passes under test - the panic only fires in a production-shaped build.
-        assert!(BridgeConfig::default()
-            .assert_configured_in_release()
-            .is_ok());
     }
 
     #[test]

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -65,6 +65,7 @@ pub mod error;
 pub mod framing;
 pub mod keys;
 pub mod networks;
+pub mod policy;
 pub mod server;
 pub mod state;
 

--- a/enclave/src/main.rs
+++ b/enclave/src/main.rs
@@ -9,6 +9,7 @@ use utexo_bridge_enclave::config::BridgeConfig;
 use utexo_bridge_enclave::networks::rgb::spv::{checkpoint_for, HeaderChain, Network};
 #[cfg(feature = "rgb-validation")]
 use utexo_bridge_enclave::networks::rgb::validation::RgbValidator;
+use utexo_bridge_enclave::policy::{BuildContext, EvmDataSource, SecurityPolicy};
 use utexo_bridge_enclave::server::{self, ServerContext};
 use utexo_bridge_enclave::state::EnclaveState;
 
@@ -65,15 +66,52 @@ fn main() {
         );
     }
 
-    // Fail-closed at BOOT for a production bridge-signing build (audit C-01
-    // systemic). A per-request refusal (evm::validation / rgb anchor) and the
-    // logs above are not enough: an operator does not tail enclave logs on a
-    // prod host, so an unconfigured or partially-pinned release enclave would
-    // start and silently reject every bridge signature. A release
-    // rgb-validation build that is not fully pinned must never become
+    // Which EVM `FundsIn` deposit-verification source this build/deployment
+    // uses (audit C-01 "allowed data sources"). Determined the same way the RPC
+    // client is selected below: `evm-rpc` off => none; `helios` +
+    // HELIOS_EXECUTION_RPC set => trustless; otherwise the raw host-relayed RPC.
+    #[cfg(not(feature = "evm-rpc"))]
+    let evm_source = EvmDataSource::Disabled;
+    #[cfg(all(feature = "evm-rpc", not(feature = "helios")))]
+    let evm_source = EvmDataSource::RawRpc;
+    #[cfg(all(feature = "evm-rpc", feature = "helios"))]
+    let evm_source = if std::env::var("HELIOS_EXECUTION_RPC").is_ok() {
+        EvmDataSource::HeliosVerified
+    } else {
+        EvmDataSource::RawRpc
+    };
+
+    // Resolve the enclave's single, explicit security posture once (audit C-01),
+    // from the build context + pinned config + selected data source. This is the
+    // value committed into attestation `user_data` (see
+    // `server::handle_get_attested_public_key`) and consulted by the signing
+    // handlers instead of re-deriving posture from features and empty fields.
+    let build_ctx = BuildContext::current();
+    let policy = SecurityPolicy::resolve(&build_ctx, &bridge_config, evm_source);
+    match &policy {
+        SecurityPolicy::Production(p) => tracing::info!(
+            chain_id = p.chain_id,
+            allow_vanilla_psbt = p.allow_vanilla_psbt,
+            evm_source = ?p.evm_source,
+            btc_source = ?p.btc_source,
+            "resolved PRODUCTION security policy (committed into attestation user_data)"
+        ),
+        SecurityPolicy::Development { reason } => tracing::warn!(
+            ?reason,
+            "resolved DEVELOPMENT security policy — this is NOT a production bridge signer"
+        ),
+    }
+
+    // Fail-closed at BOOT (audit C-01 systemic). A per-request refusal
+    // (evm::validation / rgb anchor) and the logs above are not enough: an
+    // operator does not tail enclave logs on a prod host, so an unconfigured,
+    // partially-pinned, or dev-feature release enclave would start and silently
+    // reject (or worse) every bridge signature. A release rgb-validation build
+    // that does not resolve to a valid Production policy must never become
     // reachable. Mirrors the placeholder-checkpoint boot check below; debug /
-    // test / allow-seed-import builds are exempt.
-    if let Err(msg) = bridge_config.assert_configured_in_release() {
+    // test / non-bridge builds are exempt. Supersedes the old
+    // BridgeConfig::assert_configured_in_release gate.
+    if let Err(msg) = policy.assert_valid_for_build(&build_ctx) {
         panic!("{msg}");
     }
 
@@ -292,6 +330,7 @@ fn main() {
     let ctx = ServerContext {
         state,
         bridge_config,
+        policy,
         #[cfg(feature = "rgb-validation")]
         rgb_validator,
         #[cfg(feature = "evm-rpc")]

--- a/enclave/src/main.rs
+++ b/enclave/src/main.rs
@@ -102,15 +102,12 @@ fn main() {
         ),
     }
 
-    // Fail-closed at BOOT (audit C-01 systemic). A per-request refusal
-    // (evm::validation / rgb anchor) and the logs above are not enough: an
-    // operator does not tail enclave logs on a prod host, so an unconfigured,
-    // partially-pinned, or dev-feature release enclave would start and silently
-    // reject (or worse) every bridge signature. A release rgb-validation build
-    // that does not resolve to a valid Production policy must never become
-    // reachable. Mirrors the placeholder-checkpoint boot check below; debug /
-    // test / non-bridge builds are exempt. Supersedes the old
-    // BridgeConfig::assert_configured_in_release gate.
+    // Fail-closed at BOOT (audit C-01 systemic). Per-request refusals and the
+    // logs above are not enough — an operator does not tail enclave logs on a
+    // prod host — so a release rgb-validation build that does not resolve to a
+    // valid Production policy must never become reachable. Mirrors the
+    // placeholder-checkpoint boot check below; debug / test / non-bridge
+    // builds are exempt.
     if let Err(msg) = policy.assert_valid_for_build(&build_ctx) {
         panic!("{msg}");
     }

--- a/enclave/src/policy.rs
+++ b/enclave/src/policy.rs
@@ -20,10 +20,8 @@
 //!     path checks [`ProductionPolicy::allow_vanilla_psbt`]) instead of
 //!     re-deriving posture from features and empty fields.
 //!
-//! Resolution and the boot gate are split into pure functions taking an explicit
-//! [`BuildContext`] so the release behaviour is unit-testable without actually
-//! being a release build (the same split `config.rs` uses for
-//! `production_readiness_error` vs `assert_configured_in_release`).
+//! Resolution and the boot gate take an explicit [`BuildContext`] so the
+//! release behaviour is unit-testable without actually being a release build.
 
 use crate::config::BridgeConfig;
 
@@ -192,8 +190,7 @@ impl SecurityPolicy {
     /// same way a placeholder SPV checkpoint does).
     ///
     /// Debug/test builds and non-bridge builds are exempt — they have no
-    /// production bridge-signing path to protect. This mirrors the scope of the
-    /// old `BridgeConfig::assert_configured_in_release`, which it supersedes.
+    /// production bridge-signing path to protect.
     pub fn assert_valid_for_build(&self, ctx: &BuildContext) -> Result<(), String> {
         if ctx.debug_or_test || !ctx.rgb_validation {
             return Ok(());
@@ -312,22 +309,30 @@ mod tests {
     #[test]
     fn each_dev_feature_forces_development_even_when_fully_pinned() {
         let base = release_bridge_ctx();
-        for (mutate, reason) in [
+        let cases = [
             (
-                (|c: &mut BuildContext| c.dev_mode = true) as fn(&mut BuildContext),
+                BuildContext {
+                    dev_mode: true,
+                    ..base
+                },
                 DevReason::DevMode,
             ),
             (
-                |c: &mut BuildContext| c.mock_attestation = true,
+                BuildContext {
+                    mock_attestation: true,
+                    ..base
+                },
                 DevReason::MockAttestation,
             ),
             (
-                |c: &mut BuildContext| c.allow_seed_import = true,
+                BuildContext {
+                    allow_seed_import: true,
+                    ..base
+                },
                 DevReason::AllowSeedImport,
             ),
-        ] {
-            let mut ctx = base;
-            mutate(&mut ctx);
+        ];
+        for (ctx, reason) in cases {
             let p = SecurityPolicy::resolve(&ctx, &pinned_config(), EvmDataSource::HeliosVerified);
             assert_eq!(p, SecurityPolicy::Development { reason });
             // Even fully pinned, a dev feature in a release rgb build must not boot.

--- a/enclave/src/policy.rs
+++ b/enclave/src/policy.rs
@@ -1,0 +1,428 @@
+//! The enclave's single, explicit security posture (audit C-01).
+//!
+//! Before this module the posture was reconstructed at runtime from several
+//! independent conditions — build features, the presence/absence of
+//! [`BridgeConfig`] fields, request shape, and which chain-verification
+//! components happened to be wired up. A verifier could not read the posture as
+//! one value, and an unsafe build/deployment combination could become active.
+//!
+//! [`SecurityPolicy`] collapses all of that into ONE object, resolved once at
+//! boot by [`SecurityPolicy::resolve`]:
+//!
+//!   * it is **fail-closed**: a release bridge-signing (`rgb-validation`) build
+//!     that does not resolve to a valid [`SecurityPolicy::Production`] refuses to
+//!     boot ([`SecurityPolicy::assert_valid_for_build`]);
+//!   * it is **attested**: [`SecurityPolicy::commitment_bytes`] is folded into
+//!     the attestation `user_data` commitment (see
+//!     `server::handle_get_attested_public_key`), so a verifier checks the whole
+//!     posture as a single value against its expected production policy;
+//!   * it is **authoritative**: request handlers consult it (e.g. the plain-BTC
+//!     path checks [`ProductionPolicy::allow_vanilla_psbt`]) instead of
+//!     re-deriving posture from features and empty fields.
+//!
+//! Resolution and the boot gate are split into pure functions taking an explicit
+//! [`BuildContext`] so the release behaviour is unit-testable without actually
+//! being a release build (the same split `config.rs` uses for
+//! `production_readiness_error` vs `assert_configured_in_release`).
+
+use crate::config::BridgeConfig;
+
+pub use attestation_verify::{AttestationMode, AttestedPolicy, BtcDataSource, EvmDataSource};
+
+/// The enclave's resolved security posture. See the module docs.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SecurityPolicy {
+    /// A fully-pinned, fail-closed bridge-signing enclave.
+    Production(ProductionPolicy),
+    /// Anything that is not a production bridge signer: a debug build, a dev
+    /// feature, a non-bridge build, or an unpinned config. Carries the reason so
+    /// boot logs and the fail-closed panic say *why*.
+    Development { reason: DevReason },
+}
+
+/// The pinned facts and enabled modes of a production bridge-signing enclave.
+/// Mirrors the recommendation in audit C-01: signing modes, the
+/// chain/contract/asset pins, the expected attestation values, and the allowed
+/// data sources — all in one place, all committed into attestation `user_data`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProductionPolicy {
+    /// Pinned EVM chain id (`EVM_CHAIN_ID`).
+    pub chain_id: u64,
+    /// Pinned bridge (MultisigProxy) contract (`BRIDGE_CONTRACT`).
+    pub bridge_contract: [u8; 20],
+    /// Pinned RGB asset id (`RGB_ASSET_ID`).
+    pub rgb_asset_id: String,
+    /// Whether the plain-BTC (vanilla / create_utxo) signing path is authorised.
+    /// Derived from the operator's `BTC_ALLOWED_SCRIPTS` + `BTC_MAX_TOTAL_SATS`
+    /// pins ([`BridgeConfig::allows_vanilla_btc`]); default fail-closed (false).
+    pub allow_vanilla_psbt: bool,
+    /// Expected attestation root of trust. Always [`AttestationMode::Real`] in a
+    /// production build (mock is a `compile_error!` in release — see `lib.rs`).
+    pub attestation: AttestationMode,
+    /// EVM `FundsIn` deposit-verification source (raw RPC vs Helios-verified vs
+    /// disabled). Recorded and attested so a verifier can tell a trustless
+    /// deployment apart from a host-relayed one.
+    pub evm_source: EvmDataSource,
+    /// Bitcoin anchor-verification source. Always SPV in a production build.
+    pub btc_source: BtcDataSource,
+}
+
+/// Why an enclave resolved to [`SecurityPolicy::Development`] rather than
+/// production. Included in boot logs and the fail-closed panic message.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DevReason {
+    /// Built with `debug_assertions` (or under `cfg(test)`).
+    DebugBuild,
+    /// `dev-mode` feature: every signing cross-check is skipped.
+    DevMode,
+    /// `mock-attestation` feature: zero-PCR attestation documents.
+    MockAttestation,
+    /// `allow-seed-import` feature: the parent can install a chosen seed.
+    AllowSeedImport,
+    /// A non-bridge build (`rgb-validation` off): no bridge-signing path exists.
+    NonBridgeBuild,
+    /// A bridge build whose chain/contract/asset pins are not fully set.
+    Unconfigured,
+}
+
+/// Compile-time posture inputs, captured so [`SecurityPolicy::resolve`] and
+/// [`SecurityPolicy::assert_valid_for_build`] are pure and unit-testable. The
+/// real values come from [`BuildContext::current`]; tests construct arbitrary
+/// contexts to exercise the release paths.
+#[derive(Clone, Copy, Debug)]
+pub struct BuildContext {
+    /// `cfg!(debug_assertions) || cfg!(test)` — the "not a release build" signal.
+    pub debug_or_test: bool,
+    pub dev_mode: bool,
+    pub mock_attestation: bool,
+    pub allow_seed_import: bool,
+    /// `rgb-validation`: the feature that turns on bridge signing. A release
+    /// build with this on is the one the production policy must protect.
+    pub rgb_validation: bool,
+}
+
+impl BuildContext {
+    /// The current build's posture inputs, read from `cfg!`.
+    pub fn current() -> Self {
+        Self {
+            debug_or_test: cfg!(debug_assertions) || cfg!(test),
+            dev_mode: cfg!(feature = "dev-mode"),
+            mock_attestation: cfg!(feature = "mock-attestation"),
+            allow_seed_import: cfg!(feature = "allow-seed-import"),
+            rgb_validation: cfg!(feature = "rgb-validation"),
+        }
+    }
+}
+
+impl SecurityPolicy {
+    /// Resolve the single security posture from the build context, the pinned
+    /// [`BridgeConfig`], and the EVM data source selected at boot.
+    ///
+    /// Fail-closed by construction: any dev feature, a debug/test build, a
+    /// non-bridge build, or an unpinned config yields
+    /// [`SecurityPolicy::Development`]. Only a release bridge build with all
+    /// three pins set becomes [`SecurityPolicy::Production`].
+    pub fn resolve(ctx: &BuildContext, bridge: &BridgeConfig, evm_source: EvmDataSource) -> Self {
+        // Any dev feature collapses the posture regardless of everything else.
+        // (These are `compile_error!` in a release build — lib.rs — so in a real
+        // production binary they are all false; the checks make dev/test builds
+        // resolve honestly and keep this function total.)
+        if ctx.dev_mode {
+            return Self::dev(DevReason::DevMode);
+        }
+        if ctx.mock_attestation {
+            return Self::dev(DevReason::MockAttestation);
+        }
+        if ctx.allow_seed_import {
+            return Self::dev(DevReason::AllowSeedImport);
+        }
+        if ctx.debug_or_test {
+            return Self::dev(DevReason::DebugBuild);
+        }
+        // Release build from here.
+        if !ctx.rgb_validation {
+            // No bridge-signing path compiled in: not a production bridge signer.
+            return Self::dev(DevReason::NonBridgeBuild);
+        }
+        if !bridge.is_configured() {
+            return Self::dev(DevReason::Unconfigured);
+        }
+        Self::Production(ProductionPolicy {
+            chain_id: bridge.chain_id,
+            bridge_contract: bridge.bridge_contract,
+            rgb_asset_id: bridge.rgb_asset_id.clone(),
+            allow_vanilla_psbt: bridge.allows_vanilla_btc(),
+            attestation: AttestationMode::Real,
+            evm_source,
+            // `rgb-validation` implies `spv` (lib.rs `compile_error!`), so a
+            // bridge build always anchors witness txs via the SPV header chain.
+            btc_source: BtcDataSource::SpvVerified,
+        })
+    }
+
+    fn dev(reason: DevReason) -> Self {
+        Self::Development { reason }
+    }
+
+    /// The commitment form folded into attestation `user_data`.
+    pub fn attested(&self) -> AttestedPolicy {
+        match self {
+            Self::Production(p) => AttestedPolicy::Production {
+                allow_vanilla_psbt: p.allow_vanilla_psbt,
+                attestation: p.attestation,
+                evm_source: p.evm_source,
+                btc_source: p.btc_source,
+                chain_id: p.chain_id,
+                bridge_contract: p.bridge_contract,
+                rgb_asset_id: p.rgb_asset_id.clone(),
+            },
+            Self::Development { .. } => AttestedPolicy::Development,
+        }
+    }
+
+    /// Canonical bytes appended to the attestation commitment preimage. Mirrored
+    /// by every verifier via [`attestation_verify::AttestedPolicy::to_bytes`].
+    pub fn commitment_bytes(&self) -> Vec<u8> {
+        self.attested().to_bytes()
+    }
+
+    /// Fail-closed boot gate. A release bridge-signing (`rgb-validation`) build
+    /// MUST resolve to a valid [`SecurityPolicy::Production`]; otherwise the
+    /// enclave refuses to become reachable (the caller `panic!`s at boot, the
+    /// same way a placeholder SPV checkpoint does).
+    ///
+    /// Debug/test builds and non-bridge builds are exempt — they have no
+    /// production bridge-signing path to protect. This mirrors the scope of the
+    /// old `BridgeConfig::assert_configured_in_release`, which it supersedes.
+    pub fn assert_valid_for_build(&self, ctx: &BuildContext) -> Result<(), String> {
+        if ctx.debug_or_test || !ctx.rgb_validation {
+            return Ok(());
+        }
+        match self {
+            Self::Production(p) => p.check_invariants(),
+            Self::Development { reason } => Err(format!(
+                "release rgb-validation (bridge-signing) build resolved to a non-production \
+                 security policy ({reason:?}); refusing to boot. A production bridge enclave must \
+                 pin EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID and be built without any dev \
+                 feature (dev-mode / mock-attestation / allow-seed-import). See audit C-01."
+            )),
+        }
+    }
+}
+
+impl ProductionPolicy {
+    /// Invariants that must hold before a production enclave signs anything.
+    ///
+    /// The EVM data source is deliberately NOT gated here: a `Disabled` source
+    /// fails closed *per request* (see `server::handle_sign`) rather than being
+    /// unsafe, and its value is attested for the external verifier to check
+    /// against the operator's expected posture. What must hold at boot is that
+    /// the identity pins are complete, the attestation is real, and Bitcoin
+    /// anchors are SPV-verified.
+    pub fn check_invariants(&self) -> Result<(), String> {
+        if self.chain_id == 0 || self.bridge_contract == [0u8; 20] || self.rgb_asset_id.is_empty() {
+            return Err(
+                "production policy is missing one or more of the chain/contract/asset pins".into(),
+            );
+        }
+        if self.attestation != AttestationMode::Real {
+            return Err(
+                "production policy must use real (NSM) attestation, not the mock path".into(),
+            );
+        }
+        if self.btc_source != BtcDataSource::SpvVerified {
+            return Err(
+                "production policy must anchor Bitcoin witness txs via the SPV header chain".into(),
+            );
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A build context for a clean release bridge build (no dev features).
+    fn release_bridge_ctx() -> BuildContext {
+        BuildContext {
+            debug_or_test: false,
+            dev_mode: false,
+            mock_attestation: false,
+            allow_seed_import: false,
+            rgb_validation: true,
+        }
+    }
+
+    fn pinned_config() -> BridgeConfig {
+        BridgeConfig {
+            chain_id: 1,
+            bridge_contract: [0x11; 20],
+            rgb_asset_id: "rgb:asset".into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn release_bridge_with_full_pins_is_production() {
+        let p = SecurityPolicy::resolve(
+            &release_bridge_ctx(),
+            &pinned_config(),
+            EvmDataSource::RawRpc,
+        );
+        match &p {
+            SecurityPolicy::Production(pp) => {
+                assert_eq!(pp.chain_id, 1);
+                assert_eq!(pp.evm_source, EvmDataSource::RawRpc);
+                assert_eq!(pp.attestation, AttestationMode::Real);
+                assert_eq!(pp.btc_source, BtcDataSource::SpvVerified);
+            }
+            other => panic!("expected Production, got {other:?}"),
+        }
+        assert!(p.assert_valid_for_build(&release_bridge_ctx()).is_ok());
+    }
+
+    #[test]
+    fn release_bridge_unconfigured_is_rejected_at_boot() {
+        let ctx = release_bridge_ctx();
+        let p = SecurityPolicy::resolve(&ctx, &BridgeConfig::default(), EvmDataSource::RawRpc);
+        assert_eq!(
+            p,
+            SecurityPolicy::Development {
+                reason: DevReason::Unconfigured
+            }
+        );
+        // The whole point of C-01: a misconfigured production build never boots.
+        let err = p.assert_valid_for_build(&ctx).unwrap_err();
+        assert!(err.contains("Unconfigured"), "got: {err}");
+    }
+
+    #[test]
+    fn release_bridge_partially_pinned_is_rejected_at_boot() {
+        let ctx = release_bridge_ctx();
+        let partial = BridgeConfig {
+            chain_id: 1,
+            ..Default::default()
+        };
+        let p = SecurityPolicy::resolve(&ctx, &partial, EvmDataSource::RawRpc);
+        assert!(matches!(p, SecurityPolicy::Development { .. }));
+        assert!(p.assert_valid_for_build(&ctx).is_err());
+    }
+
+    #[test]
+    fn each_dev_feature_forces_development_even_when_fully_pinned() {
+        let base = release_bridge_ctx();
+        for (mutate, reason) in [
+            (
+                (|c: &mut BuildContext| c.dev_mode = true) as fn(&mut BuildContext),
+                DevReason::DevMode,
+            ),
+            (
+                |c: &mut BuildContext| c.mock_attestation = true,
+                DevReason::MockAttestation,
+            ),
+            (
+                |c: &mut BuildContext| c.allow_seed_import = true,
+                DevReason::AllowSeedImport,
+            ),
+        ] {
+            let mut ctx = base;
+            mutate(&mut ctx);
+            let p = SecurityPolicy::resolve(&ctx, &pinned_config(), EvmDataSource::HeliosVerified);
+            assert_eq!(p, SecurityPolicy::Development { reason });
+            // Even fully pinned, a dev feature in a release rgb build must not boot.
+            assert!(p.assert_valid_for_build(&ctx).is_err());
+        }
+    }
+
+    #[test]
+    fn debug_build_is_development_and_exempt_from_the_boot_gate() {
+        let ctx = BuildContext {
+            debug_or_test: true,
+            ..release_bridge_ctx()
+        };
+        let p = SecurityPolicy::resolve(&ctx, &pinned_config(), EvmDataSource::RawRpc);
+        assert_eq!(
+            p,
+            SecurityPolicy::Development {
+                reason: DevReason::DebugBuild
+            }
+        );
+        assert!(p.assert_valid_for_build(&ctx).is_ok());
+    }
+
+    #[test]
+    fn minimal_non_bridge_release_is_exempt() {
+        let ctx = BuildContext {
+            rgb_validation: false,
+            ..release_bridge_ctx()
+        };
+        let p = SecurityPolicy::resolve(&ctx, &BridgeConfig::default(), EvmDataSource::Disabled);
+        assert_eq!(
+            p,
+            SecurityPolicy::Development {
+                reason: DevReason::NonBridgeBuild
+            }
+        );
+        // No bridge path to protect -> the boot gate passes.
+        assert!(p.assert_valid_for_build(&ctx).is_ok());
+    }
+
+    #[test]
+    fn allow_vanilla_psbt_tracks_the_btc_pins() {
+        let ctx = release_bridge_ctx();
+        let mut cfg = pinned_config();
+        // Unset BTC pins -> vanilla disabled (fail-closed).
+        let p = SecurityPolicy::resolve(&ctx, &cfg, EvmDataSource::RawRpc);
+        assert!(matches!(
+            p,
+            SecurityPolicy::Production(ProductionPolicy {
+                allow_vanilla_psbt: false,
+                ..
+            })
+        ));
+        // Operator sets the allowlist + cap -> vanilla enabled and attested.
+        cfg.btc_allowed_scripts = vec![vec![0x00, 0x14]];
+        cfg.btc_max_total_sats = 100_000;
+        let p = SecurityPolicy::resolve(&ctx, &cfg, EvmDataSource::RawRpc);
+        assert!(matches!(
+            p,
+            SecurityPolicy::Production(ProductionPolicy {
+                allow_vanilla_psbt: true,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn evm_source_is_carried_into_the_commitment() {
+        let ctx = release_bridge_ctx();
+        let raw = SecurityPolicy::resolve(&ctx, &pinned_config(), EvmDataSource::RawRpc);
+        let helios = SecurityPolicy::resolve(&ctx, &pinned_config(), EvmDataSource::HeliosVerified);
+        // A raw-RPC deployment and a Helios deployment commit to different bytes,
+        // so a verifier expecting one rejects the other (audit C-01 data source).
+        assert_ne!(raw.commitment_bytes(), helios.commitment_bytes());
+    }
+
+    #[test]
+    fn development_commitment_is_stable_and_distinct() {
+        let dev_a = SecurityPolicy::Development {
+            reason: DevReason::DebugBuild,
+        };
+        let dev_b = SecurityPolicy::Development {
+            reason: DevReason::MockAttestation,
+        };
+        // The reason is for logs only; it is NOT part of the commitment, so any
+        // Development enclave commits the same bytes a verifier can reconstruct.
+        assert_eq!(dev_a.commitment_bytes(), dev_b.commitment_bytes());
+        assert_ne!(
+            dev_a.commitment_bytes(),
+            SecurityPolicy::resolve(
+                &release_bridge_ctx(),
+                &pinned_config(),
+                EvmDataSource::RawRpc
+            )
+            .commitment_bytes()
+        );
+    }
+}

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -20,6 +20,12 @@ pub struct ServerContext {
     /// `user_data` commitment and used to cross-check `SignEvm` requests
     /// against operator-pinned values.
     pub bridge_config: BridgeConfig,
+    /// The enclave's single, explicit security posture, resolved once at boot
+    /// (audit C-01). Committed into the attestation `user_data` commitment via
+    /// [`crate::policy::SecurityPolicy::commitment_bytes`] and consulted by the
+    /// signing handlers instead of re-deriving posture from build features and
+    /// empty request fields.
+    pub policy: crate::policy::SecurityPolicy,
     #[cfg(feature = "rgb-validation")]
     pub rgb_validator: Option<crate::networks::rgb::validation::RgbValidator>,
     /// In-enclave EVM RPC client for independent `FundsIn` verification (#60).
@@ -101,9 +107,20 @@ impl ServerContext {
         bridge_config: BridgeConfig,
         header_chain: std::sync::Mutex<crate::networks::rgb::spv::HeaderChain>,
     ) -> Self {
+        // Resolve the posture from the current build + this config. The main
+        // binary sets `policy` explicitly (it knows the selected EVM data
+        // source); this constructor is used by tests and the parent E2E harness,
+        // where the EVM source is not wired, so it resolves with `Disabled`.
+        // Debug/test builds resolve to `Development` regardless.
+        let policy = crate::policy::SecurityPolicy::resolve(
+            &crate::policy::BuildContext::current(),
+            &bridge_config,
+            crate::policy::EvmDataSource::Disabled,
+        );
         Self {
             state,
             bridge_config,
+            policy,
             #[cfg(feature = "rgb-validation")]
             rgb_validator: None,
             #[cfg(feature = "evm-rpc")]
@@ -624,8 +641,13 @@ fn handle_get_attested_public_key(
     let keys = ctx.state.get_keys()?;
     let public_keys = build_public_keys_response(keys, &ctx.bridge_config);
 
-    let bundle = canonical_pubkey_bundle(&public_keys);
-    let commitment: [u8; 32] = Sha256::digest(&bundle).into();
+    // The attestation `user_data` commits to BOTH the public-key bundle and the
+    // enclave's resolved security policy (audit C-01), so a verifier checks the
+    // whole posture as one value: sha256(pubkey_bundle || policy_commitment).
+    // The verifier mirror is `parent/src/attest_verify.rs::verify_attested_pubkey`.
+    let mut preimage = canonical_pubkey_bundle(&public_keys);
+    preimage.extend_from_slice(&ctx.policy.commitment_bytes());
+    let commitment: [u8; 32] = Sha256::digest(&preimage).into();
 
     let attestation_doc = crate::attestation::get_attestation(
         &nonce,
@@ -729,6 +751,21 @@ fn handle_sign_psbt(ctx: &ServerContext, req: RgbDestination) -> Result<EnclaveR
 /// structural half of the M-01/#69 fix — the bridge `SignPsbt` (RgbDestination)
 /// path can no longer be reached by omitting its fields.
 fn handle_sign_btc(ctx: &ServerContext, req: SignBtcRequest) -> Result<EnclaveResponse> {
+    // Authoritative posture check: in a production enclave the plain-BTC path is
+    // only reachable when the attested policy enables it (audit C-01). This is
+    // the same predicate `validate_btc_request` enforces via the BTC pins, but
+    // sourced from the single resolved policy rather than re-derived here — and
+    // the enabled/disabled state is committed into attestation `user_data`.
+    if let crate::policy::SecurityPolicy::Production(p) = &ctx.policy {
+        if !p.allow_vanilla_psbt {
+            return Err(EnclaveError::Signing(
+                "plain-BTC (vanilla) signing is disabled by the enclave's production security \
+                 policy (BTC_ALLOWED_SCRIPTS / BTC_MAX_TOTAL_SATS unset) — refusing to sign"
+                    .into(),
+            ));
+        }
+    }
+
     // Pinned output allowlist + amount cap (skipped only in dev-mode).
     #[cfg(not(feature = "dev-mode"))]
     crate::networks::rgb::btc_crosscheck::validate_btc_request(&req, &ctx.bridge_config)?;

--- a/enclave/tests/common/mod.rs
+++ b/enclave/tests/common/mod.rs
@@ -5,6 +5,7 @@ use std::thread;
 use utexo_bridge_enclave::config::BridgeConfig;
 use utexo_bridge_enclave::framing;
 use utexo_bridge_enclave::networks::rgb::spv::{checkpoint_for, HeaderChain, Network};
+use utexo_bridge_enclave::policy::{BuildContext, EvmDataSource, SecurityPolicy};
 use utexo_bridge_enclave::proto::*;
 use utexo_bridge_enclave::server::{self, ServerContext};
 use utexo_bridge_enclave::state::EnclaveState;
@@ -47,10 +48,10 @@ pub fn start_test_server_with_config(
         Network::Regtest,
         checkpoint_for(Network::Regtest),
     ));
-    let policy = utexo_bridge_enclave::policy::SecurityPolicy::resolve(
-        &utexo_bridge_enclave::policy::BuildContext::current(),
+    let policy = SecurityPolicy::resolve(
+        &BuildContext::current(),
         &bridge_config,
-        utexo_bridge_enclave::policy::EvmDataSource::Disabled,
+        EvmDataSource::Disabled,
     );
     let ctx = Arc::new(ServerContext {
         state,

--- a/enclave/tests/common/mod.rs
+++ b/enclave/tests/common/mod.rs
@@ -47,9 +47,15 @@ pub fn start_test_server_with_config(
         Network::Regtest,
         checkpoint_for(Network::Regtest),
     ));
+    let policy = utexo_bridge_enclave::policy::SecurityPolicy::resolve(
+        &utexo_bridge_enclave::policy::BuildContext::current(),
+        &bridge_config,
+        utexo_bridge_enclave::policy::EvmDataSource::Disabled,
+    );
     let ctx = Arc::new(ServerContext {
         state,
         bridge_config,
+        policy,
         #[cfg(feature = "rgb-validation")]
         rgb_validator: None,
         #[cfg(feature = "evm-rpc")]

--- a/enclave/tests/test_attested_pubkey.rs
+++ b/enclave/tests/test_attested_pubkey.rs
@@ -56,6 +56,16 @@ fn canonical_bundle(keys: &PublicKeysResponse) -> Vec<u8> {
     out
 }
 
+/// The commitment the enclave actually produces: sha256(pubkey_bundle ||
+/// policy_commitment) (audit C-01). These tests run in a debug build with
+/// `mock-attestation`, so the enclave resolves to the `Development` policy;
+/// mirror that here so the parity check matches byte-for-byte.
+fn expected_user_data(keys: &PublicKeysResponse) -> [u8; 32] {
+    let mut preimage = canonical_bundle(keys);
+    preimage.extend_from_slice(&attestation_verify::AttestedPolicy::Development.to_bytes());
+    Sha256::digest(preimage).into()
+}
+
 fn request_attested(port: u16, nonce: &[u8]) -> GetAttestedPublicKeyResponse {
     let resp = send_request(
         port,
@@ -92,12 +102,12 @@ fn attested_pubkey_happy_path_binds_evm_pubkey_and_commitment() {
     // The NSM `public_key` field MUST be the bridge's EVM uncompressed pubkey.
     assert_eq!(verified.enclave_pubkey, public_keys.evm_uncompressed_pub);
 
-    // The NSM `user_data` field MUST be sha256 of the canonical bundle.
-    let expected_commitment: [u8; 32] = Sha256::digest(canonical_bundle(&public_keys)).into();
+    // The NSM `user_data` field MUST be sha256(canonical_bundle || policy).
+    let expected_commitment = expected_user_data(&public_keys);
     assert_eq!(
         verified.user_data.as_deref(),
         Some(expected_commitment.as_slice()),
-        "user_data must be sha256(canonical_bundle)"
+        "user_data must be sha256(canonical_bundle || policy_commitment)"
     );
 
     // Nonce echoed.
@@ -233,11 +243,11 @@ fn attested_bundle_verifies_unmodified_and_tampering_is_rejected() {
     )
     .expect("enclave-built bundle verifies without adaptation");
 
-    let good_commitment: [u8; 32] = Sha256::digest(canonical_bundle(&public_keys)).into();
+    let good_commitment = expected_user_data(&public_keys);
     assert_eq!(
         verified.user_data.as_deref(),
         Some(good_commitment.as_slice()),
-        "canonical-serialization parity: attested user_data == sha256(canonical_bundle)"
+        "canonical-serialization parity: attested user_data == sha256(canonical_bundle || policy)"
     );
 
     // (2) Tampered bundle rejected: flipping a single byte of any committed

--- a/parent/src/attest_verify.rs
+++ b/parent/src/attest_verify.rs
@@ -9,6 +9,7 @@
 //! by the binary against an in-process parent + enclave stack.
 
 use anyhow::{bail, Context, Result};
+use attestation_verify::{AttestationMode, AttestedPolicy, BtcDataSource, EvmDataSource};
 use rand::RngCore;
 use sha2::{Digest, Sha256};
 
@@ -21,6 +22,26 @@ use crate::grpc_proto::{AttestedPublicKeyRequest, AttestedPublicKeyResponse};
 pub enum VerifyMode {
     Real,
     Mock,
+}
+
+/// The security posture the caller expects the attested enclave to have (audit
+/// C-01). The enclave commits its resolved posture into `user_data`; the
+/// verifier reconstructs the *expected* posture here and requires the commitment
+/// to match, so a downgraded enclave (vanilla signing on, a raw instead of
+/// Helios-verified data source, a dev build) is rejected rather than trusted.
+///
+/// The chain/contract/asset pins are taken from the wire response (already bound
+/// by the public-key bundle), so a production expectation only states the
+/// posture flags.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExpectedPolicy {
+    /// Expect a production bridge enclave with these posture flags.
+    Production {
+        allow_vanilla_psbt: bool,
+        evm_source: EvmDataSource,
+    },
+    /// Expect a dev/mock enclave (e.g. behind `--mock`). Never for production.
+    Development,
 }
 
 /// Successful verification result. The presence of this value is the
@@ -73,6 +94,7 @@ pub async fn verify_attested_pubkey(
     endpoint: &str,
     expected_pcrs: attestation_verify::ExpectedPcrs,
     mode: VerifyMode,
+    expected_policy: ExpectedPolicy,
 ) -> Result<AttestedPubkeyResult> {
     let mut nonce = [0u8; 32];
     rand::thread_rng().fill_bytes(&mut nonce);
@@ -112,15 +134,24 @@ pub async fn verify_attested_pubkey(
         );
     }
 
-    let bundle = canonical_bundle(&response);
-    let bundle_commitment: [u8; 32] = Sha256::digest(&bundle).into();
+    // The enclave commits to sha256(pubkey_bundle || policy_commitment) (audit
+    // C-01). Reconstruct the expected policy — pins from the wire response,
+    // posture flags from `expected_policy` — and require the whole commitment to
+    // match. A mismatch means the attested posture is not the one the operator
+    // expects (downgraded data source, vanilla signing on, a dev build, …).
+    let attested_policy = expected_attested_policy(&expected_policy, &response)?;
+    let mut preimage = canonical_bundle(&response);
+    preimage.extend_from_slice(&attested_policy.to_bytes());
+    let bundle_commitment: [u8; 32] = Sha256::digest(&preimage).into();
     let user_data = verified
         .user_data
         .as_deref()
         .context("attestation has no user_data field")?;
     if user_data != bundle_commitment {
         bail!(
-            "attestation `user_data` ({}) does not match sha256(canonical_bundle) ({})",
+            "attestation `user_data` ({}) does not match sha256(canonical_bundle || policy) ({}) \
+             for the expected policy {expected_policy:?} — the enclave's attested public keys or \
+             security posture differ from what was expected",
             hex::encode(user_data),
             hex::encode(bundle_commitment),
         );
@@ -132,4 +163,44 @@ pub async fn verify_attested_pubkey(
         bundle_commitment,
         nonce_sent: nonce,
     })
+}
+
+/// Build the [`AttestedPolicy`] the verifier expects the enclave to have
+/// committed, combining the operator-declared posture ([`ExpectedPolicy`]) with
+/// the pins from the wire response (which the pubkey bundle already binds). MUST
+/// produce the same bytes the enclave's `SecurityPolicy::commitment_bytes` does.
+fn expected_attested_policy(
+    expected: &ExpectedPolicy,
+    resp: &AttestedPublicKeyResponse,
+) -> Result<AttestedPolicy> {
+    match expected {
+        ExpectedPolicy::Development => Ok(AttestedPolicy::Development),
+        ExpectedPolicy::Production {
+            allow_vanilla_psbt,
+            evm_source,
+        } => {
+            let bridge_contract: [u8; 20] = resp
+                .bridge_contract
+                .as_slice()
+                .try_into()
+                .with_context(|| {
+                    format!(
+                        "wire bridge_contract is {} bytes, expected 20 (is this really a \
+                         production bridge enclave?)",
+                        resp.bridge_contract.len()
+                    )
+                })?;
+            Ok(AttestedPolicy::Production {
+                allow_vanilla_psbt: *allow_vanilla_psbt,
+                // A real-verified production enclave always uses real (NSM)
+                // attestation; SPV is the only Bitcoin anchor source.
+                attestation: AttestationMode::Real,
+                evm_source: *evm_source,
+                btc_source: BtcDataSource::SpvVerified,
+                chain_id: resp.chain_id,
+                bridge_contract,
+                rgb_asset_id: resp.rgb_asset_id.clone(),
+            })
+        }
+    }
 }

--- a/parent/src/bin/attest_verify.rs
+++ b/parent/src/bin/attest_verify.rs
@@ -22,8 +22,9 @@ use std::process::ExitCode;
 use anyhow::{Context, Result};
 use clap::Parser;
 
+use attestation_verify::EvmDataSource;
 use utexo_bridge_parent::attest_verify::{
-    verify_attested_pubkey, AttestedPubkeyResult, VerifyMode,
+    verify_attested_pubkey, AttestedPubkeyResult, ExpectedPolicy, VerifyMode,
 };
 
 #[derive(Parser)]
@@ -50,8 +51,35 @@ struct Cli {
 
     /// Verify a mock-attestation document (zero PCRs, no COSE wrapping).
     /// For dev/CI only. Real production verification MUST NOT use this flag.
+    /// Implies the expected security policy is `Development` (audit C-01).
     #[arg(long)]
     mock: bool,
+
+    /// Expect the enclave to enable the plain-BTC (vanilla / create_utxo)
+    /// signing path. Default: expect it DISABLED (fail-closed). Ignored with
+    /// --mock. Audit C-01: this posture is committed into attestation user_data.
+    #[arg(long)]
+    expect_vanilla_psbt: bool,
+
+    /// Expected EVM `FundsIn` deposit-verification data source the enclave must
+    /// have committed to: `raw` (host-relayed RPC), `helios` (trustless,
+    /// checkpoint-verified), or `disabled`. Defaults to `raw` — the source the
+    /// shipped image uses. Pass `helios` to require the trustless path and fail
+    /// verification if the enclave is only on raw RPC. Ignored with --mock.
+    #[arg(long, default_value = "raw")]
+    expect_evm_source: String,
+}
+
+/// Parse the `--expect-evm-source` flag into an [`EvmDataSource`].
+fn parse_evm_source(s: &str) -> Result<EvmDataSource> {
+    match s.to_ascii_lowercase().as_str() {
+        "raw" | "raw-rpc" | "rawrpc" => Ok(EvmDataSource::RawRpc),
+        "helios" | "helios-verified" => Ok(EvmDataSource::HeliosVerified),
+        "disabled" | "none" | "off" => Ok(EvmDataSource::Disabled),
+        other => anyhow::bail!(
+            "invalid --expect-evm-source '{other}' (expected: raw | helios | disabled)"
+        ),
+    }
 }
 
 #[tokio::main]
@@ -68,21 +96,32 @@ async fn main() -> ExitCode {
 }
 
 async fn run(cli: Cli) -> Result<()> {
-    let (expected_pcrs, mode) = if cli.mock {
+    let (expected_pcrs, mode, expected_policy) = if cli.mock {
         eprintln!(
             "warning: --mock skips COSE/cert-chain checks; do NOT use against production enclaves"
         );
-        (attestation_verify::ExpectedPcrs::zero(), VerifyMode::Mock)
+        (
+            attestation_verify::ExpectedPcrs::zero(),
+            VerifyMode::Mock,
+            // A mock/dev enclave resolves to the Development posture.
+            ExpectedPolicy::Development,
+        )
     } else {
         let pcr0 = cli.pcr0.context("--pcr0 required (or pass --mock)")?;
         let pcr1 = cli.pcr1.context("--pcr1 required (or pass --mock)")?;
         let pcr2 = cli.pcr2.context("--pcr2 required (or pass --mock)")?;
         let pcrs = attestation_verify::ExpectedPcrs::from_hex(&pcr0, &pcr1, &pcr2)
             .context("invalid PCR hex")?;
-        (pcrs, VerifyMode::Real)
+        let expected_policy = ExpectedPolicy::Production {
+            allow_vanilla_psbt: cli.expect_vanilla_psbt,
+            evm_source: parse_evm_source(&cli.expect_evm_source)?,
+        };
+        (pcrs, VerifyMode::Real, expected_policy)
     };
 
-    let result = verify_attested_pubkey(&cli.endpoint, expected_pcrs, mode).await?;
+    eprintln!("expecting security policy: {expected_policy:?}");
+    let result =
+        verify_attested_pubkey(&cli.endpoint, expected_pcrs, mode, expected_policy).await?;
     print_ok(&result);
     Ok(())
 }

--- a/parent/tests/test_attest_verify_e2e.rs
+++ b/parent/tests/test_attest_verify_e2e.rs
@@ -13,11 +13,12 @@ use std::sync::Arc;
 
 use tonic::transport::Server;
 
+use attestation_verify::EvmDataSource;
 use utexo_bridge_enclave::config::BridgeConfig;
 use utexo_bridge_enclave::networks::rgb::spv::{checkpoint_for, HeaderChain, Network};
 use utexo_bridge_enclave::server::{self as enclave_server, ServerContext};
 use utexo_bridge_enclave::state::EnclaveState;
-use utexo_bridge_parent::attest_verify::{verify_attested_pubkey, VerifyMode};
+use utexo_bridge_parent::attest_verify::{verify_attested_pubkey, ExpectedPolicy, VerifyMode};
 use utexo_bridge_parent::grpc_proto::parent_service_server::ParentServiceServer;
 use utexo_bridge_parent::grpc_server::{EnclaveTarget, ParentAdapterService};
 
@@ -90,6 +91,8 @@ async fn e2e_attest_verify_succeeds_against_live_stack() {
         &format!("http://127.0.0.1:{grpc_port}"),
         attestation_verify::ExpectedPcrs::zero(),
         VerifyMode::Mock,
+        // The in-process enclave is a debug/mock build => Development posture.
+        ExpectedPolicy::Development,
     )
     .await
     .expect("end-to-end verification succeeds");
@@ -132,6 +135,7 @@ async fn e2e_attest_verify_fails_on_pcr_mismatch() {
         &format!("http://127.0.0.1:{grpc_port}"),
         wrong_pcrs,
         VerifyMode::Mock,
+        ExpectedPolicy::Development,
     )
     .await
     .expect_err("PCR0 mismatch must fail verification");
@@ -156,6 +160,7 @@ async fn e2e_attest_verify_fails_on_real_path_against_mock_enclave() {
         &format!("http://127.0.0.1:{grpc_port}"),
         attestation_verify::ExpectedPcrs::zero(),
         VerifyMode::Real, // <- real path against mock doc
+        ExpectedPolicy::Development,
     )
     .await
     .expect_err("real verifier must reject a mock document");
@@ -174,6 +179,7 @@ async fn e2e_attest_verify_fails_on_unreachable_endpoint() {
         "http://127.0.0.1:1", // nothing listening here
         attestation_verify::ExpectedPcrs::zero(),
         VerifyMode::Mock,
+        ExpectedPolicy::Development,
     )
     .await
     .expect_err("connection to dead port must fail");
@@ -185,5 +191,34 @@ async fn e2e_attest_verify_fails_on_unreachable_endpoint() {
             || msg.contains("Connection")
             || msg.contains("transport"),
         "expected connection error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn e2e_attest_verify_fails_on_policy_mismatch() {
+    // The in-process enclave is a debug/mock build, so it attests the
+    // `Development` posture. A verifier that expects a *production* enclave must
+    // reject it: the committed policy differs, so the user_data commitment no
+    // longer matches. This is the C-01 property — the security posture is one
+    // attested value the verifier checks, not something inferred out of band.
+    let enclave_port = start_real_enclave();
+    let grpc_port = start_real_parent_grpc(enclave_port).await;
+
+    let err = verify_attested_pubkey(
+        &format!("http://127.0.0.1:{grpc_port}"),
+        attestation_verify::ExpectedPcrs::zero(),
+        VerifyMode::Mock,
+        ExpectedPolicy::Production {
+            allow_vanilla_psbt: false,
+            evm_source: EvmDataSource::RawRpc,
+        },
+    )
+    .await
+    .expect_err("expecting a production policy against a dev enclave must fail");
+
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("user_data") || msg.contains("security posture") || msg.contains("policy"),
+        "expected a policy/user_data mismatch error, got: {msg}"
     );
 }


### PR DESCRIPTION
## What

Closes the systemic half of audit finding **C-01** (issue #154): the enclave now has **one explicit security policy**, resolved once at boot, that a verifier checks as a single attested value — instead of reconstructing the posture at runtime from build features, empty `BridgeConfig` fields, request shape, and which chain-verification components happened to be wired up.

## The policy object

`SecurityPolicy` (`enclave/src/policy.rs`) is `Production { … }` or `Development { reason }`. A `Production` policy carries everything the finding asked for in one place:

- **signing modes** — `allow_vanilla_psbt` (derived from the BTC pins, default fail-closed)
- **chain/contract/asset pins** — `chain_id`, `bridge_contract`, `rgb_asset_id`
- **expected attestation** — `AttestationMode::Real` (mock is a `compile_error!` in release)
- **allowed data sources** — `evm_source` (disabled / raw-RPC / Helios-verified) and `btc_source` (SPV)

It is resolved once in `main.rs` via `SecurityPolicy::resolve(BuildContext, BridgeConfig, EvmDataSource)`.

## Fail-closed at boot

`assert_valid_for_build` panics at boot for any release `rgb-validation` build that does not resolve to a valid `Production` policy (unpinned, partially pinned, or carrying a dev feature). This supersedes `BridgeConfig::assert_configured_in_release` and mirrors the existing placeholder-checkpoint boot gate.

## Attested as one value

`user_data` now commits to `sha256(canonical_pubkey_bundle || policy_commitment)`. The canonical encoding is shared (`attestation-verify/src/policy.rs`) so the enclave and every verifier produce identical bytes. The parent verifier (`verify_attested_pubkey`) and the `attest-verify` CLI reconstruct the **expected** policy and require the commitment to match — so an enclave that shipped with a downgraded posture (vanilla signing on, raw instead of Helios-verified RPC, a dev build) now **fails** verification instead of being silently trusted. New CLI flags: `--expect-evm-source`, `--expect-vanilla-psbt`.

## Tests

- Unit tests for `resolve` / boot gate / commitment across every posture (`enclave/src/policy.rs`, `attestation-verify/src/policy.rs`).
- New e2e test `e2e_attest_verify_fails_on_policy_mismatch` — expecting a production policy against a dev enclave fails.
- Updated the attested-pubkey and e2e commitment checks to the new format.
- The existing `release-guards` / `feature-guards` CI jobs already reject each dangerous feature in a release build.

Verified locally across default / spv / evm-rpc / helios / mock-attestation / minimal feature combinations (build + clippy `-D warnings` + tests).

Docs: `docs/pubkey-attestation.md` updated with the new commitment format and CLI usage.
