### PR TITLE
feat(enclave): bound aggregate request size/compute before parsing

### DIFF
--- a/enclave/src/config.rs
+++ b/enclave/src/config.rs
@@ -20,8 +20,26 @@
 
 use crate::error::{EnclaveError, Result};
 
+/// Default aggregate request-size caps for the RGB signing path, used when the
+/// matching env var is unset. Operators may override each via env
+/// (`MAX_CONSIGNMENT_BYTES`, `MAX_MERKLE_PROOFS`, `MAX_TOTAL_PROOF_BYTES`), a
+/// per-deployment tune that needs no rebuild or re-attestation. These are
+/// defense-in-depth DoS bounds on the serial signing path; consignment size is
+/// additionally hard-capped by the 4 MB wire frame regardless of this value.
+///
+/// Real USDT-swap consignments are a few KB (the in-tree fixture is ~5.5 KB);
+/// 1 MiB is a generous ceiling well under the 4 MB frame.
+pub const DEFAULT_MAX_CONSIGNMENT_BYTES: usize = 1024 * 1024;
+/// Default cap on the number of Merkle proofs a source may carry (env
+/// `MAX_MERKLE_PROOFS`). A consignment anchors a handful of witness txs.
+pub const DEFAULT_MAX_MERKLE_PROOFS: usize = 256;
+/// Default cap on total variable-length proof bytes (txids + Merkle-path
+/// siblings) across all proofs (env `MAX_TOTAL_PROOF_BYTES`), bounding aggregate
+/// Merkle-hashing work independently of the per-proof depth cap.
+pub const DEFAULT_MAX_TOTAL_PROOF_BYTES: usize = 128 * 1024;
+
 /// Bridge config pinned at enclave boot from env. See module docs.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct BridgeConfig {
     pub chain_id: u64,
     pub bridge_contract: [u8; 20],
@@ -65,6 +83,31 @@ pub struct BridgeConfig {
     /// pins the MultisigProxy for the EVM signing cross-check — one pin cannot
     /// serve both lookups.
     pub funds_in_contract: [u8; 20],
+    /// Aggregate request-size caps for the RGB signing path, operator-tunable
+    /// via env (`MAX_CONSIGNMENT_BYTES` / `MAX_MERKLE_PROOFS` /
+    /// `MAX_TOTAL_PROOF_BYTES`); each defaults to its `DEFAULT_*` constant when
+    /// unset (or set to 0). Defense-in-depth DoS bounds, not attested — like the
+    /// operational pins above. See [`DEFAULT_MAX_CONSIGNMENT_BYTES`].
+    pub max_consignment_bytes: usize,
+    pub max_merkle_proofs: usize,
+    pub max_total_proof_bytes: usize,
+}
+
+impl Default for BridgeConfig {
+    fn default() -> Self {
+        Self {
+            chain_id: 0,
+            bridge_contract: [0u8; 20],
+            rgb_asset_id: String::new(),
+            gas_tx_allowed_to: None,
+            btc_allowed_scripts: Vec::new(),
+            btc_max_total_sats: 0,
+            funds_in_contract: [0u8; 20],
+            max_consignment_bytes: DEFAULT_MAX_CONSIGNMENT_BYTES,
+            max_merkle_proofs: DEFAULT_MAX_MERKLE_PROOFS,
+            max_total_proof_bytes: DEFAULT_MAX_TOTAL_PROOF_BYTES,
+        }
+    }
 }
 
 impl BridgeConfig {
@@ -113,6 +156,21 @@ impl BridgeConfig {
             .and_then(|s| parse_eth_address(&s).ok())
             .unwrap_or(bridge_contract);
 
+        // Aggregate request-size caps (operator-tunable, defense-in-depth). An
+        // unset, unparseable, or zero value falls back to the default.
+        let parse_cap = |name: &str, default: usize| -> usize {
+            std::env::var(name)
+                .ok()
+                .and_then(|s| s.parse::<usize>().ok())
+                .filter(|&n| n > 0)
+                .unwrap_or(default)
+        };
+        let max_consignment_bytes =
+            parse_cap("MAX_CONSIGNMENT_BYTES", DEFAULT_MAX_CONSIGNMENT_BYTES);
+        let max_merkle_proofs = parse_cap("MAX_MERKLE_PROOFS", DEFAULT_MAX_MERKLE_PROOFS);
+        let max_total_proof_bytes =
+            parse_cap("MAX_TOTAL_PROOF_BYTES", DEFAULT_MAX_TOTAL_PROOF_BYTES);
+
         Self {
             chain_id,
             bridge_contract,
@@ -121,6 +179,9 @@ impl BridgeConfig {
             btc_allowed_scripts,
             btc_max_total_sats,
             funds_in_contract,
+            max_consignment_bytes,
+            max_merkle_proofs,
+            max_total_proof_bytes,
         }
     }
 

--- a/enclave/src/networks/rgb/mod.rs
+++ b/enclave/src/networks/rgb/mod.rs
@@ -150,14 +150,14 @@ pub fn validate_destination_anchor(
                 .into(),
         ));
     }
-    // Aggregate size cap, before the keccak hash and the rgbstd parse below —
-    // the destination consignment is otherwise bounded only by the generic 4 MB
-    // wire frame.
-    if destination.consignment.len() > validation::MAX_CONSIGNMENT_BYTES {
+    // Aggregate size cap (operator-configurable via `MAX_CONSIGNMENT_BYTES`),
+    // before the keccak hash and the rgbstd parse below — the destination
+    // consignment is otherwise bounded only by the generic 4 MB wire frame.
+    if destination.consignment.len() > ctx.bridge_config.max_consignment_bytes {
         return Err(EnclaveError::CrossCheck(format!(
             "send-RGB consignment too large: {} bytes (max {})",
             destination.consignment.len(),
-            validation::MAX_CONSIGNMENT_BYTES
+            ctx.bridge_config.max_consignment_bytes
         )));
     }
     // Wire-tamper detection, mirroring the EVM path's defence-in-depth check.

--- a/enclave/src/networks/rgb/mod.rs
+++ b/enclave/src/networks/rgb/mod.rs
@@ -150,6 +150,16 @@ pub fn validate_destination_anchor(
                 .into(),
         ));
     }
+    // Aggregate size cap, before the keccak hash and the rgbstd parse below —
+    // the destination consignment is otherwise bounded only by the generic 4 MB
+    // wire frame.
+    if destination.consignment.len() > validation::MAX_CONSIGNMENT_BYTES {
+        return Err(EnclaveError::CrossCheck(format!(
+            "send-RGB consignment too large: {} bytes (max {})",
+            destination.consignment.len(),
+            validation::MAX_CONSIGNMENT_BYTES
+        )));
+    }
     // Wire-tamper detection, mirroring the EVM path's defence-in-depth check.
     // INTEGRITY, NOT AUTHORIZATION (audit I-02 / Oxorio I-09): the listener
     // controls both `consignment` and `consignment_hash`, so a match only

--- a/enclave/src/networks/rgb/validation.rs
+++ b/enclave/src/networks/rgb/validation.rs
@@ -28,6 +28,31 @@ use crate::proto::RgbSource;
 #[cfg(feature = "spv")]
 use super::spv_validation;
 
+/// Aggregate request-size caps enforced *before* the expensive rgbstd
+/// consignment parse and the SPV Merkle-proof loop. The generic
+/// 4 MB wire-frame cap (`framing::MAX_MESSAGE_SIZE`) and the per-field caps
+/// (`spv_validation::MAX_MERKLE_PATH_DEPTH`,
+/// `evm::validation::MAX_FUNDS_OUT_CALL_DATA_LEN`) leave the *aggregate* parse
+/// and hashing budget unbounded: a request can stay under every individual
+/// limit yet still carry a multi-megabyte consignment or a large set of proofs.
+/// These caps bound that aggregate work up front, on the serial signing path.
+///
+/// Real USDT-swap consignments are a few KB (the in-tree transfer fixture is
+/// ~5.5 KB); 1 MiB is a generous ceiling well under the 4 MB frame.
+pub const MAX_CONSIGNMENT_BYTES: usize = 1024 * 1024;
+
+/// Maximum number of Merkle proofs (witness txids) a single source may carry.
+/// A consignment anchors a handful of witness transactions; 256 is far above
+/// any realistic transfer history.
+pub const MAX_MERKLE_PROOFS: usize = 256;
+
+/// Maximum total variable-length proof bytes (txids + Merkle-path siblings)
+/// summed across every proof, bounding aggregate Merkle-hashing work
+/// independently of the per-proof depth cap. 128 KiB permits a large multiple
+/// of any realistic proof set while rejecting a proof flood that stays under
+/// both the count cap and the per-path-depth cap.
+pub const MAX_TOTAL_PROOF_BYTES: usize = 128 * 1024;
+
 /// Validate all fields and source-chain evidence owned by an RGB source.
 ///
 /// This deliberately does not inspect or care about the destination network.
@@ -117,6 +142,32 @@ fn validate_source_payload(source: &RgbSource) -> Result<()> {
             "RGB source requires raw consignment bytes; consignment_valid is not authoritative"
                 .into(),
         ));
+    }
+    // Aggregate size/compute caps, enforced before the keccak hash and the full
+    // rgbstd parse below so a request cannot force disproportionate
+    // parsing/hashing while staying under every per-field cap.
+    if source.consignment.len() > MAX_CONSIGNMENT_BYTES {
+        return Err(EnclaveError::CrossCheck(format!(
+            "RGB source consignment too large: {} bytes (max {MAX_CONSIGNMENT_BYTES})",
+            source.consignment.len()
+        )));
+    }
+    if source.merkle_proofs.len() > MAX_MERKLE_PROOFS {
+        return Err(EnclaveError::CrossCheck(format!(
+            "RGB source carries too many merkle proofs: {} (max {MAX_MERKLE_PROOFS})",
+            source.merkle_proofs.len()
+        )));
+    }
+    let total_proof_bytes: usize = source
+        .merkle_proofs
+        .iter()
+        .map(|p| p.txid.len() + p.merkle_path.iter().map(|s| s.len()).sum::<usize>())
+        .sum();
+    if total_proof_bytes > MAX_TOTAL_PROOF_BYTES {
+        return Err(EnclaveError::CrossCheck(format!(
+            "RGB source merkle proofs too large in aggregate: {total_proof_bytes} bytes \
+             (max {MAX_TOTAL_PROOF_BYTES})"
+        )));
     }
     // Hash integrity check between listener-supplied bytes and the pre-computed
     // keccak. This is INTEGRITY, NOT AUTHORIZATION (audit I-02 / Oxorio I-09):
@@ -1016,6 +1067,8 @@ mod tests {
     const CONTRACT_FIXTURE: &[u8] =
         include_bytes!("../../../tests/fixtures/contract_consignment.rgbc");
 
+    use crate::proto::MerkleProofEntry;
+
     #[test]
     fn rejects_invalid_bytes() {
         let validator = RgbValidator::new("http://localhost:1".to_string(), "regtest").unwrap();
@@ -1477,6 +1530,66 @@ mod tests {
     #[test]
     fn accepts_valid_consignment_hash() {
         assert!(validate_source_payload(&fixture_source("rgb:any-declared-asset")).is_ok());
+    }
+
+    /// A consignment larger than `MAX_CONSIGNMENT_BYTES` is rejected by the
+    /// payload gate with the aggregate-size error *before* any rgbstd parse
+    /// (the error is the size cap, not a decode failure).
+    #[test]
+    fn rejects_oversized_consignment_before_parse() {
+        let mut source = fixture_source("rgb:any-declared-asset");
+        source.consignment = vec![0u8; MAX_CONSIGNMENT_BYTES + 1];
+        source.consignment_hash = keccak(&source.consignment);
+        let err = validate_source_payload(&source).unwrap_err().to_string();
+        assert!(err.contains("consignment too large"), "unexpected: {err}");
+    }
+
+    /// Boundary: a consignment exactly at `MAX_CONSIGNMENT_BYTES` passes the
+    /// aggregate gate (rejection is strictly `>` the cap).
+    #[test]
+    fn accepts_consignment_at_size_cap() {
+        let mut source = fixture_source("rgb:any-declared-asset");
+        source.consignment = vec![0u8; MAX_CONSIGNMENT_BYTES];
+        source.consignment_hash = keccak(&source.consignment);
+        assert!(validate_source_payload(&source).is_ok());
+    }
+
+    /// Too many Merkle proofs is rejected on count alone, even when each proof
+    /// is individually tiny.
+    #[test]
+    fn rejects_too_many_merkle_proofs() {
+        let mut source = fixture_source("rgb:any-declared-asset");
+        source.merkle_proofs = (0..MAX_MERKLE_PROOFS + 1)
+            .map(|_| MerkleProofEntry::default())
+            .collect();
+        let err = validate_source_payload(&source).unwrap_err().to_string();
+        assert!(err.contains("too many merkle proofs"), "unexpected: {err}");
+    }
+
+    /// Proofs that each stay under the per-path-depth cap but exceed the
+    /// aggregate byte budget are rejected by the aggregate gate — the case the
+    /// per-field caps miss.
+    #[test]
+    fn rejects_aggregate_proof_bytes_over_budget() {
+        // Each proof counts 32-byte txid + 32 siblings * 32 bytes = 1056 bytes,
+        // all within MAX_MERKLE_PATH_DEPTH. Take just enough to cross the
+        // aggregate cap while staying under the proof-count cap.
+        let per_proof = 32 + 32 * 32;
+        let n = MAX_TOTAL_PROOF_BYTES / per_proof + 1;
+        assert!(
+            n <= MAX_MERKLE_PROOFS,
+            "test would trip the count cap first"
+        );
+        let proof = MerkleProofEntry {
+            txid: vec![0u8; 32],
+            block_height: 0,
+            tx_position: 0,
+            merkle_path: vec![vec![0u8; 32]; 32],
+        };
+        let mut source = fixture_source("rgb:any-declared-asset");
+        source.merkle_proofs = vec![proof; n];
+        let err = validate_source_payload(&source).unwrap_err().to_string();
+        assert!(err.contains("too large in aggregate"), "unexpected: {err}");
     }
 
     /// Old `ignores_consignment_valid_flag_when_bytes_present`: an identical

--- a/enclave/src/networks/rgb/validation.rs
+++ b/enclave/src/networks/rgb/validation.rs
@@ -21,37 +21,13 @@ use rgbstd::validation::ValidationConfig;
 use rgbstd::ChainNet;
 use sha3::{Digest, Keccak256};
 
+use crate::config::BridgeConfig;
 use crate::error::{EnclaveError, Result};
 use crate::networks::ValidationContext;
 use crate::proto::RgbSource;
 
 #[cfg(feature = "spv")]
 use super::spv_validation;
-
-/// Aggregate request-size caps enforced *before* the expensive rgbstd
-/// consignment parse and the SPV Merkle-proof loop. The generic
-/// 4 MB wire-frame cap (`framing::MAX_MESSAGE_SIZE`) and the per-field caps
-/// (`spv_validation::MAX_MERKLE_PATH_DEPTH`,
-/// `evm::validation::MAX_FUNDS_OUT_CALL_DATA_LEN`) leave the *aggregate* parse
-/// and hashing budget unbounded: a request can stay under every individual
-/// limit yet still carry a multi-megabyte consignment or a large set of proofs.
-/// These caps bound that aggregate work up front, on the serial signing path.
-///
-/// Real USDT-swap consignments are a few KB (the in-tree transfer fixture is
-/// ~5.5 KB); 1 MiB is a generous ceiling well under the 4 MB frame.
-pub const MAX_CONSIGNMENT_BYTES: usize = 1024 * 1024;
-
-/// Maximum number of Merkle proofs (witness txids) a single source may carry.
-/// A consignment anchors a handful of witness transactions; 256 is far above
-/// any realistic transfer history.
-pub const MAX_MERKLE_PROOFS: usize = 256;
-
-/// Maximum total variable-length proof bytes (txids + Merkle-path siblings)
-/// summed across every proof, bounding aggregate Merkle-hashing work
-/// independently of the per-proof depth cap. 128 KiB permits a large multiple
-/// of any realistic proof set while rejecting a proof flood that stays under
-/// both the count cap and the per-path-depth cap.
-pub const MAX_TOTAL_PROOF_BYTES: usize = 128 * 1024;
 
 /// Validate all fields and source-chain evidence owned by an RGB source.
 ///
@@ -72,7 +48,7 @@ pub fn validate_source(
     source: &RgbSource,
     ctx: &ValidationContext<'_>,
 ) -> Result<ValidatedConsignment> {
-    validate_source_payload(source)?;
+    validate_source_payload(source, ctx.bridge_config)?;
 
     let validator = ctx.rgb_validator.ok_or_else(|| {
         EnclaveError::CrossCheck(
@@ -136,26 +112,29 @@ pub fn validate_source(
     Ok(validated)
 }
 
-fn validate_source_payload(source: &RgbSource) -> Result<()> {
+fn validate_source_payload(source: &RgbSource, cfg: &BridgeConfig) -> Result<()> {
     if source.consignment.is_empty() {
         return Err(EnclaveError::CrossCheck(
             "RGB source requires raw consignment bytes; consignment_valid is not authoritative"
                 .into(),
         ));
     }
-    // Aggregate size/compute caps, enforced before the keccak hash and the full
+    // Aggregate size/compute caps (operator-configurable, defaulting to the
+    // `DEFAULT_*` constants), enforced before the keccak hash and the full
     // rgbstd parse below so a request cannot force disproportionate
     // parsing/hashing while staying under every per-field cap.
-    if source.consignment.len() > MAX_CONSIGNMENT_BYTES {
+    if source.consignment.len() > cfg.max_consignment_bytes {
         return Err(EnclaveError::CrossCheck(format!(
-            "RGB source consignment too large: {} bytes (max {MAX_CONSIGNMENT_BYTES})",
-            source.consignment.len()
+            "RGB source consignment too large: {} bytes (max {})",
+            source.consignment.len(),
+            cfg.max_consignment_bytes
         )));
     }
-    if source.merkle_proofs.len() > MAX_MERKLE_PROOFS {
+    if source.merkle_proofs.len() > cfg.max_merkle_proofs {
         return Err(EnclaveError::CrossCheck(format!(
-            "RGB source carries too many merkle proofs: {} (max {MAX_MERKLE_PROOFS})",
-            source.merkle_proofs.len()
+            "RGB source carries too many merkle proofs: {} (max {})",
+            source.merkle_proofs.len(),
+            cfg.max_merkle_proofs
         )));
     }
     let total_proof_bytes: usize = source
@@ -163,10 +142,10 @@ fn validate_source_payload(source: &RgbSource) -> Result<()> {
         .iter()
         .map(|p| p.txid.len() + p.merkle_path.iter().map(|s| s.len()).sum::<usize>())
         .sum();
-    if total_proof_bytes > MAX_TOTAL_PROOF_BYTES {
+    if total_proof_bytes > cfg.max_total_proof_bytes {
         return Err(EnclaveError::CrossCheck(format!(
-            "RGB source merkle proofs too large in aggregate: {total_proof_bytes} bytes \
-             (max {MAX_TOTAL_PROOF_BYTES})"
+            "RGB source merkle proofs too large in aggregate: {total_proof_bytes} bytes (max {})",
+            cfg.max_total_proof_bytes
         )));
     }
     // Hash integrity check between listener-supplied bytes and the pre-computed
@@ -1067,6 +1046,10 @@ mod tests {
     const CONTRACT_FIXTURE: &[u8] =
         include_bytes!("../../../tests/fixtures/contract_consignment.rgbc");
 
+    use crate::config::{
+        BridgeConfig, DEFAULT_MAX_CONSIGNMENT_BYTES, DEFAULT_MAX_MERKLE_PROOFS,
+        DEFAULT_MAX_TOTAL_PROOF_BYTES,
+    };
     use crate::proto::MerkleProofEntry;
 
     #[test]
@@ -1529,29 +1512,55 @@ mod tests {
     /// validator/SPV work, not payload shape.
     #[test]
     fn accepts_valid_consignment_hash() {
-        assert!(validate_source_payload(&fixture_source("rgb:any-declared-asset")).is_ok());
+        assert!(validate_source_payload(
+            &fixture_source("rgb:any-declared-asset"),
+            &BridgeConfig::default()
+        )
+        .is_ok());
     }
 
-    /// A consignment larger than `MAX_CONSIGNMENT_BYTES` is rejected by the
-    /// payload gate with the aggregate-size error *before* any rgbstd parse
-    /// (the error is the size cap, not a decode failure).
+    /// A consignment larger than the configured cap is rejected by the payload
+    /// gate with the aggregate-size error *before* any rgbstd parse (the error
+    /// is the size cap, not a decode failure).
     #[test]
     fn rejects_oversized_consignment_before_parse() {
         let mut source = fixture_source("rgb:any-declared-asset");
-        source.consignment = vec![0u8; MAX_CONSIGNMENT_BYTES + 1];
+        source.consignment = vec![0u8; DEFAULT_MAX_CONSIGNMENT_BYTES + 1];
         source.consignment_hash = keccak(&source.consignment);
-        let err = validate_source_payload(&source).unwrap_err().to_string();
+        let err = validate_source_payload(&source, &BridgeConfig::default())
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("consignment too large"), "unexpected: {err}");
     }
 
-    /// Boundary: a consignment exactly at `MAX_CONSIGNMENT_BYTES` passes the
-    /// aggregate gate (rejection is strictly `>` the cap).
+    /// Boundary: a consignment exactly at the cap passes the aggregate gate
+    /// (rejection is strictly `>` the cap).
     #[test]
     fn accepts_consignment_at_size_cap() {
         let mut source = fixture_source("rgb:any-declared-asset");
-        source.consignment = vec![0u8; MAX_CONSIGNMENT_BYTES];
+        source.consignment = vec![0u8; DEFAULT_MAX_CONSIGNMENT_BYTES];
         source.consignment_hash = keccak(&source.consignment);
-        assert!(validate_source_payload(&source).is_ok());
+        assert!(validate_source_payload(&source, &BridgeConfig::default()).is_ok());
+    }
+
+    /// The caps are operator-configurable: a smaller `max_consignment_bytes`
+    /// rejects a consignment the default would accept.
+    #[test]
+    fn honors_configured_consignment_cap() {
+        let mut source = fixture_source("rgb:any-declared-asset");
+        source.consignment = vec![0u8; 200];
+        source.consignment_hash = keccak(&source.consignment);
+        // The default cap accepts 200 bytes.
+        assert!(validate_source_payload(&source, &BridgeConfig::default()).is_ok());
+        // A 100-byte configured cap rejects the same source.
+        let cfg = BridgeConfig {
+            max_consignment_bytes: 100,
+            ..BridgeConfig::default()
+        };
+        let err = validate_source_payload(&source, &cfg)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("consignment too large"), "unexpected: {err}");
     }
 
     /// Too many Merkle proofs is rejected on count alone, even when each proof
@@ -1559,10 +1568,12 @@ mod tests {
     #[test]
     fn rejects_too_many_merkle_proofs() {
         let mut source = fixture_source("rgb:any-declared-asset");
-        source.merkle_proofs = (0..MAX_MERKLE_PROOFS + 1)
+        source.merkle_proofs = (0..DEFAULT_MAX_MERKLE_PROOFS + 1)
             .map(|_| MerkleProofEntry::default())
             .collect();
-        let err = validate_source_payload(&source).unwrap_err().to_string();
+        let err = validate_source_payload(&source, &BridgeConfig::default())
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("too many merkle proofs"), "unexpected: {err}");
     }
 
@@ -1575,9 +1586,9 @@ mod tests {
         // all within MAX_MERKLE_PATH_DEPTH. Take just enough to cross the
         // aggregate cap while staying under the proof-count cap.
         let per_proof = 32 + 32 * 32;
-        let n = MAX_TOTAL_PROOF_BYTES / per_proof + 1;
+        let n = DEFAULT_MAX_TOTAL_PROOF_BYTES / per_proof + 1;
         assert!(
-            n <= MAX_MERKLE_PROOFS,
+            n <= DEFAULT_MAX_MERKLE_PROOFS,
             "test would trip the count cap first"
         );
         let proof = MerkleProofEntry {
@@ -1588,7 +1599,9 @@ mod tests {
         };
         let mut source = fixture_source("rgb:any-declared-asset");
         source.merkle_proofs = vec![proof; n];
-        let err = validate_source_payload(&source).unwrap_err().to_string();
+        let err = validate_source_payload(&source, &BridgeConfig::default())
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("too large in aggregate"), "unexpected: {err}");
     }
 
@@ -1599,9 +1612,9 @@ mod tests {
     fn ignores_consignment_valid_flag_when_bytes_present() {
         let mut source = fixture_source("rgb:any-declared-asset");
         source.consignment_valid = false;
-        assert!(validate_source_payload(&source).is_ok());
+        assert!(validate_source_payload(&source, &BridgeConfig::default()).is_ok());
         source.consignment_valid = true;
-        assert!(validate_source_payload(&source).is_ok());
+        assert!(validate_source_payload(&source, &BridgeConfig::default()).is_ok());
     }
 
     /// Old `rejects_empty_consignment_even_with_valid_flag` (P0 regression):
@@ -1613,7 +1626,7 @@ mod tests {
         source.consignment = vec![];
         source.consignment_hash = vec![];
         source.consignment_valid = true;
-        let err = validate_source_payload(&source).unwrap_err();
+        let err = validate_source_payload(&source, &BridgeConfig::default()).unwrap_err();
         assert!(
             err.to_string().contains("requires raw consignment bytes"),
             "expected raw-bytes-required rejection, got: {err}"
@@ -1626,7 +1639,7 @@ mod tests {
         let mut source = fixture_source("rgb:any-declared-asset");
         source.consignment_hash = vec![0xDE; 32];
         source.consignment_valid = true;
-        let err = validate_source_payload(&source).unwrap_err();
+        let err = validate_source_payload(&source, &BridgeConfig::default()).unwrap_err();
         assert!(
             err.to_string().contains("consignment hash mismatch"),
             "expected hash-mismatch rejection, got: {err}"


### PR DESCRIPTION
The generic 4 MB wire-frame cap and the existing per-field caps left the aggregate parse/hash budget unbounded: a request could stay under every per-field limit yet still force a large rgbstd consignment parse or proof-verification loop on the serial signing path.

Enforce aggregate caps before any expensive parsing:
- consignment size (1 MiB), on both the source and send-RGB destination paths;
- number of Merkle proofs (256);
- aggregate txid + Merkle-path bytes (128 KiB), bounding hashing work independently of the per-proof depth cap.

Real swap consignments are a few KB, so the caps sit far above legitimate traffic. Adds boundary and rejection tests.

Closes #163