### PR TITLE
docs: refresh architecture and sequence diagrams to the current code

### DIFF
--- a/docs/diagrams/01-components.md
+++ b/docs/diagrams/01-components.md
@@ -10,59 +10,58 @@ flowchart TB
     %% parent crate
     subgraph PARENT [parent crate — utexo-bridge-parent]
         PMain[main.rs<br/>gRPC server tonic, 127.0.0.1]
-        Grpc[grpc_server.rs<br/>ParentAdapterService<br/>gRPC ↔ enclave wire]
+        Grpc[grpc_server.rs<br/>ParentAdapterService — gRPC ↔ enclave wire<br/>TRANSACTION → Sign, EVM_GAS_TX → SignRawDigest,<br/>BTC_UTXO → SignBtc]
         PClient[client.rs<br/>EnclaveClient<br/>TCP / vsock]
         PFr[framing.rs<br/>u32 LE len + protobuf]
-        PALib[attest_verify.rs<br/>library half of CLI]
+        PALib[attest_verify.rs<br/>library half of CLI —<br/>rebuilds expected policy + bundle]
         PCli[bin/cli.rs<br/>utexo-bridge-parent-cli]
-        AVCli[bin/attest_verify.rs<br/>attest-verify CLI]
+        AVCli[attest-verify CLI<br/>--pcr0/1/2, --expect-vanilla-psbt,<br/>--expect-evm-source raw or helios or disabled]
         PMisc[config.rs / error.rs]
     end
 
     %% attestation-verify shared crate
     subgraph ATTV [attestation-verify crate — shared]
-        AV[verify_attestation<br/>COSE_Sign1 + AWS Nitro<br/>cert chain + PCRs]
+        AV[verify_attestation<br/>COSE_Sign1, alg pinned ES384, raw 96-byte sig,<br/>cert chain + CA constraints + PCR0/1/2]
+        AVPol[policy.rs<br/>AttestedPolicy — canonical policy<br/>commitment encoding v1, audit C-01]
         AVMock[verify_mock_attestation<br/>feature 'mock']
-        AVBuild[build_mock_document<br/>feature 'mock']
         Root[Embedded AWS Nitro<br/>root CA PEM]
     end
 
     %% enclave crate
     subgraph ENC [enclave crate — utexo-bridge-enclave]
-        EMain[main.rs<br/>listener loop<br/>vsock / TCP]
-        ESrv[server.rs<br/>ServerContext + handler dispatch]
-        EState[state.rs<br/>EnclaveState<br/>Phase Initial/Cloning/Active<br/>+ NonceReplayGuard]
-        EFr[framing.rs<br/>len-prefixed proto, 4 MB cap]
-        EErr[error.rs<br/>EnclaveError + error_code]
-        BCfg[config.rs<br/>BridgeConfig env-pinned<br/>chain_id / contract / rgb_asset_id]
+        EMain[main.rs<br/>boot: resolve SecurityPolicy — a release<br/>bridge build panics unless valid Production —<br/>then listener loop vsock / TCP]
+        EConn[conn.rs<br/>DeadlineStream 10 s idle / 30 s total<br/>4 worker threads, queue of 16]
+        ESrv[server.rs<br/>ServerContext + handler dispatch<br/>+ SubmitHeaders rate limiter]
+        EPol[policy.rs<br/>SecurityPolicy C-01<br/>Production / Development,<br/>resolved once at boot]
+        EState[state.rs<br/>Phase Initial / Cloning / Active<br/>NonceReplayGuard 1 h TTL<br/>op_replay_guard 24 h TTL]
+        EFr[framing.rs<br/>len-prefixed proto, 4 MiB cap]
+        BCfg[config.rs — BridgeConfig env pins<br/>EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID<br/>GAS_TX_ALLOWED_TO / FUNDS_IN_CONTRACT<br/>BTC_ALLOWED_SCRIPTS / BTC_MAX_TOTAL_SATS]
         VFwd[vsock_forwarder.rs<br/>loopback → vsock, per-port instances<br/>3443→8001 Esplora, 3444→8002 EVM RPC,<br/>18545→8003 / 18550→8004 Helios]
+        KM[keys.rs — KeyManager<br/>BIP-39/32/44/84/86<br/>SecretBox seed + keys]
 
-        subgraph KEYS [keys.rs]
-            KM[KeyManager<br/>BIP-39/32/84/86<br/>SecretBox seed + keys]
+        subgraph NEVM [networks/evm/]
+            NEV[validation.rs<br/>selector allowlist 0xccddb768,<br/>canonical ABI decode + re-encode,<br/>64 KiB cap, pins, deadline]
+            NEC[crosscheck.rs<br/>witnesses-confirmed, BtcRelay proof,<br/>consignment amount bind]
+            NEE[evm_event.rs<br/>independent FundsIn verify —<br/>alloy raw RPC or Helios in-TEE]
+            NEG[gas_tx.rs<br/>gas-tx preimage allowlist:<br/>strict RLP + chain / to pins]
+            NES[signing.rs<br/>EIP-712 MultisigProxy v1<br/>BridgeOperation digest]
         end
-        subgraph SIGN [signing/]
-            SE[evm.rs<br/>EIP-712 domain + digest]
-            SP[psbt.rs<br/>P2WSH segwit-v0<br/>anchor: script_pubkey]
-            ST[taproot.rs<br/>BIP-341 script-path<br/>verify_taproot_commitment]
-        end
-        subgraph VAL [validation/]
-            VEvm[evm_crosscheck.rs<br/>selector allowlist + pinned-config<br/>amount bound to consignment<br/>funds_out burn/transfer]
-            VPsbt[psbt_crosscheck.rs<br/>bridge vs vanilla<br/>amount + consignment bind]
-            VRgb[rgb.rs<br/>rgbstd Transfer<br/>+ Esplora resolver]
-            VSpv[spv_crosscheck.rs<br/>coverage + depth<br/>+ chain_net + staleness]
-            VEvt[evm_event.rs<br/>independent FundsIn verify<br/>alloy #60 / Helios #77<br/>evm-rpc / helios features]
-            VGas[evm_gas_tx.rs<br/>gas-tx shape allowlist]
-        end
-        subgraph SPVMOD [spv/]
-            SCh[chain.rs<br/>HeaderChain<br/>bounded reorg ≤100]
-            SCp[checkpoint.rs<br/>compile-time anchors → PCR0]
-            SMk[merkle.rs<br/>Bitcoin merkle proof]
-            SVal[validation.rs<br/>linkage + PoW + nBits]
-            STy[types.rs<br/>Network, SpvError]
+        subgraph NRGB [networks/rgb/]
+            NRV[validation.rs<br/>rgbstd Transfer + Esplora resolver,<br/>typesystem pinned per schema]
+            NRP[psbt_validation.rs<br/>PSBT ↔ consignment anchor,<br/>fee-rate 3x cap]
+            NRB[btc_crosscheck.rs<br/>plain-BTC output allowlist<br/>+ total-sats cap]
+            NRS[spv_validation.rs<br/>coverage + depth ≥ 6<br/>+ chain_net + staleness]
+            NRSIG[signing/<br/>psbt.rs P2WSH ECDSA<br/>taproot.rs BIP-341 Schnorr]
+            subgraph SPVMOD [spv/]
+                SCh[chain.rs — HeaderChain<br/>full retention, 1M cap,<br/>bounded reorg ≤ 100]
+                SCp[checkpoint.rs<br/>compile-time anchors → PCR0]
+                SMk[merkle.rs]
+                SVal[validation.rs<br/>linkage + PoW + nBits]
+            end
         end
         subgraph ATTGRP [attestation + cloning]
             AF[attestation.rs<br/>NSM facade<br/>+ verify_peer_attestation]
-            CL[cloning.rs<br/>CloneSession<br/>X25519 + HKDF-SHA256<br/>+ ChaCha20Poly1305]
+            CL[cloning.rs<br/>X25519 + HKDF-SHA256<br/>+ ChaCha20Poly1305]
         end
     end
 
@@ -74,60 +73,62 @@ flowchart TB
     VPe[(host vsock-proxy<br/>8002 / 8003 / 8004)]
 
     %% Wires
-    L -->|"gRPC EnclaveService<br/>Sign / PublicKey / Initialize / Clone /<br/>SubmitHeaders / GetLastSavedBlock /<br/>AttestedPublicKey"| PMain
+    L -->|"gRPC EnclaveService<br/>Sign / SignBtc / SignRawDigest / SignRawMessage /<br/>PublicKey / Initialize / Clone /<br/>SubmitHeaders / GetLastSavedBlock /<br/>AttestedPublicKey"| PMain
     Op --> PCli
-    V -->|"--pcr0/1/2 + endpoint"| AVCli
+    V --> AVCli
     PCli --> PClient
     AVCli --> PALib
     PALib -->|"verify_attestation()"| AV
+    PALib -->|"expected policy commitment"| AVPol
     PALib -->|"feature mock"| AVMock
 
     PMain --> Grpc
     Grpc --> PFr
     Grpc -.->|"u32 LE len + EnclaveRequest<br/>TCP 127.0.0.1:5000 or vsock CID 16:5000"| EFr
 
-    EMain -->|"ServerContext: state, header_chain, rgb_validator"| ESrv
+    EMain --> EPol
+    EMain --> EConn
+    EConn --> ESrv
     ESrv --> EFr
     ESrv --> EState
-    ESrv --> VEvm
-    ESrv --> VPsbt
-    ESrv --> VRgb
-    ESrv --> VSpv
+    ESrv --> NEV
+    ESrv --> NEC
+    ESrv --> NEE
+    ESrv --> NEG
+    ESrv --> NRV
+    ESrv --> NRP
+    ESrv --> NRB
+    ESrv --> NRS
     ESrv -->|"InitiateCloning / GetClone / SetClone /<br/>GetAttestedPublicKey"| AF
     ESrv --> CL
     ESrv -->|"SubmitHeaders / lookup"| SCh
 
     EState -->|"Phase::Active(km)"| KM
-    KM --> SE
-    KM --> SP
-    KM --> ST
+    KM --> NES
+    KM --> NRSIG
 
-    VRgb -->|"esplora_blocking via localhost:3443"| Esp
-    VRgb -.->|"HTTP"| VFwd
+    NRV -->|"esplora_blocking via localhost:3443,<br/>30 s timeout"| VFwd
     VFwd -->|"vsock CID 3:8001"| VP
     VP -->|"real HTTP"| Esp
 
-    ESrv --> VEvt
-    ESrv --> VGas
-    VEvt -.->|"eth_getTransactionReceipt /<br/>eth_blockNumber (host-relayed evidence,<br/>Helios-verified in #77)"| VFwd
+    NEE -.->|"eth_getTransactionReceipt /<br/>eth_blockNumber — host-relayed evidence,<br/>or Helios-verified in-TEE"| VFwd
     VFwd -->|"vsock 8002 / 8003 / 8004"| VPe
     VPe -->|"real HTTP"| EvmRpc
 
-    VSpv --> SCh
-    VSpv --> SMk
+    NRS --> SCh
+    NRS --> SMk
     SCh --> SVal
     SCh --> SCp
-    SCh --> STy
 
     AF -->|"Linux only — Request::Attestation /<br/>DescribePCR"| NSM
     AF -->|"peer verification (real)"| AV
     AF -->|"peer verification (mock)"| AVMock
-    AF --> AVBuild
     CL -.->|"ephemeral pubkey ↔ attestation user_data"| AF
     AV --> Root
 
-    EErr -->|"From<SpvError>"| STy
-
-    BCfg -->|"pinned chain/contract/asset cross-check"| VEvm
-    BCfg -.->|"folded into canonical bundle<br/>(attestation user_data)"| AF
+    BCfg -->|"pinned chain / contract / asset cross-check"| NEV
+    BCfg -->|"gas-tx to-pin"| NEG
+    BCfg -->|"BTC allowlist + cap"| NRB
+    BCfg --> EPol
+    EPol -.->|"user_data = sha256(pubkey_bundle ‖<br/>policy commitment) — C-01"| AF
 ```

--- a/docs/diagrams/01-components.md
+++ b/docs/diagrams/01-components.md
@@ -73,7 +73,7 @@ flowchart TB
     VPe[(host vsock-proxy<br/>8002 / 8003 / 8004)]
 
     %% Wires
-    L -->|"gRPC EnclaveService<br/>Sign / SignBtc / SignRawDigest / SignRawMessage /<br/>PublicKey / Initialize / Clone /<br/>SubmitHeaders / GetLastSavedBlock /<br/>AttestedPublicKey"| PMain
+    L -->|"gRPC ParentService<br/>Sign (data_type TRANSACTION /<br/>EVM_GAS_TX / BTC_UTXO) /<br/>PublicKey / Initialize / Clone /<br/>SubmitHeaders / GetLastSavedBlock /<br/>AttestedPublicKey"| PMain
     Op --> PCli
     V --> AVCli
     PCli --> PClient

--- a/docs/diagrams/02-deployment.md
+++ b/docs/diagrams/02-deployment.md
@@ -17,10 +17,10 @@ flowchart TB
         VPe["vsock-proxy 8002 / 8003 / 8004<br/>―<br/>evm-rpc / helios builds only.<br/>8002 → EVM JSON-RPC #60.<br/>8003 / 8004 → Helios exec / consensus #77.<br/>Allowlisted per upstream."]
 
         subgraph ENCL [AWS Nitro Enclave — TRUSTED, PCR-pinned]
-            Bin[utexo-bridge-enclave<br/>static-linked Rust<br/>―<br/>Listens on vsock CID 16, port 5000.<br/>One connection = one request.<br/>No filesystem persistence.<br/>No shell. No /dev access except /dev/nsm.<br/>Bridge config pinned from env at boot<br/>EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID<br/>→ bound into attestation.]
+            Bin[utexo-bridge-enclave<br/>static-linked Rust<br/>―<br/>Listens on vsock CID 16, port 5000.<br/>One connection = one request;<br/>4 worker threads, queue of 16,<br/>10 s idle / 30 s total deadlines.<br/>No filesystem persistence.<br/>No shell. No /dev access except /dev/nsm.<br/>Env pins read at boot:<br/>EVM_CHAIN_ID / BRIDGE_CONTRACT / RGB_ASSET_ID<br/>GAS_TX_ALLOWED_TO / FUNDS_IN_CONTRACT<br/>BTC_ALLOWED_SCRIPTS / BTC_MAX_TOTAL_SATS<br/>→ SecurityPolicy resolved once, committed<br/>into attestation user_data C-01.<br/>Release bridge build refuses to boot<br/>unless the policy is valid Production.]
             Headers[(Header chain<br/>in-memory)]
             State[(EnclaveState<br/>Phase + KeyManager in SecretBox)]
-            Replay[(NonceReplayGuard<br/>≤10 000 entries)]
+            Replay[(NonceReplayGuard — cloning<br/>≤10 000 entries, 1 h TTL<br/>+ op_replay_guard — bridge ops<br/>≤100 000 entries, 24 h TTL)]
             Fwd[vsock_forwarder<br/>loopback → vsock, per-port<br/>3443/3444/18545/18550]
             RgbVal[RgbValidator<br/>rgbstd + Esplora HTTP]
             EvmVer[evm_event verifier<br/>alloy #60 / Helios #77<br/>fail-closed FundsIn check]

--- a/docs/diagrams/02-deployment.md
+++ b/docs/diagrams/02-deployment.md
@@ -31,7 +31,7 @@ flowchart TB
     Esp{{Esplora API}}
     EvmRpc{{EVM JSON-RPC / Helios<br/>exec + consensus upstreams}}
 
-    V -->|"gRPC /50051<br/>AttestedPublicKey(nonce)"| Parent
+    V -->|"gRPC /5000 (GRPC_PORT)<br/>AttestedPublicKey(nonce)"| Parent
     L -->|"gRPC /5000<br/>Sign / PublicKey / SubmitHeaders ..."| Parent
     Cli -->|"direct enclave RPC (dev/ops only)<br/>TCP 127.0.0.1:5000 or vsock CID 16:5000"| ENCL
 

--- a/docs/diagrams/03-seq-sign-evm.md
+++ b/docs/diagrams/03-seq-sign-evm.md
@@ -1,80 +1,87 @@
-# Sign EVM (RGB → EVM unlock) — full path with cross-checks
+# Sign (RGB → EVM unlock, `fundsOut`) — full path with cross-checks
 
 ```mermaid
 sequenceDiagram
     actor Orc as Orchestrator
     participant Listener as Go Listener
     participant Parent as utexo-bridge-parent<br/>(grpc_server.rs)
-    participant Srv as enclave/server.rs<br/>handle_sign_evm
-    participant Rgb as validation::rgb<br/>RgbValidator
-    participant Evm as validation::evm_crosscheck
-    participant Spv as validation::spv_crosscheck
+    participant Srv as enclave/server.rs<br/>handle_sign
+    participant Rgb as networks::rgb::validation<br/>RgbValidator
+    participant Spv as networks::rgb::spv_validation
     participant Chain as spv::HeaderChain
     participant Esplora as vsock_forwarder →<br/>Esplora
-    participant Sign as signing::evm<br/>+ KeyManager
+    participant Evm as networks::evm::validation
+    participant Cx as networks::evm::crosscheck
+    participant Sign as networks::evm::signing<br/>+ KeyManager
 
     Note over Orc,Listener: Intent
     Orc->>Listener: signing intent (op, calldata)
-    Listener->>Listener: enrich (chain_id, proxy_contract, rgb_amount, consignment, merkle_proofs)
-    Listener->>Parent: gRPC EnclaveService.Sign(SWAP, EnrichedEvmPayload)
+    Listener->>Listener: enrich (chain_id, proxy_contract, consignment, merkle_proofs)
+    Listener->>Parent: gRPC EnclaveService.Sign(TRANSACTION, enriched payload)
 
     Note over Parent,Srv: Translate gRPC → enclave wire
-    Parent->>Parent: decode EnrichedEvmPayload
-    Parent->>Srv: SignEvmRequest (TCP/vsock, length-prefixed proto)
+    Parent->>Srv: Sign{source_network: RgbSource,<br/>destination_network: EvmDestination}<br/>(TCP/vsock, length-prefixed proto)
 
-    Note over Srv: Build-skew guard
-    Srv->>Srv: cfg(not "spv") AND !merkle_proofs.is_empty() ⇒ REJECT
-
-    Note over Srv,Esplora: In-enclave RGB validation
-    Srv->>Rgb: validate_consignment(bytes)
-    Rgb->>Rgb: Transfer::load(...), extract chain_net + witness_txids
-    Rgb->>Esplora: esplora_blocking GET /tx/.../merkle-proof
+    Note over Srv,Esplora: 1 — validate_source (RGB, skipped under dev-mode)
+    Srv->>Rgb: validate_source(RgbSource)
+    Rgb->>Rgb: cheap payload gate first (W-04):<br/>consignment bytes present,<br/>keccak256(consignment) == consignment_hash (integrity),<br/>asset_id declared
+    Rgb->>Rgb: Transfer::load(...), extract chain_net + witness_txids<br/>+ last transition + burned/total amounts
+    Rgb->>Rgb: trusted typesystem pinned per schema_id (W-09),<br/>unknown schema ⇒ REFUSE
+    Rgb->>Esplora: esplora_blocking (30 s timeout)
     Esplora-->>Rgb: witness tx data
-    Rgb->>Rgb: rgbstd::validate(...)
-    Rgb-->>Srv: ValidatedConsignment (contract_id, witness_txids, chain_net)
-    alt rgb_asset_id present
-        Srv->>Srv: assert v.contract_id == req.rgb_asset_id
-    end
+    Rgb->>Rgb: rgbstd validate(chain_net, trusted_typesystem)
+    Rgb->>Rgb: contract_id == declared asset_id<br/>(== pinned RGB_ASSET_ID when configured)
+    Rgb-->>Srv: SourceProof (amount from consignment —<br/>TS_TRANSFER total_output / TS_BURN burned amount —<br/>host rgb_amount is NOT used)
 
-    Note over Srv,Evm: Cross-checks (skipped under dev-mode)
-    Srv->>Evm: validate_evm_request(req, bridge_config)
-    Evm->>Evm: selector ∈ FUNDS_OUT_SELECTORS (legacy 0x1ad880b2 / mint-burn 0x179bef59)
-    Evm->>Evm: consignment bytes present (consignment_valid flag NOT trusted — #47)
-    Evm->>Evm: keccak256(consignment) == consignment_hash
-    Evm->>Evm: legacy: rgb_amount ≥ calldata_amount + commission, offsets 68/100 == declared
-    Evm->>Evm: chain_id > 0 ∧ len(proxy_contract)==20 ∧ deadline > now
-    Evm->>Evm: if bridge_config pinned (#43): chain_id/proxy_contract/rgb_asset_id == env pins
-    Evm-->>Srv: Ok / CrossCheck err
-
-    Note over Srv,Evm: Amount bound to consignment (#44/#47)
-    Srv->>Srv: require validated_consignment for any fundsOut selector
-    Srv->>Evm: validate_funds_out_burn(req, validated)
-    Evm->>Evm: mint-burn: last == TS_BURN ∧ calldata amount@36 ≤ burned_asset_amount
-    Srv->>Evm: validate_funds_out_transfer(req, validated)
-    Evm->>Evm: legacy: last == TS_TRANSFER ∧ amount+commission ≤ total_output_amount
-    Evm-->>Srv: Ok / CrossCheck err
-
-    Note over Srv,Chain: SPV gate (feature = "spv")
-    Srv->>Chain: lock + tip_height/time
-    Srv->>Spv: assert_chain_not_stale(now, 2h)
-    Srv->>Spv: assert_chain_net(consignment, chain.network())
-    Srv->>Spv: validate_spv_proofs(expected_txids, proofs, MIN_CONF=6)
-    Spv->>Spv: set-equality(expected, proofs)
+    Note over Srv,Chain: SPV gate (inside validate_source, feature spv)
+    Srv->>Chain: lock chain
+    Srv->>Spv: assert_chain_not_stale (≤ 2 h old, ≤ 2 h future)
+    Srv->>Spv: assert_chain_net(consignment, enclave network)
+    Srv->>Spv: validate_spv_proofs(witness_txids, proofs)
+    Spv->>Spv: exact set-equality(expected txids, proofs)
     loop each MerkleProofEntry
+        Spv->>Spv: merkle path depth ≤ 32
         Spv->>Chain: header_at(block_height)
-        Spv->>Spv: depth ≥ 6
-        Spv->>Spv: verify_merkle_proof(txid_internal, position, path, root)
+        Spv->>Spv: depth ≥ SPV_MIN_CONFIRMATIONS (6)
+        Spv->>Spv: verify_merkle_proof(txid, position, path, root)
     end
     Spv-->>Srv: Ok / Spv err
 
-    Note over Srv,Sign: Sign
-    Srv->>Sign: build_evm_domain(req)
+    Note over Srv,Evm: 2 — validate_destination (EVM, skipped under dev-mode)
+    Srv->>Evm: validate_destination(EvmDestination)
+    Evm->>Evm: calldata ≥ 4 bytes, ≤ 64 KiB
+    Evm->>Evm: selector == 0xccddb768<br/>fundsOut(address,uint256,uint256,uint256,uint256,string,bytes,bytes)
+    Evm->>Evm: canonical ABI check (W-01): abi_decode_validate,<br/>then re-encode must byte-equal input
+    Evm->>Evm: decoded amount == declared calldata_amount (fits u64)
+    Evm->>Evm: config pinned? chain_id / proxy_contract == env pins<br/>(unconfigured ⇒ REFUSE on bridge builds)
+    Evm->>Evm: deadline strictly in the future
+    Evm-->>Srv: Ok / CrossCheck err
+
+    Note over Srv: 3 — validate_route_proofs
+    Srv->>Srv: source amount (consignment) ≥ destination amount
+
+    Note over Srv,Cx: 4 — apply_funds_out_binding (rgb-validation builds)
+    Srv->>Cx: require validated consignment for any fundsOut
+    Srv->>Cx: assert_witnesses_confirmed (no unmined witness tx)
+    opt calldata proof slot populated (#57/#122)
+        Srv->>Cx: verify_btc_relay_agreement:<br/>decode (blockHeight, commitmentHash),<br/>enclave header at that height must match<br/>(inert while the listener sends an empty proof)
+    end
+    Srv->>Cx: validate_funds_out_transfer:<br/>last transition == TS_TRANSFER AND<br/>consignment total_output ≥ amount read from calldata bytes
+    Note right of Cx: burnId / fundsInIds are preserved as received (#168) —<br/>the in-enclave OpId rewrite exists but is dormant<br/>until flows are routed by network id.<br/>Mint/burn unlock is not wired yet.
+    Cx-->>Srv: Ok / CrossCheck err
+
+    Note over Srv,Sign: 5 — Sign
+    Srv->>Sign: build_evm_domain(chain_id, proxy_contract)<br/>name "MultisigProxy", version "1"<br/>(pinned by contract-fixture test)
     Srv->>Sign: sign_request_digest(domain, calldata, nonce, deadline)
-    Sign->>Sign: keccak256(0x1901 ‖ domSep ‖ structHash)
+    Sign->>Sign: digest = keccak256(0x1901 ‖ domSep ‖<br/>structHash BridgeOperation(selector, callData, nonce, deadline))
     Sign->>Sign: k256 ECDSA sign_prehash_recoverable (r‖s‖v)
     Sign-->>Srv: signature (65 bytes)
 
-    Srv-->>Parent: EvmSignatureResponse
+    Srv-->>Parent: EvmSignatureResponse{signature, call_data}
     Parent-->>Listener: gRPC Signature
     Listener-->>Orc: signed (relays to MultisigProxy)
 ```
+
+The on-chain quorum (`MultisigProxy` M-of-N) and nonce consumption are the
+authoritative replay guards for this direction; the enclave commits `nonce`
+and `deadline` into the digest but keeps no fundsOut nonce state.

--- a/docs/diagrams/03-seq-sign-evm.md
+++ b/docs/diagrams/03-seq-sign-evm.md
@@ -17,7 +17,7 @@ sequenceDiagram
     Note over Orc,Listener: Intent
     Orc->>Listener: signing intent (op, calldata)
     Listener->>Listener: enrich (chain_id, proxy_contract, consignment, merkle_proofs)
-    Listener->>Parent: gRPC EnclaveService.Sign(TRANSACTION, enriched payload)
+    Listener->>Parent: gRPC ParentService.Sign(TRANSACTION, enriched payload)
 
     Note over Parent,Srv: Translate gRPC → enclave wire
     Parent->>Srv: Sign{source_network: RgbSource,<br/>destination_network: EvmDestination}<br/>(TCP/vsock, length-prefixed proto)

--- a/docs/diagrams/04-seq-sign-psbt.md
+++ b/docs/diagrams/04-seq-sign-psbt.md
@@ -1,15 +1,23 @@
-# Sign PSBT (EVM → RGB lock) — taproot + segwit-v0, anchored authorisation
+# Sign (EVM → RGB, bridge PSBT) — taproot + segwit-v0, anchored authorisation
+
+Plain-BTC (non-bridge) PSBTs do **not** go through this path anymore: they use
+the separate `SignBtc` request (M-05 / #102), gated by the attested
+`allow_vanilla_psbt` policy, the `BTC_ALLOWED_SCRIPTS` output allowlist, and the
+`BTC_MAX_TOTAL_SATS` cap, with signing scoped to the vanilla BIP-86 account
+only. The bridge path below always requires the EVM deposit hash **and** the
+RGB consignment.
 
 ```mermaid
 sequenceDiagram
     actor Orc as Orchestrator
     participant Listener as Go Listener
     participant Parent as utexo-bridge-parent<br/>(grpc_server.rs)
-    participant Srv as enclave/server.rs<br/>handle_sign_psbt
-    participant PsbtCx as validation::psbt_crosscheck
-    participant Rgb as validation::rgb<br/>(rgbstd + Esplora + SPV)
-    participant Evt as validation::evm_event
+    participant Srv as enclave/server.rs<br/>handle_sign
+    participant Evm as networks::evm::validation
+    participant Evt as networks::evm::evm_event
     participant Rpc as EVM RPC / Helios<br/>loopback→vsock→host
+    participant Rgb as networks::rgb<br/>(rgbstd + Esplora + SPV)
+    participant Anchor as networks::rgb::psbt_validation
     participant State as EnclaveState<br/>op_replay_guard
     participant Km as KeyManager::sign_psbt
     participant Tap as signing::taproot<br/>find_taproot_sign_jobs
@@ -19,45 +27,47 @@ sequenceDiagram
     Note over Orc,Listener: Intent
     Orc->>Listener: bridge intent (FundsIn deposit observed on EVM)
     Listener->>Listener: fetch PSBT from rgb-multisig-bridge,<br/>enrich with EVM event fields + RGB consignment
-    Listener->>Parent: gRPC Sign(TRANSACTION, EnrichedPsbtPayload)
+    Listener->>Parent: gRPC Sign(TRANSACTION, enriched payload)
 
     Note over Parent,Srv: Translate
-    Parent->>Srv: SignPsbtRequest (psbt_bytes, evm_tx_hash, operation_idx,<br/>amounts, consignment, ...)
+    Parent->>Srv: Sign{source_network: EvmSource,<br/>destination_network: RgbDestination}
 
-    Note over Srv,PsbtCx: Shape + amount cross-checks (skipped in dev-mode)
-    Srv->>PsbtCx: validate_psbt_request(req)
-    PsbtCx->>PsbtCx: PSBT shape whitelist (#40):<br/>psbt_bytes non-empty,<br/>Psbt::deserialize ok,<br/>unsigned tx has ≥ 1 input
-    alt evm_tx_hash empty (vanilla, e.g. create_utxo)
-        PsbtCx-->>Srv: Ok — only psbt_bytes required, skip bridge checks
-    else bridge mode
-        PsbtCx->>PsbtCx: len(evm_tx_hash) == 32
-        Note right of PsbtCx: listener evm_event_valid /<br/>evm_event_finalized are IGNORED (#51) —<br/>validity/finality established below, not trusted
-        PsbtCx->>PsbtCx: evm_amount ≥ psbt_output_amount + evm_commission
-    end
-    PsbtCx-->>Srv: Ok / CrossCheck err
+    Note over Srv,Evm: 1 — validate_source (EVM, skipped in dev-mode)
+    Srv->>Evm: validate_source(EvmSource)
+    Evm->>Evm: len(evm_tx_hash) == 32
+    Note right of Evm: listener event_valid / event_finalized<br/>are IGNORED (#51) — validity and finality<br/>are established below, never trusted
+    Evm-->>Srv: Ok / CrossCheck err
 
-    Note over Srv,State: Bridge-mode authorisation (bridge mode only)
-    opt rgb-validation build — send-RGB consignment binding (#79)
-        Srv->>Rgb: psbt_consignment_crosscheck: validate_consignment<br/>(rgbstd + Esplora resolver + SPV anchoring)
-        Rgb-->>Srv: ValidatedConsignment / REFUSE
-        Srv->>Srv: keccak256(consignment)==consignment_hash<br/>contract_id==pinned RGB_ASSET_ID<br/>unsigned txid==last TS_TRANSFER witness txid<br/>input prevouts match, sighash ALL/DEFAULT<br/>total_output ≥ evm_amount − evm_commission
-    end
-    alt evm-rpc build — independent FundsIn verification (M-06 / #60, #77)
-        Srv->>Evt: verify_funds_in_event(PINNED contract, EVM_MIN_CONFIRMATIONS,<br/>tx_hash, operation_id, evm_amount, evm_commission)
+    Note over Srv,Rpc: 2 — independent FundsIn verification (M-06 / #60)
+    alt evm-rpc (or helios) build
+        Srv->>Evt: verify_funds_in_event(pinned FUNDS_IN_CONTRACT,<br/>tx_hash, funds_in_operation_id, amount, commission)
         Evt->>Rpc: eth_getTransactionReceipt / eth_blockNumber
-        Note right of Rpc: raw alloy path = host-relayed evidence (#60)<br/>Helios path = cryptographically verified in-TEE (#77)
+        Note right of Rpc: raw alloy path = host-relayed evidence (#60)<br/>Helios path = verified in-TEE vs pinned checkpoint —<br/>Helios sync failure fails closed, no raw fallback
         Rpc-->>Evt: receipt / head (or none)
-        Evt->>Evt: receipt exists + status success<br/>UNIQUE FundsIn/BridgeFundsIn log from PINNED contract<br/>operationId/amount/commission bind (net==gross−commission)<br/>depth ≥ EVM_MIN_CONFIRMATIONS
+        Evt->>Evt: receipt exists + status success
+        Evt->>Evt: UNIQUE deposit event from the PINNED contract<br/>(FUNDS_IN_CONTRACT, else BRIDGE_CONTRACT — #152) —<br/>BridgeFundsIn preferred, same-tx FundsIn+BridgeFundsIn<br/>pair counts as ONE deposit (#150)
+        Evt->>Evt: on-chain operationId == funds_in_operation_id (#153,<br/>NOT the hub's operation_idx) —<br/>gross == amount, commission bound,<br/>net == gross − commission — uint256 > u64 ⇒ REFUSE
+        Evt->>Evt: depth ≥ EVM_MIN_CONFIRMATIONS (default 12) —<br/>receipt above head (reorg) ⇒ REFUSE
         Evt-->>Srv: Ok / CrossCheck err (fail closed)
-    else no evm-rpc feature (bridge mode)
-        Srv->>Srv: REFUSE — deposit cannot be independently verified<br/>rebuild with --features evm-rpc (or helios)
-    end
-    opt bridge mode — soft replay guard (#84)
-        Srv->>State: op_replay_guard.check_and_record(op_key)
-        State-->>Srv: Ok / duplicate operation → REFUSE
+    else no evm-rpc feature
+        Srv->>Srv: REFUSE — deposit cannot be independently verified —<br/>rebuild with --features evm-rpc (or helios)
     end
 
-    Note over Srv,Km: Sign PSBT inputs
+    Note over Srv,State: 3 — soft replay guard (#84)
+    Srv->>State: op_replay_guard.check_and_record(<br/>hash(chain_id, bridge_contract, evm_tx_hash,<br/>operation_idx, asset_id)) — 24 h TTL
+    State-->>Srv: Ok / duplicate operation → REFUSE
+
+    Note over Srv,Anchor: 4 — validate_destination_anchor (rgb-validation, consignment MANDATORY)
+    Srv->>Rgb: validate_consignment (cheap hash gate first, then<br/>rgbstd + Esplora resolver + typesystem pin)
+    Rgb-->>Srv: ValidatedConsignment / REFUSE
+    Srv->>Anchor: keccak256(consignment) == consignment_hash (integrity)
+    Srv->>Anchor: asset pin: declared asset_id == validated contract_id<br/>== pinned RGB_ASSET_ID (unconditional on this path)
+    Srv->>Anchor: PSBT unsigned txid == last witness txid —<br/>input prevouts == witness prevouts —<br/>sighash ALL / taproot DEFAULT only
+    Srv->>Anchor: last transition TS_TRANSFER or TS_INFLATION (mint-RGB, #146) —<br/>asset_output_amount (OS_ASSET only, #54)<br/>≥ amount − commission
+    Srv->>Anchor: fee sanity (#147): implied fee rate ≤ 3x the<br/>enclave-fetched Esplora estimate, fail-closed<br/>(compile-time floor only on non-mainnet, #149)
+    Anchor-->>Srv: Ok / CrossCheck err
+
+    Note over Srv,Km: 5 — Sign PSBT inputs
     Srv->>Km: sign_psbt(psbt_bytes)
     Km->>Km: Psbt::deserialize(...)
     Note over Km: Two passes per input:<br/>1. Taproot script-path (Schnorr)<br/>2. SegWit v0 P2WSH (ECDSA)<br/>Skip if already signed.
@@ -112,29 +122,34 @@ sequenceDiagram
     Listener-->>Orc: signed PSBT (assembles + broadcasts)
 ```
 
-## FundsIn verification predicate (`validation::evm_event`, #60 / #77)
+## FundsIn verification predicate (`networks::evm::evm_event`, M-06 / #60)
 
-Bridge-mode `signPsbt` releases RGB against an EVM deposit. The listener-supplied
-`evm_event_valid` / `evm_event_finalized` booleans are **no longer trusted** (audit
-M-06 / #51); the enclave establishes validity + finality itself, fail-closed:
+Bridge PSBT signing releases RGB against an EVM deposit. The listener-supplied
+`event_valid` / `event_finalized` booleans are **not trusted** (audit M-06 /
+#51); the enclave establishes validity + finality itself, fail-closed:
 
 1. **Receipt exists** for `evm_tx_hash` — `None` (not mined / host withheld) → refuse.
-2. **Receipt status == success** — a reverted tx emits no real `FundsIn`.
-3. **Unique** `FundsIn` / `BridgeFundsIn` log from the **pinned** `BRIDGE_CONTRACT`
-   (address from config, never the request); multiple matches are ambiguous → refuse.
-4. **Field binding** — decoded `operationId` (== `operation_idx`), gross `amount`
-   (== `evm_amount`), `tokenCommission` (== `evm_commission`), and the internal
-   `net == gross − commission`. A `uint256` exceeding `u64` is rejected, not truncated.
+2. **Receipt status == success** — a reverted tx emits no real deposit event.
+3. **Unique** deposit event from the **pinned** `FUNDS_IN_CONTRACT` (falls back
+   to `BRIDGE_CONTRACT`; #152 — address from config, never the request).
+   `BridgeFundsIn` is preferred; a same-tx `FundsIn` + `BridgeFundsIn` pair is
+   one deposit (#150). Two real deposits in one tx are ambiguous → refuse.
+4. **Field binding** — on-chain `operationId` == `funds_in_operation_id`
+   (the bridge transfer id, **not** the hub's `operation_idx`; #153), gross
+   `amount`, `tokenCommission`, and `net == gross − commission`. A `uint256`
+   exceeding `u64` is rejected, not truncated.
 5. **Confirmation depth** — `head − receipt.block` ≥ `EVM_MIN_CONFIRMATIONS`
    (default 12); a receipt block above head (reorg) → refuse.
 
 **Provider selection (build/runtime):**
-- No `evm-rpc` feature → bridge-mode `signPsbt` is **refused** (deposit unverifiable).
+- No `evm-rpc` feature → bridge PSBT signing is **refused** (deposit unverifiable).
 - `evm-rpc` → raw alloy JSON-RPC over the loopback vsock forwarder; responses are
   **host-relayed evidence**, verified fail-closed but not trustless.
-- `helios` + `HELIOS_EXECUTION_RPC` set → the a16z Helios light client verifies the
-  execution/consensus RPCs against a pinned checkpoint **inside the TEE** (trustless);
-  `HELIOS_NETWORK` must be consistent with the pinned `EVM_CHAIN_ID`.
+- `helios` + `HELIOS_EXECUTION_RPC` set → the Helios light client verifies the
+  execution/consensus RPCs against an operator-pinned checkpoint **inside the
+  TEE** (trustless); `HELIOS_NETWORK` must be consistent with the pinned
+  `EVM_CHAIN_ID`. A Helios init/sync failure fails closed — it never downgrades
+  to the raw path. The selected source is part of the attested security policy
+  (C-01).
 
 See [`10-signing-gate.md`](10-signing-gate.md) for the `fundsOut` (RGB → EVM) direction.
-```

--- a/docs/diagrams/04-seq-sign-psbt.md
+++ b/docs/diagrams/04-seq-sign-psbt.md
@@ -38,7 +38,20 @@ sequenceDiagram
     Note right of Evm: listener event_valid / event_finalized<br/>are IGNORED (#51) — validity and finality<br/>are established below, never trusted
     Evm-->>Srv: Ok / CrossCheck err
 
-    Note over Srv,Rpc: 2 — independent FundsIn verification (M-06 / #60)
+    Note over Srv,Anchor: 2 — validate_destination_anchor (rgb-validation, consignment MANDATORY)
+    Srv->>Rgb: validate_consignment (cheap hash gate first, then<br/>rgbstd + Esplora resolver + typesystem pin)
+    Rgb-->>Srv: ValidatedConsignment / REFUSE
+    Srv->>Anchor: keccak256(consignment) == consignment_hash (integrity)
+    Srv->>Anchor: asset pin: declared asset_id == validated contract_id<br/>== pinned RGB_ASSET_ID (unconditional on this path)
+    Srv->>Anchor: PSBT unsigned txid == last witness txid —<br/>input prevouts == witness prevouts —<br/>sighash ALL / taproot DEFAULT only
+    Srv->>Anchor: last transition TS_TRANSFER or TS_INFLATION (mint-RGB, #146) —<br/>asset_output_amount (OS_ASSET only, #54)<br/>≥ amount − commission
+    Srv->>Anchor: fee sanity (#147): implied fee rate ≤ 3x the<br/>enclave-fetched Esplora estimate, fail-closed<br/>(compile-time floor only on non-mainnet, #149)
+    Anchor-->>Srv: Ok / CrossCheck err
+
+    Note over Srv: 3 — validate_route_proofs
+    Srv->>Srv: source amount ≥ psbt_output_amount + commission
+
+    Note over Srv,Rpc: 4 — independent FundsIn verification (M-06 / #60)
     alt evm-rpc (or helios) build
         Srv->>Evt: verify_funds_in_event(pinned FUNDS_IN_CONTRACT,<br/>tx_hash, funds_in_operation_id, amount, commission)
         Evt->>Rpc: eth_getTransactionReceipt / eth_blockNumber
@@ -53,21 +66,11 @@ sequenceDiagram
         Srv->>Srv: REFUSE — deposit cannot be independently verified —<br/>rebuild with --features evm-rpc (or helios)
     end
 
-    Note over Srv,State: 3 — soft replay guard (#84)
+    Note over Srv,State: 5 — soft replay guard (#84)
     Srv->>State: op_replay_guard.check_and_record(<br/>hash(chain_id, bridge_contract, evm_tx_hash,<br/>operation_idx, asset_id)) — 24 h TTL
     State-->>Srv: Ok / duplicate operation → REFUSE
 
-    Note over Srv,Anchor: 4 — validate_destination_anchor (rgb-validation, consignment MANDATORY)
-    Srv->>Rgb: validate_consignment (cheap hash gate first, then<br/>rgbstd + Esplora resolver + typesystem pin)
-    Rgb-->>Srv: ValidatedConsignment / REFUSE
-    Srv->>Anchor: keccak256(consignment) == consignment_hash (integrity)
-    Srv->>Anchor: asset pin: declared asset_id == validated contract_id<br/>== pinned RGB_ASSET_ID (unconditional on this path)
-    Srv->>Anchor: PSBT unsigned txid == last witness txid —<br/>input prevouts == witness prevouts —<br/>sighash ALL / taproot DEFAULT only
-    Srv->>Anchor: last transition TS_TRANSFER or TS_INFLATION (mint-RGB, #146) —<br/>asset_output_amount (OS_ASSET only, #54)<br/>≥ amount − commission
-    Srv->>Anchor: fee sanity (#147): implied fee rate ≤ 3x the<br/>enclave-fetched Esplora estimate, fail-closed<br/>(compile-time floor only on non-mainnet, #149)
-    Anchor-->>Srv: Ok / CrossCheck err
-
-    Note over Srv,Km: 5 — Sign PSBT inputs
+    Note over Srv,Km: 6 — Sign PSBT inputs
     Srv->>Km: sign_psbt(psbt_bytes)
     Km->>Km: Psbt::deserialize(...)
     Note over Km: Two passes per input:<br/>1. Taproot script-path (Schnorr)<br/>2. SegWit v0 P2WSH (ECDSA)<br/>Skip if already signed.
@@ -135,9 +138,12 @@ Bridge PSBT signing releases RGB against an EVM deposit. The listener-supplied
    `BridgeFundsIn` is preferred; a same-tx `FundsIn` + `BridgeFundsIn` pair is
    one deposit (#150). Two real deposits in one tx are ambiguous → refuse.
 4. **Field binding** — on-chain `operationId` == `funds_in_operation_id`
-   (the bridge transfer id, **not** the hub's `operation_idx`; #153), gross
-   `amount`, `tokenCommission`, and `net == gross − commission`. A `uint256`
-   exceeding `u64` is rejected, not truncated.
+   (the bridge transfer id, **not** the hub's `operation_idx`; #153). A
+   `BridgeFundsIn` event additionally chain-binds gross `amount` and
+   `tokenCommission` (`net == gross − commission`); the plain `FundsIn`
+   fallback binds only `operationId` and the net amount, leaving the
+   commission split listener-supplied. A `uint256` exceeding `u64` is
+   rejected, not truncated.
 5. **Confirmation depth** — `head − receipt.block` ≥ `EVM_MIN_CONFIRMATIONS`
    (default 12); a receipt block above head (reorg) → refuse.
 

--- a/docs/diagrams/05-seq-attested-pubkey.md
+++ b/docs/diagrams/05-seq-attested-pubkey.md
@@ -14,8 +14,8 @@ sequenceDiagram
     participant RootCa as Embedded AWS Nitro<br/>root CA (PEM)
 
     Note over V,Lib: Verifier issues nonce
-    V->>Cli: attest-verify --endpoint ... --pcr0 ... --pcr1 ... --pcr2 ...
-    Cli->>Lib: verify_attested_pubkey(endpoint, expected_pcrs, Real)
+    V->>Cli: attest-verify --endpoint ... --pcr0/1/2 ...<br/>--expect-vanilla-psbt --expect-evm-source raw|helios|disabled
+    Cli->>Lib: verify_attested_pubkey(endpoint, expected_pcrs, expected_policy)
     Lib->>Lib: nonce := rand_32_bytes()
 
     Note over Lib,Srv: gRPC round-trip
@@ -24,10 +24,10 @@ sequenceDiagram
     Parent->>Srv: GetAttestedPublicKeyRequest{nonce}
 
     Srv->>State: get_keys() (requires Phase::Active)
-    State-->>Srv: KeyInfo{evm_address, evm_uncompressed_pub,<br/>btc xpub, master_fingerprint,<br/>account xpubs vanilla+colored}
+    State-->>Srv: KeyInfo{evm_address, evm_uncompressed_pub,<br/>btc keys, master_fingerprint,<br/>account xpubs vanilla+colored,<br/>gas-tx key, chain_id, bridge_contract, rgb_asset_id}
 
-    Srv->>Srv: bundle := canonical_pubkey_bundle(keys)<br/>(length-prefixed concat)
-    Srv->>Srv: commitment := sha256(bundle)
+    Srv->>Srv: bundle := canonical_pubkey_bundle(keys)<br/>(12 length-prefixed fields, proto order)
+    Srv->>Srv: commitment := sha256(bundle ‖ policy_commitment)<br/>policy = boot-resolved SecurityPolicy (C-01)
 
     Srv->>Att: get_attestation(nonce, pubkey=evm_uncompressed_pub, user_data=commitment)
     alt mock-attestation feature
@@ -60,10 +60,10 @@ sequenceDiagram
     Verify-->>Lib: VerifiedAttestation{pubkey, pcrs, user_data, ...}
 
     Lib->>Lib: assert verified.enclave_pubkey ==<br/>response.evm_uncompressed_pub
-    Lib->>Lib: rebuild canonical_bundle locally,<br/>assert verified.user_data == sha256(bundle)
+    Lib->>Lib: rebuild canonical_bundle + EXPECTED policy<br/>(from CLI flags + wire pins),<br/>assert verified.user_data ==<br/>sha256(bundle ‖ expected_policy_bytes)
 
     Lib-->>Cli: AttestedPubkeyResult
     Cli-->>V: OK + printed bundle + PCRs
 
-    Note right of V: After OK the verifier knows:<br/>"AWS Nitro hardware certifies that an<br/>enclave with PCR0=X / PCR1=Y / PCR2=Z<br/>produced this signing pubkey, and the<br/>full key bundle commits to user_data."
+    Note right of V: After OK the verifier knows:<br/>"AWS Nitro hardware certifies that an<br/>enclave with PCR0=X / PCR1=Y / PCR2=Z<br/>produced this signing pubkey, and the full<br/>key bundle PLUS the enclave's resolved<br/>security policy commit to user_data."<br/>A downgraded posture (vanilla on, raw<br/>instead of Helios, dev build) FAILS here.
 ```

--- a/docs/diagrams/05-seq-attested-pubkey.md
+++ b/docs/diagrams/05-seq-attested-pubkey.md
@@ -24,8 +24,9 @@ sequenceDiagram
     Parent->>Srv: GetAttestedPublicKeyRequest{nonce}
 
     Srv->>State: get_keys() (requires Phase::Active)
-    State-->>Srv: KeyInfo{evm_address, evm_uncompressed_pub,<br/>btc keys, master_fingerprint,<br/>account xpubs vanilla+colored,<br/>gas-tx key, chain_id, bridge_contract, rgb_asset_id}
+    State-->>Srv: KeyInfo{evm_address, evm_uncompressed_pub,<br/>gas-tx key, btc keys, master_fingerprint,<br/>account xpubs vanilla+colored}
 
+    Srv->>Srv: merge boot-pinned BridgeConfig<br/>(chain_id, bridge_contract, rgb_asset_id)<br/>into PublicKeysResponse
     Srv->>Srv: bundle := canonical_pubkey_bundle(keys)<br/>(12 length-prefixed fields, proto order)
     Srv->>Srv: commitment := sha256(bundle ‖ policy_commitment)<br/>policy = boot-resolved SecurityPolicy (C-01)
 

--- a/docs/diagrams/06-seq-cloning.md
+++ b/docs/diagrams/06-seq-cloning.md
@@ -30,11 +30,12 @@ sequenceDiagram
     Don->>DN: read_own_pcrs()
     DN-->>Don: ExpectedPcrs{pcr0, pcr1, pcr2}
     Don->>Don: verify_peer_attestation(requester_attestation,<br/>expected=own_PCRs, nonce=None)
-    Note right of Don: Cert-chain → AWS Nitro root,<br/>COSE_Sign1 signature, PCR equality.<br/>No expected_nonce — freshness via the<br/>replay guard immediately after.
-    Don->>Don: replay_guard.check_and_record(verified.nonce)
+    Note right of Don: Cert-chain → AWS Nitro root,<br/>COSE_Sign1 signature, PCR equality.<br/>No expected_nonce — freshness via the<br/>replay guard after auth.
     Don->>Don: verified.public_key == encryption_pubkey (pubkey binding)
     Don->>Don: verified.user_data == cloning_digest (digest binding)
     Don->>Don: with_donor_cloning_secret:<br/>HMAC(secret, encryption_pubkey) == cloning_digest
+    Don->>Don: replay_guard.check_and_record(verified.nonce)
+    Note right of Don: Nonce recorded only AFTER all auth checks<br/>pass (W-13 / #129) — a rejected handshake<br/>never consumes guard capacity. Guard is<br/>TTL-bounded: 1 h, oldest-first eviction (#80).
     Don->>Don: with_seed: (ct, donor_pubkey) :=<br/>encrypt_seed_for_peer(encryption_pubkey, seed)
     Note right of Don: encrypt_seed_for_peer:<br/>our_eph := EphemeralSecret::random<br/>shared := our_eph * encryption_pubkey<br/>reject_non_contributory(shared) — small-order guard<br/>key := HKDF-SHA256(shared, salt="utexo-cloning-v1",<br/>  info="seed-encryption" ‖ donor_pub ‖ requester_pub)<br/>ct := ChaCha20Poly1305(key, nonce=[0,12]).encrypt(seed)
     Don->>Don: donor_nonce := getrandom_32()
@@ -47,10 +48,10 @@ sequenceDiagram
     Req->>RN: read_own_pcrs()
     RN-->>Req: ExpectedPcrs
     Req->>Req: verify_peer_attestation(donor_attestation,<br/>expected=own_PCRs, nonce=None)
-    Req->>Req: replay_guard.check_and_record(verified.nonce)
     Req->>Req: verified.public_key == donor_pubkey
     Req->>Req: complete_cloning {<br/>  seed := session.decrypt_seed_from_peer(donor_pubkey, ct)<br/>  km := KeyManager::from_seed(seed, network)<br/>  assert km.evm_address() == session.cluster_public_key<br/>  return km<br/>}
     Req->>Req: state := Phase::Active(km)
+    Req->>Req: replay_guard.check_and_record(verified.nonce)<br/>(after auth + commit — W-13 / #129)
     Req-->>Parent: SetCloneResponse{} (empty)
     Parent-->>Op: Initialize OK (probes GetPublicKey for confirmation)
 

--- a/docs/diagrams/06-seq-cloning.md
+++ b/docs/diagrams/06-seq-cloning.md
@@ -11,16 +11,15 @@ sequenceDiagram
 
     Note over Req,Don: Both enclaves must have IDENTICAL PCRs<br/>(same compiled binary) for cloning to succeed.<br/>The cloning_secret is a pre-shared operator value,<br/>the donor reads it from UTEXO_CLONING_SECRET.
 
-    Note over Op,Req: Message 1 — parent → requester
-    Op->>Parent: gRPC Initialize(cloning_secret)
+    Note over Op,Req: Message 1 — operator tooling → requester<br/>(the parent's gRPC Clone RPC is currently a stub —<br/>the handshake runs over the enclave wire protocol,<br/>the parent acting only as an untrusted relay)
+    Op->>Parent: start cluster clone
     Parent->>Req: InitiateCloningRequest{cloning_secret, cluster_public_key=donor_evm}
-    Req->>Req: ensure Phase::Initial
     Req->>Req: ephemeral X25519 keypair (StaticSecret + PublicKey)
     Req->>Req: digest := HMAC-SHA256(secret, encryption_pubkey)
     Req->>Req: nonce := getrandom_32()
     Req->>RN: NSM Attestation(nonce, public_key=encryption_pubkey, user_data=digest)
     RN-->>Req: requester_attestation (COSE_Sign1)
-    Req->>Req: state := Phase::Cloning(session, cluster_pk)
+    Req->>Req: enter_cloning: ensure Phase::Initial (else reject),<br/>state := Phase::Cloning(session, cluster_pk)
     Req-->>Parent: InitiateCloningResponse{requester_attestation, encryption_pubkey, cloning_digest}
 
     Note over Parent,Don: Message 2 — parent → donor

--- a/docs/diagrams/07-seq-initialize-keys.md
+++ b/docs/diagrams/07-seq-initialize-keys.md
@@ -27,7 +27,7 @@ sequenceDiagram
     Km->>Km: seed := mnemonic.to_seed("")
     Km->>Km: seed_box := SecretBox::new(seed), seed.zeroize()
     Km->>Km: master := Xpriv::new_master(network, seed)
-    Km->>Km: EVM   = m/44'/60'/0'/0/0<br/>BTC   = m/84'/0'/0'/0/0<br/>BIP-86 vanilla = m/86'/COIN'/0'<br/>BIP-86 colored = m/86'/827167'/0'
+    Km->>Km: EVM bridge = m/44'/60'/0'/0/0<br/>EVM gas-tx = m/44'/60'/0'/0/1<br/>BTC = m/84'/0'/0'/0/0<br/>BIP-86 vanilla = m/86'/COIN'/0'<br/>BIP-86 colored = m/86'/827167'/0'
     Km->>Km: evm_address = keccak256(uncomp_pub[1..])[12..]
     Km-->>State: (KeyManager, Mnemonic)
 
@@ -39,7 +39,7 @@ sequenceDiagram
 
     Note over Srv: tracing::info! evm_address, master_fingerprint,<br/>account_xpubs (public values only).<br/>The mnemonic is dropped here — its content lives<br/>only in the SecretBox(seed) from now on.
 
-    Srv-->>PClient: InitializeKeyResponse{evm_address, btc_compressed_pub,<br/>btc_xpub, master_fingerprint, account xpubs,<br/>evm_uncompressed_pub}
+    Srv-->>PClient: InitializeKeyResponse{evm_address, btc_compressed_pub,<br/>btc_xpub, master_fingerprint, account xpubs,<br/>evm_uncompressed_pub, evm_gas_tx pubkey + address,<br/>chain_id, bridge_contract, rgb_asset_id}
     PClient-->>Cli: print pubkeys
     Cli-->>Op: enclave ready
 ```

--- a/docs/diagrams/08-seq-spv-submit-headers.md
+++ b/docs/diagrams/08-seq-spv-submit-headers.md
@@ -25,8 +25,11 @@ sequenceDiagram
         Listener->>Parent: gRPC SubmitHeaders{start_height=N+1, headers[]}
         Parent->>Srv: SubmitHeadersRequest
 
+        Srv->>Srv: rate limiter: ≤ 100 000 headers per 60 s window<br/>(cumulative, counted before validation)
         Srv->>Chain: submit_headers(start_height, &headers)
+        Chain->>Chain: batch ≤ MAX_HEADERS_PER_SUBMIT (10 000)
         Chain->>Chain: check bounds:<br/>start_height > checkpoint AND<br/>start_height ≤ tip+1
+        Chain->>Chain: projected retained count ≤<br/>MAX_STORED_HEADERS (1 000 000) — REJECT, never prune
         Chain->>Chain: reorg_depth := (tip+1) − start_height
         Chain->>Chain: require reorg_depth ≤ MAX_REORG_DEPTH (100)
 
@@ -56,5 +59,5 @@ sequenceDiagram
         Listener->>Listener: N := N'
     end
 
-    Note over Chain: Boot-time invariants:<br/>— Checkpoint::assert_real_in_release() panics<br/>  on placeholder checkpoint in release builds.<br/>— header_at(checkpoint.height) returns None<br/>  (we never store the checkpoint header itself,<br/>  only its hash/bits/time metadata).
+    Note over Chain: Boot-time invariants:<br/>— Checkpoint::assert_real_in_release() panics<br/>  on placeholder checkpoint in release builds.<br/>— assert_retarget_aligned() panics (all profiles)<br/>  on a non-retarget-aligned PoW checkpoint (W-14).<br/>— header_at(checkpoint.height) returns None<br/>  (we never store the checkpoint header itself,<br/>  only its hash/bits/time metadata).<br/>Retention: ALL headers from the checkpoint are kept<br/>(#130 — no sliding window; deep RGB anchors stay verifiable).
 ```

--- a/docs/diagrams/08-seq-spv-submit-headers.md
+++ b/docs/diagrams/08-seq-spv-submit-headers.md
@@ -20,7 +20,7 @@ sequenceDiagram
 
     Note over Listener,Chain: Fetch + push loop
     loop while remote_tip > N
-        Listener->>Esplora: GET /block-height/{N+1..N+500}
+        Listener->>Esplora: fetch hashes + headers<br/>(/block-height/:h, /block/:hash/header)
         Esplora-->>Listener: raw 80-byte headers
         Listener->>Parent: gRPC SubmitHeaders{start_height=N+1, headers[]}
         Parent->>Srv: SubmitHeadersRequest
@@ -29,13 +29,13 @@ sequenceDiagram
         Srv->>Chain: submit_headers(start_height, &headers)
         Chain->>Chain: batch ≤ MAX_HEADERS_PER_SUBMIT (10 000)
         Chain->>Chain: check bounds:<br/>start_height > checkpoint AND<br/>start_height ≤ tip+1
-        Chain->>Chain: projected retained count ≤<br/>MAX_STORED_HEADERS (1 000 000) — REJECT, never prune
         Chain->>Chain: reorg_depth := (tip+1) − start_height
         Chain->>Chain: require reorg_depth ≤ MAX_REORG_DEPTH (100)
+        Chain->>Chain: projected retained count ≤<br/>MAX_STORED_HEADERS (1 000 000) — REJECT, never prune
 
         loop staged in batch
             Chain->>Chain: deserialize 80-byte Header (atomic fail)
-            Chain->>Cp: epoch_start_time(...) on retarget heights
+            Chain->>Chain: epoch_start_time on retarget heights<br/>(staged batch → chain → checkpoint base_time)
             Chain->>Val: expected_bits(height, prev_bits, prev_time,<br/>epoch_start_time, network)
             Val-->>Chain: Some(bits) for mainnet/testnet3,<br/>None for signet/regtest
             Chain->>Val: validate_header_full(<br/>header, height, prev_hash, expected_bits, net)

--- a/docs/diagrams/09-state-phase.md
+++ b/docs/diagrams/09-state-phase.md
@@ -20,7 +20,7 @@ stateDiagram-v2
 
     Cloning --> Active : complete_cloning() (SetClone — decrypt + install peer seed, assert evm_address == cluster_public_key)
 
-    Active --> Active : SignEvm / SignPsbt / GetAttestedPublicKey (no state change)
+    Active --> Active : Sign / SignBtc / SignRawMessage / SignRawDigest / GetAttestedPublicKey (no state change)
     Active --> Active : GetClone (donor — exports sealed seed, stays Active)
 
     note right of Active

--- a/docs/diagrams/09-state-phase.md
+++ b/docs/diagrams/09-state-phase.md
@@ -16,7 +16,7 @@ stateDiagram-v2
 
     Initial --> Active : initialize_from_entropy() — first enclave, OS entropy
     Initial --> Active : initialize_from_seed/mnemonic() — feature allow-seed-import, dev only
-    Initial --> Cloning : begin_cloning() (InitiateCloning — requester)
+    Initial --> Cloning : enter_cloning() (InitiateCloning — requester)
 
     Cloning --> Active : complete_cloning() (SetClone — decrypt + install peer seed, assert evm_address == cluster_public_key)
 

--- a/docs/diagrams/10-signing-gate.md
+++ b/docs/diagrams/10-signing-gate.md
@@ -1,80 +1,98 @@
-# `fundsOut` signing gate — TEE validation predicates (`handle_sign_evm`)
+# `fundsOut` signing gate — TEE validation predicates (`handle_sign`)
 
 ```mermaid
 flowchart TD
-    start([SignEvmRequest received<br/>call_data, nonce, deadline, consignment,<br/>merkle_proofs, chain_id, proxy_contract, ...])
-    start --> bs{built without 'spv' but<br/>request carries merkle_proofs?}
-    bs -->|yes| bsr[REFUSE — build/feature mismatch]:::refuse
+    start([Sign request received<br/>RgbSource + EvmDestination:<br/>consignment, merkle_proofs, call_data,<br/>nonce, deadline, chain_id, proxy_contract, ...])
 
-    subgraph P1 [P1 — RGB consignment validity, Sec 10.1]
-        p1a[Transfer::load consignment_bytes] --> p1b[rgbstd validate against Esplora resolver]
+    subgraph P1 ["P1 — RGB source (validate_source)"]
+        p1w["cheap payload gate first (W-04):<br/>consignment bytes present,<br/>keccak256 == consignment_hash,<br/>asset_id declared"]
+        p1w --> p1wq{pass?}
+        p1wq -->|no| p1wr[REFUSE — payload gate]:::refuse
+        p1wq -->|yes| p1a["Transfer::load + typesystem pinned<br/>per schema_id (W-09)"]
+        p1a --> p1b[rgbstd validate against Esplora resolver<br/>30 s timeout]
         p1b --> p1q{valid?}
         p1q -->|no| p1r[REFUSE — invalid consignment]:::refuse
-        p1q -->|yes| p1e[extract chain_net, witness_txids,<br/>all_op_ids, last_transition]
-        p1e --> p1c{contract_id == declared rgb_asset_id?}
-        p1c -->|no| p1cr[REFUSE — contract_id mismatch]:::refuse
+        p1q -->|yes| p1c{"contract_id == declared asset_id<br/>(== pinned RGB_ASSET_ID when configured)?"}
+        p1c -->|no| p1cr[REFUSE — asset mismatch]:::refuse
+        p1c -->|yes| p1e["source amount from consignment:<br/>TS_TRANSFER total_output /<br/>TS_BURN burned amount<br/>(host rgb_amount NOT used);<br/>other transition ⇒ REFUSE"]
     end
-    bs -->|no| p1a
+    start --> p1w
 
-    subgraph P2 [P2 — EVM cross-checks, validate_evm_request, Sec 10.3/4/5]
-        p2sel{selector in FUNDS_OUT allowlist?<br/>legacy 0x1ad880b2 / mint-burn 0x179bef59}
-        p2sel -->|no| p2selr[REFUSE — unknown selector]:::refuse
-        p2sel -->|yes| p2cp{consignment bytes present?<br/>consignment_valid flag NOT trusted — #47}
-        p2cp -->|no| p2cpr[REFUSE — fundsOut needs validated consignment]:::refuse
-        p2cp -->|yes| p2h{keccak256(consignment)<br/>== consignment_hash?}
-        p2h -->|no| p2hr[REFUSE — consignment tampered]:::refuse
-        p2h -->|yes| p2am{legacy: rgb_amount ≥ calldata_amount + commission<br/>AND offsets 68/100 == declared?}
-        p2am -->|no| p2amr[REFUSE — amount / calldata mismatch]:::refuse
-        p2am -->|yes| p2d{chain_id > 0 AND<br/>len(proxy_contract)==20 AND<br/>deadline not expired?}
-        p2d -->|no| p2dr[REFUSE — bad domain / expired]:::refuse
-        p2d -->|yes| p2p{bridge config pinned (#43)?<br/>chain_id / proxy_contract / rgb_asset_id == env pins}
-        p2p -->|no| p2pr[REFUSE — pinned-config mismatch]:::refuse
-    end
-    p1c -->|yes| p2sel
-
-    subgraph P2b [P2b — Amount bound to consignment, #44/#47, Sec 9/10.2/10.3]
-        p2bv{validated consignment present?<br/>rgb_validator ran}
-        p2bv -->|no| p2bvr[REFUSE — fundsOut requires validated consignment]:::refuse
-        p2bv -->|yes| p2bb{mint-burn: last == TS_BURN<br/>AND calldata amount@36 ≤ burned_asset_amount?}
-        p2bb -->|no| p2bbr[REFUSE — burn amount / type mismatch]:::refuse
-        p2bb -->|yes| p2bt{legacy: last == TS_TRANSFER<br/>AND amount+commission ≤ total_output_amount?}
-        p2bt -->|no| p2btr[REFUSE — transfer amount / type mismatch]:::refuse
-    end
-    p2p -->|yes| p2bv
-
-    subgraph P3 [P3 — SPV / Bitcoin anchoring, Sec 10.7/8, Sec 12]
-        p3stale{chain tip fresh?<br/>not stale / not future}
+    subgraph P3 ["P2 — SPV / Bitcoin anchoring (feature spv)"]
+        p3stale{"chain tip fresh?<br/>≤ 2 h old, ≤ 2 h future"}
         p3stale -->|no| p3sr[REFUSE — chain stale, frozen feed]:::refuse
         p3stale -->|yes| p3net{consignment chain_net == enclave network?}
         p3net -->|no| p3nr[REFUSE — cross-network replay]:::refuse
-        p3net -->|yes| p3v[for EVERY witness txid: coverage (set equality),<br/>inclusion proof vs stored header root,<br/>confirmation depth ≥ 6]
+        p3net -->|yes| p3v["for EVERY witness txid:<br/>exact proof set-equality,<br/>merkle path ≤ 32,<br/>inclusion vs stored header,<br/>depth ≥ 6"]
         p3v --> p3q{all proofs pass?}
         p3q -->|no| p3qr[REFUSE — SPV failure]:::refuse
     end
-    p2bt -->|yes| p3stale
+    p1e --> p3stale
+
+    subgraph P2 ["P3 — EVM destination (validate_destination)"]
+        p2len{"calldata ≥ 4 bytes AND ≤ 64 KiB?"}
+        p2len -->|no| p2lenr[REFUSE — size]:::refuse
+        p2len -->|yes| p2sel{"selector == 0xccddb768<br/>fundsOut(address,uint256,uint256,<br/>uint256,uint256,string,bytes,bytes)?"}
+        p2sel -->|no| p2selr[REFUSE — unknown selector]:::refuse
+        p2sel -->|yes| p2abi{"canonical ABI (W-01):<br/>abi_decode_validate AND<br/>re-encode byte-equals input?"}
+        p2abi -->|no| p2abir[REFUSE — non-canonical calldata]:::refuse
+        p2abi -->|yes| p2am{"decoded amount == declared<br/>calldata_amount, fits u64?"}
+        p2am -->|no| p2amr[REFUSE — amount mismatch]:::refuse
+        p2am -->|yes| p2p{"config pinned AND chain_id /<br/>proxy_contract == env pins?"}
+        p2p -->|no| p2pr[REFUSE — pinned-config mismatch]:::refuse
+        p2p -->|yes| p2d{deadline strictly in the future?}
+        p2d -->|no| p2dr[REFUSE — expired]:::refuse
+    end
+    p3q -->|yes| p2len
+
+    subgraph P4 ["P4 — route + fundsOut binding (apply_funds_out_binding)"]
+        p4r{"route: source amount ≥ destination amount?"}
+        p4r -->|no| p4rr[REFUSE — not covered]:::refuse
+        p4r -->|yes| p4w{all consignment witnesses mined?}
+        p4w -->|no| p4wr[REFUSE — unmined witness]:::refuse
+        p4w -->|yes| p4b{"calldata proof slot populated?<br/>(#57/#122 — empty pre-migration)"}
+        p4b -->|yes| p4bv{"decoded (blockHeight, commitmentHash)<br/>matches enclave header at that height?"}
+        p4bv -->|no| p4bvr[REFUSE — BtcRelay disagreement]:::refuse
+        p4b -->|"no (inert)"| p4t
+        p4bv -->|yes| p4t{"last transition == TS_TRANSFER AND<br/>consignment total_output ≥<br/>amount read from calldata bytes?"}
+        p4t -->|no| p4tr[REFUSE — transfer bind]:::refuse
+    end
+    p2d -->|yes| p4r
 
     subgraph S [Sign]
-        s1[build EIP-712 domain<br/>name, version, chain_id, proxy_contract] --> s2[digest = EIP-712 BridgeOperation<br/>selector, callData, nonce, deadline]
+        s1["EIP-712 domain: name MultisigProxy, version 1,<br/>chain_id, proxy_contract<br/>(pinned by contract-fixture test)"] --> s2["digest = BridgeOperation(selector,<br/>callData, nonce, deadline)"]
         s2 --> s3[signature = ECDSA over digest<br/>Active KeyManager]
-        s3 --> sR([RETURN EvmSignatureResponse signature]):::accept
+        s3 --> sR([RETURN signature + call_data]):::accept
     end
-    p3q -->|yes| s1
+    p4t -->|yes| s1
 
     classDef refuse fill:#FADBD8,stroke:#922,color:#222
     classDef accept fill:#D5F5E3,stroke:#292,color:#222
 ```
 
-### Status vs spec (see `audit/cross-flow-findings.md` Part 7)
+### Notes
 
-**Closed since original review:**
-- Sec 9 / 10.2 — burn amount now bound to the consignment (`TS_BURN` + amount ≤ `burned_asset_amount`, #44; transfer amount ≤ `total_output_amount`, #47).
-- Sec 10.1 — `consignment_valid` bypass removed (#47).
-- Sec 10.4/5 — `chain_id` / contract / asset pinned from env (#43).
-- EIP-712 typehash now `BridgeOperation(bytes4 selector, ...)` matching `MultisigProxy._buildDigest()` (PR #48).
+- `burnId` / `fundsInIds` inside the calldata are **preserved as received**
+  (#168). The in-enclave OpId rewrite (`burnId` derived from the validated
+  consignment OpId, M-02 / #93) is implemented but dormant until flows are
+  routed by network id; mint/burn unlock (`TS_BURN` consignments) cannot
+  complete this gate — only the swap flow (`TS_TRANSFER`) signs.
+- `dev-mode` builds bypass the validation subgraphs entirely; every dev
+  feature is a `compile_error!` in release builds, and a release bridge build
+  refuses to boot without a valid attested `Production` policy (C-01).
+
+### Status vs audit (Oxorio final IDs)
+
+**Closed since the original review:** amount bound to the consignment (host
+`rgb_amount` unused); canonical ABI validation (W-01); single pools selector,
+pinned by an ABI-derived test; EIP-712 domain `MultisigProxy`/`1` pinned by a
+deployed-contract fixture test; chain / contract / asset env-pinned; BtcRelay
+proof agreement wired (#57/#122, inert until the listener populates it).
 
 **Remaining gaps:**
-- Sec 10.6 — `OpId` binding NOT checked / NOT in payload (`TEE-SE-02`).
-- Sec 13 — EVM recipient NOT derived from / bound to the RGB payload (`TEE-SE-03`).
-- Amount bind is `≤`, not the spec's strict `==` (`TEE-SE-04`).
-- EIP-712 domain `name` / `version` hardcoded `"Tricorn"` / `"1"`; calldata offsets unverified vs deployed ABI (`TEE-SE-05`).
-- Mint-burn path inert until the listener emits `0x179bef59`.
+- Recipient not derived from / bound to the RGB payload (C-04 / #66 —
+  blocked on an EVM-destination commitment in the RGB burn schema, cross-repo).
+- OpId binding dormant (M-02 — see note above); backend `burnId` is signed as
+  received.
+- Amount bind is coverage (`≥`), not strict `==` (I-06; per-output recipient-leg
+  binding is #58).

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -1,8 +1,9 @@
 # Diagrams
 
 Architecture / sequence / state / flow diagrams referenced from
-[`docs/audit/ENCLAVE_SIGNER_CONTEXT.md`](../audit/ENCLAVE_SIGNER_CONTEXT.md) and
-[`docs/tee-spec.md`](../tee-spec.md).
+[`docs/tee-spec.md`](../tee-spec.md). Refreshed 2026-07-28 against the
+audit-fix line (`networks/` layout, unified `Sign` request, `SignBtc` split,
+C-01 attested security policy).
 
 Mermaid in Markdown — GitHub, GitLab, VS Code, and most modern Markdown renderers
 display these inline; no separate render step.
@@ -11,9 +12,9 @@ display these inline; no separate render step.
 |---|---|
 | [`01-components.md`](01-components.md) | Crate-level component structure across `enclave`, `parent`, `attestation-verify`, and the external infrastructure (NSM, Esplora, vsock-proxy). |
 | [`02-deployment.md`](02-deployment.md) | Production deployment: Orchestrator → EC2 (parent) → Nitro Enclave → vsock-proxy → Esplora, with trust zones called out. |
-| [`03-seq-sign-evm.md`](03-seq-sign-evm.md) | EIP-712 signing path (RGB → EVM unlock): build-skew guard, in-enclave RGB validation, cross-checks, SPV gate, signature. |
-| [`04-seq-sign-psbt.md`](04-seq-sign-psbt.md) | PSBT signing path (EVM → RGB lock): bridge-mode authorisation (independent FundsIn verification #60/#77, consignment binding), then taproot script-path (Schnorr) + SegWit v0 P2WSH (ECDSA), both anchored to `witness_utxo.script_pubkey`. |
-| [`05-seq-attested-pubkey.md`](05-seq-attested-pubkey.md) | External verifier ↔ enclave attested-pubkey protocol (`attest-verify` CLI, NSM, COSE_Sign1, cert-chain to AWS Nitro root, PCR + nonce + bundle commitment). |
+| [`03-seq-sign-evm.md`](03-seq-sign-evm.md) | `fundsOut` signing path (RGB → EVM unlock) via the unified `Sign` request: in-enclave RGB validation, SPV gate, canonical-ABI destination checks, fundsOut binding, EIP-712 signature. |
+| [`04-seq-sign-psbt.md`](04-seq-sign-psbt.md) | Bridge PSBT path (EVM → RGB): independent FundsIn verification (M-06/#60, Helios optional), consignment anchoring, fee sanity, then taproot script-path (Schnorr) + SegWit v0 P2WSH (ECDSA), both anchored to `witness_utxo.script_pubkey`. Plain-BTC signing is the separate `SignBtc` request. |
+| [`05-seq-attested-pubkey.md`](05-seq-attested-pubkey.md) | External verifier ↔ enclave attested-pubkey protocol (`attest-verify` CLI, NSM, COSE_Sign1, cert-chain to AWS Nitro root, PCR + nonce + bundle-and-policy commitment, C-01). |
 | [`06-seq-cloning.md`](06-seq-cloning.md) | Three-message enclave-to-enclave seed cloning (X25519 + HKDF-SHA256 + ChaCha20-Poly1305 + HMAC + PCR equality). |
 | [`07-seq-initialize-keys.md`](07-seq-initialize-keys.md) | First-time key initialisation from OS entropy (BIP-39 → BIP-32 → BIP-84/86 derivation). |
 | [`08-seq-spv-submit-headers.md`](08-seq-spv-submit-headers.md) | Listener-driven SPV header sync into the in-enclave chain, with bounded-reorg / weaker-chain rejection. |

--- a/docs/tee-spec.md
+++ b/docs/tee-spec.md
@@ -460,18 +460,18 @@ mint-PSBT binding (#146) · swap op-id preservation (#168) · audit regression +
 
 Mermaid in Markdown -- rendered inline on GitHub.
 
-| Diagram                   | File                                    | Freshness                                           |
-|---------------------------|-----------------------------------------|-----------------------------------------------------|
-| Component structure       | `diagrams/01-components.md`             | stale -- predates the `networks/` layout and Sec 4  |
-| Deployment / trust zones  | `diagrams/02-deployment.md`             | mostly current                                      |
-| Sign EVM (unlock)         | `diagrams/03-seq-sign-evm.md`           | stale -- predates unified `Sign` + canonical ABI    |
-| Sign PSBT                 | `diagrams/04-seq-sign-psbt.md`          | stale -- predates `SignBtc` split + `FundsIn` pins  |
-| Attested pubkey           | `diagrams/05-seq-attested-pubkey.md`    | mostly current (commitment now includes the policy) |
-| Cloning handshake         | `diagrams/06-seq-cloning.md`            | mostly current                                      |
-| Initialize keys           | `diagrams/07-seq-initialize-keys.md`    | mostly current                                      |
-| SPV submit headers        | `diagrams/08-seq-spv-submit-headers.md` | mostly current (missing submission caps)            |
-| Phase state machine       | `diagrams/09-state-phase.md`            | current                                             |
-| Signing gate / predicates | `diagrams/10-signing-gate.md`           | stale -- see Sec 9 for the authoritative gate       |
+| Diagram                   | File                                    |
+|---------------------------|-----------------------------------------|
+| Component structure       | `diagrams/01-components.md`             |
+| Deployment / trust zones  | `diagrams/02-deployment.md`             |
+| Sign fundsOut (unlock)    | `diagrams/03-seq-sign-evm.md`           |
+| Sign bridge PSBT          | `diagrams/04-seq-sign-psbt.md`          |
+| Attested pubkey           | `diagrams/05-seq-attested-pubkey.md`    |
+| Cloning handshake         | `diagrams/06-seq-cloning.md`            |
+| Initialize keys           | `diagrams/07-seq-initialize-keys.md`    |
+| SPV submit headers        | `diagrams/08-seq-spv-submit-headers.md` |
+| Phase state machine       | `diagrams/09-state-phase.md`            |
+| Signing gate / predicates | `diagrams/10-signing-gate.md`           |
 
-A diagram refresh is tracked separately; where a diagram and this spec
-disagree, this spec is authoritative.
+All diagrams refreshed 2026-07-28 to match this spec; where a diagram and this
+spec disagree, this spec is authoritative.


### PR DESCRIPTION
## What

Refreshes all `docs/diagrams/*.md` to match the current `dev-ng` code, following up on the tee-spec rewrite in #170. Stacked on `docs/tee-spec-refresh`; when #170 merges this retargets to `dev-ng`.

## Main updates

- **01-components**: redrawn for the `networks/{evm,rgb}` module layout; adds `policy.rs` (C-01), `conn.rs`, the full request set, and the current `BridgeConfig` pins.
- **03-seq-sign-evm**: rewritten for the unified `Sign` request — single pools selector, canonical ABI check (W-01), witness-confirmation and BtcRelay gates, `MultisigProxy`/`1` domain, op-id preservation (#168).
- **04-seq-sign-psbt**: rewritten for the bridge-only path — `FUNDS_IN_CONTRACT` pin (#152), `BridgeFundsIn` preference (#150), `funds_in_operation_id` binding (#153), fee sanity (#147/#149), mint-RGB transitions (#146); notes the separate `SignBtc` path (#102).
- **10-signing-gate**: predicate flow redrawn to match the spec's Sec 9, with current closed/open status.
- **02, 05, 06, 07, 08, 09**: targeted updates — C-01 policy commitment in `user_data`, post-auth nonce recording (W-13/#129), header submission caps (#86/#130), gas-tx key, current request names.
- `tee-spec.md` Appendix A now marks all diagrams current; dead `docs/audit/` links removed.

All mermaid blocks validated with the mermaid parser (v11).