### PR TITLE
feat(enclave): replace the Esplora forwarder with a typed, pinned client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7926,6 +7926,7 @@ dependencies = [
  "rgb-schemas",
  "secrecy",
  "serde",
+ "serde_json",
  "sha2 0.10.9",
  "sha3 0.10.8",
  "subtle",

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -65,6 +65,11 @@ rgb-consignment = { git = "ssh://git@github.com/UTEXO-Protocol/rgb-consignment-p
 # Pins per schema_id so a consignment cannot self-validate its own types
 # (audit 4th W-01 / #92). `default-features = false` skips the CLI bin deps.
 rgb-schemas = { version = "=0.11.1-rc.10", default-features = false, optional = true }
+# JSON decode for the typed, pinned Esplora client: reuses
+# `esplora_client::TxStatus` + the fee-estimate map decoders. Already present in
+# the tree via `rgb-ops`'s esplora-client, so this direct dep adds nothing to
+# the binary. Gated to `rgb-validation` (the only code path that fetches).
+serde_json = { version = "1", optional = true }
 
 # Attestation verification (COSE_Sign1 + AWS Nitro cert chain) lives in
 # the workspace `attestation-verify` crate so the parent CLI binary and
@@ -127,7 +132,7 @@ dev-mode = []
 # resolver, so a malicious host could have the enclave sign a release against a
 # fabricated Bitcoin anchor. Kept as a separate feature (rather than adding
 # `spv` to this list) to avoid a feature cycle with `spv` below.
-rgb-validation = ["rgb-ops", "rgb-consignment", "rgb-schemas"]
+rgb-validation = ["rgb-ops", "rgb-consignment", "rgb-schemas", "dep:serde_json"]
 # Bitcoin SPV verification of consignment witness txids before signing EVM
 # transactions. Implies `rgb-validation` because SPV needs the consignment
 # parsed to extract witness txids. When the feature is OFF, handle_sign_evm

--- a/enclave/src/main.rs
+++ b/enclave/src/main.rs
@@ -88,29 +88,18 @@ fn main() {
         }
     }
 
-    // Start vsock-to-TCP forwarder for Esplora access (production only).
-    // The host must run: vsock-proxy <ESPLORA_VSOCK_PORT> <esplora-host> <esplora-port>
-    // Untrusted, host-controlled egress boundary (audit I-01): data fetched
-    // through it is evidence verified by SPV + rgbstd validation, never
-    // trusted input. See `vsock_forwarder`'s module-level TRUST BOUNDARY note.
+    // Host-egress vsock forwarders (production only). Untrusted,
+    // host-controlled egress boundary: bytes fetched through them are evidence
+    // verified in-enclave (SPV + rgbstd validation, or Helios), never trusted
+    // input. Esplora no longer uses a generic forwarder — the RGB validator
+    // owns a typed, destination-pinned Esplora client that dials the parent
+    // vsock directly (see `RgbValidator::new_vsock`), so no loopback Esplora
+    // port is bound. These forwarders serve only the EVM-RPC and Helios paths.
     #[cfg(all(feature = "vsock", target_os = "linux"))]
     {
-        let vsock_port: u32 = std::env::var("ESPLORA_VSOCK_PORT")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(8001);
-        tracing::info!(
-            vsock_port,
-            "starting Esplora vsock forwarder (host must run: vsock-proxy {vsock_port} <esplora-host> <esplora-port>)"
-        );
-        if let Err(e) = utexo_bridge_enclave::vsock_forwarder::start_forwarder(3443, vsock_port) {
-            tracing::error!("failed to start vsock forwarder: {e}");
-        }
-
-        // Second forwarder for the EVM JSON-RPC used by in-enclave FundsIn
-        // verification (#60). Distinct loopback/vsock ports from Esplora
-        // (3443/8001). Untrusted, host-controlled egress boundary (audit I-01);
-        // the host must run: vsock-proxy <EVM_RPC_VSOCK_PORT> <evm-rpc-host> <port>.
+        // Forwarder for the EVM JSON-RPC used by in-enclave FundsIn
+        // verification. Untrusted, host-controlled egress boundary; the host
+        // must run: vsock-proxy <EVM_RPC_VSOCK_PORT> <evm-rpc-host> <port>.
         #[cfg(feature = "evm-rpc")]
         {
             let evm_vsock_port: u32 = std::env::var("EVM_RPC_VSOCK_PORT")
@@ -173,10 +162,24 @@ fn main() {
     // Build RGB consignment validator (when feature enabled).
     #[cfg(feature = "rgb-validation")]
     let rgb_validator = {
-        let esplora_url =
-            std::env::var("ESPLORA_URL").unwrap_or_else(|_| "http://127.0.0.1:3443".into());
         let network = std::env::var("BITCOIN_NETWORK").unwrap_or_else(|_| "bitcoin".into());
-        match RgbValidator::new(esplora_url, &network) {
+        // Production dials the parent vsock directly through the pinned, typed
+        // Esplora client (no loopback forwarder); dev/tests use a direct TCP URL.
+        #[cfg(all(feature = "vsock", target_os = "linux"))]
+        let validator = {
+            let vsock_port: u32 = std::env::var("ESPLORA_VSOCK_PORT")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(8001);
+            RgbValidator::new_vsock(vsock_port, &network)
+        };
+        #[cfg(not(all(feature = "vsock", target_os = "linux")))]
+        let validator = {
+            let esplora_url =
+                std::env::var("ESPLORA_URL").unwrap_or_else(|_| "http://127.0.0.1:3443".into());
+            RgbValidator::new(esplora_url, &network)
+        };
+        match validator {
             Ok(v) => {
                 tracing::info!("RGB validator initialized");
                 Some(v)

--- a/enclave/src/networks/rgb/esplora_egress.rs
+++ b/enclave/src/networks/rgb/esplora_egress.rs
@@ -1,0 +1,715 @@
+//! Typed, destination-pinned Esplora egress for the RGB consignment resolver.
+//!
+//! Replaces the generic loopback→vsock forwarder for the Esplora path. The
+//! forwarder is a process-wide egress primitive: any code inside the enclave
+//! that can open a loopback socket could tunnel arbitrary host-bound traffic
+//! through it. This client instead:
+//!   * dials a **boot-pinned** destination — production dials the parent vsock
+//!     directly (CID 3, no loopback port at all); dev/tests use a fixed TCP
+//!     host:port;
+//!   * exposes **only** the four GETs the resolver and the fee-rate check
+//!     issue (`/block-height/0`, `/tx/{txid}/raw`, `/tx/{txid}/status`,
+//!     `/fee-estimates`). There is no arbitrary-path method, so no other
+//!     host-bound traffic can be composed;
+//!   * bounds every call with a connect/read timeout, **no retries**, and a
+//!     response-size cap, so a stalled or 429/5xx-spamming host can neither
+//!     amplify one fetch nor pin a signing worker. esplora-client's default
+//!     6-retry backoff is what this replaces.
+//!
+//! TRUST BOUNDARY: responses are still HOST-RELAYED and UNTRUSTED. This client
+//! bounds *what* is fetched and *how long* it may take; it never makes the
+//! bytes trustworthy. Authorisation comes from SPV proof checking and rgbstd
+//! consignment validation, never from these responses. The resolver logic below
+//! mirrors rgb-ops' `EsploraClient` / `AnyResolver` exactly so the RGB
+//! validation semantics are unchanged.
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::num::NonZeroU32;
+use std::str::FromStr;
+use std::time::Duration;
+
+use bitcoin::consensus::encode::deserialize as consensus_deserialize;
+use bitcoin::{BlockHash, Transaction, Txid};
+use rgbstd::indexers::esplora_blocking::esplora_client::TxStatus;
+use rgbstd::rgbcore::validation::{ResolveWitness, WitnessResolverError, WitnessStatus};
+use rgbstd::rgbcore::vm::{WitnessOrd, WitnessPos};
+use rgbstd::rgbcore::ChainNet;
+
+use crate::conn::{DeadlineStream, SocketTimeout};
+use crate::error::{EnclaveError, Result};
+
+/// Parent instance CID in Nitro enclaves is always 3.
+#[cfg(all(feature = "vsock", target_os = "linux"))]
+const PARENT_CID: u32 = 3;
+
+/// Upper bound on a single Esplora response (headers + body). Witness txs and
+/// fee maps are a few KB; this ceiling only bounds a host that streams forever
+/// without ever closing (the read timeout bounds a host that stalls silently).
+const MAX_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+/// A boot-pinned Esplora destination. The host still relays the bytes; pinning
+/// only removes the caller's ability to choose *where* the egress goes.
+#[derive(Debug, Clone)]
+pub enum EsploraDest {
+    /// Parent vsock (CID 3) at the given port. Production: no loopback port.
+    #[cfg(all(feature = "vsock", target_os = "linux"))]
+    Vsock { port: u32 },
+    /// Direct TCP host:port. Dev / tests (and the local stub servers).
+    Tcp { host: String, port: u16 },
+}
+
+impl EsploraDest {
+    /// Parse a `http://host:port` URL into a pinned TCP destination (dev/tests).
+    /// Only `http` is accepted: the host controls this relay so TLS to it buys
+    /// nothing, and the payload is verified regardless.
+    pub fn tcp_from_url(url: &str) -> Result<Self> {
+        let rest = url.strip_prefix("http://").ok_or_else(|| {
+            EnclaveError::Internal(format!("ESPLORA_URL must be http://host:port, got {url:?}"))
+        })?;
+        let rest = rest.trim_end_matches('/');
+        let (host, port) = match rest.rsplit_once(':') {
+            Some((h, p)) => {
+                let port = p.parse::<u16>().map_err(|_| {
+                    EnclaveError::Internal(format!("ESPLORA_URL has a non-numeric port: {url:?}"))
+                })?;
+                (h.to_string(), port)
+            }
+            None => (rest.to_string(), 80),
+        };
+        if host.is_empty() {
+            return Err(EnclaveError::Internal(format!(
+                "ESPLORA_URL has no host: {url:?}"
+            )));
+        }
+        Ok(EsploraDest::Tcp { host, port })
+    }
+}
+
+/// A pinned transport: a TCP socket (dev/tests) or a vsock socket (production).
+/// Both expose std-style timeout setters, so a [`DeadlineStream`] can bound
+/// every read/write by an absolute per-call deadline.
+enum EsploraStream {
+    Tcp(TcpStream),
+    #[cfg(all(feature = "vsock", target_os = "linux"))]
+    Vsock(vsock::VsockStream),
+}
+
+impl Read for EsploraStream {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            EsploraStream::Tcp(s) => s.read(buf),
+            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            EsploraStream::Vsock(s) => s.read(buf),
+        }
+    }
+}
+
+impl Write for EsploraStream {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            EsploraStream::Tcp(s) => s.write(buf),
+            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            EsploraStream::Vsock(s) => s.write(buf),
+        }
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            EsploraStream::Tcp(s) => s.flush(),
+            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            EsploraStream::Vsock(s) => s.flush(),
+        }
+    }
+}
+
+impl SocketTimeout for EsploraStream {
+    fn set_read_timeout(&self, dur: Option<Duration>) -> std::io::Result<()> {
+        match self {
+            EsploraStream::Tcp(s) => s.set_read_timeout(dur),
+            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            EsploraStream::Vsock(s) => s.set_read_timeout(dur),
+        }
+    }
+    fn set_write_timeout(&self, dur: Option<Duration>) -> std::io::Result<()> {
+        match self {
+            EsploraStream::Tcp(s) => s.set_write_timeout(dur),
+            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            EsploraStream::Vsock(s) => s.set_write_timeout(dur),
+        }
+    }
+}
+
+/// How a response body is delimited, decided from the response headers.
+enum BodyFraming {
+    /// `Content-Length: N` — read exactly N body bytes, then stop (do not wait
+    /// for the peer to close).
+    Length(usize),
+    /// `Transfer-Encoding: chunked` — read to EOF, then de-chunk.
+    Chunked,
+    /// Neither header — read to EOF (relies on `Connection: close`).
+    Eof,
+}
+
+/// A typed Esplora client with a pinned destination and per-call limits.
+#[derive(Debug, Clone)]
+pub struct TypedEsploraClient {
+    dest: EsploraDest,
+    timeout: Duration,
+    max_response_bytes: usize,
+}
+
+impl TypedEsploraClient {
+    pub fn new(dest: EsploraDest, timeout: Duration) -> Self {
+        Self {
+            dest,
+            timeout,
+            max_response_bytes: MAX_RESPONSE_BYTES,
+        }
+    }
+
+    /// Shrink the timeout so the stalled-host test doesn't wait the production
+    /// budget. Test-only.
+    #[cfg(test)]
+    pub fn set_timeout(&mut self, timeout: Duration) {
+        self.timeout = timeout;
+    }
+
+    /// Open a fresh pinned connection wrapped in a [`DeadlineStream`], so every
+    /// read/write is bounded by one absolute `self.timeout` budget — a
+    /// slow-trickle host that keeps a per-read timeout re-arming cannot pin a
+    /// worker. Both the TCP and vsock connects are themselves time-bounded.
+    fn connect(&self) -> Result<DeadlineStream<EsploraStream>> {
+        let stream = match &self.dest {
+            #[cfg(all(feature = "vsock", target_os = "linux"))]
+            EsploraDest::Vsock { port } => EsploraStream::Vsock(self.vsock_connect(*port)?),
+            EsploraDest::Tcp { host, port } => {
+                let addr = (host.as_str(), *port)
+                    .to_socket_addrs()
+                    .map_err(|e| {
+                        EnclaveError::CrossCheck(format!(
+                            "esplora TCP resolve {host}:{port} failed: {e}"
+                        ))
+                    })?
+                    .next()
+                    .ok_or_else(|| {
+                        EnclaveError::CrossCheck(format!(
+                            "esplora TCP resolve {host}:{port} yielded no address"
+                        ))
+                    })?;
+                let stream = TcpStream::connect_timeout(&addr, self.timeout).map_err(|e| {
+                    EnclaveError::CrossCheck(format!("esplora TCP connect {addr} failed: {e}"))
+                })?;
+                EsploraStream::Tcp(stream)
+            }
+        };
+        Ok(DeadlineStream::new(stream, self.timeout, self.timeout))
+    }
+
+    /// `vsock::VsockStream::connect_with_cid_port` is a blocking connect with no
+    /// timeout, so a host that keeps the connection pending would park a signing
+    /// worker before any read timeout could apply. Run it on a watchdog thread
+    /// and abandon it if it outlasts the budget (matching the TCP arm's
+    /// `connect_timeout` guarantee).
+    #[cfg(all(feature = "vsock", target_os = "linux"))]
+    fn vsock_connect(&self, port: u32) -> Result<vsock::VsockStream> {
+        use std::sync::mpsc;
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(vsock::VsockStream::connect_with_cid_port(PARENT_CID, port));
+        });
+        match rx.recv_timeout(self.timeout) {
+            Ok(Ok(stream)) => Ok(stream),
+            Ok(Err(e)) => Err(EnclaveError::CrossCheck(format!(
+                "esplora vsock connect to CID {PARENT_CID}:{port} failed: {e}"
+            ))),
+            Err(_) => Err(EnclaveError::CrossCheck(format!(
+                "esplora vsock connect to CID {PARENT_CID}:{port} timed out"
+            ))),
+        }
+    }
+
+    /// Issue a fixed `GET path` and return the response body, or `None` on 404.
+    ///
+    /// Parses the response framing: `Content-Length` (stop at the declared
+    /// length, without waiting for the peer to close), `Transfer-Encoding:
+    /// chunked` (read to EOF then de-chunk), else read to EOF. `path` is only
+    /// ever one of the four fixed strings the typed methods below pass — this is
+    /// not public, so no arbitrary path can be requested.
+    fn get(&self, path: &str) -> Result<Option<Vec<u8>>> {
+        let mut stream = self.connect()?;
+        let req = format!(
+            "GET {path} HTTP/1.1\r\nHost: esplora\r\nUser-Agent: utexo-enclave\r\n\
+             Accept: */*\r\nConnection: close\r\n\r\n"
+        );
+        stream
+            .write_all(req.as_bytes())
+            .and_then(|_| stream.flush())
+            .map_err(|e| {
+                EnclaveError::CrossCheck(format!("esplora write failed for {path}: {e}"))
+            })?;
+
+        // Read at least through the end of the headers (the first CRLFCRLF).
+        let mut raw = Vec::new();
+        let mut buf = [0u8; 8192];
+        let header_end = loop {
+            if let Some(pos) = find_subsequence(&raw, b"\r\n\r\n") {
+                break pos;
+            }
+            let n = self.read_into(&mut stream, &mut buf, path)?;
+            if n == 0 {
+                return Err(EnclaveError::CrossCheck(format!(
+                    "esplora response for {path} closed before headers completed"
+                )));
+            }
+            self.push_capped(&mut raw, &buf[..n], path)?;
+        };
+
+        let head = &raw[..header_end];
+        let code = parse_status_code(head).ok_or_else(|| {
+            EnclaveError::CrossCheck(format!("esplora response for {path} had no status code"))
+        })?;
+        let framing = parse_body_framing(head);
+        let mut body = raw[header_end + 4..].to_vec();
+
+        match framing {
+            BodyFraming::Length(len) => {
+                while body.len() < len {
+                    let n = self.read_into(&mut stream, &mut buf, path)?;
+                    if n == 0 {
+                        break;
+                    }
+                    self.push_capped(&mut body, &buf[..n], path)?;
+                }
+                if body.len() < len {
+                    return Err(EnclaveError::CrossCheck(format!(
+                        "esplora response for {path} truncated: {} of {len} body bytes",
+                        body.len()
+                    )));
+                }
+                body.truncate(len);
+            }
+            BodyFraming::Chunked | BodyFraming::Eof => {
+                loop {
+                    let n = self.read_into(&mut stream, &mut buf, path)?;
+                    if n == 0 {
+                        break;
+                    }
+                    self.push_capped(&mut body, &buf[..n], path)?;
+                }
+                if matches!(framing, BodyFraming::Chunked) {
+                    body = dechunk(&body).map_err(|e| {
+                        EnclaveError::CrossCheck(format!(
+                            "esplora response for {path} has a malformed chunked body: {e}"
+                        ))
+                    })?;
+                }
+            }
+        }
+
+        match code {
+            200 => Ok(Some(body)),
+            404 => Ok(None),
+            other => Err(EnclaveError::CrossCheck(format!(
+                "esplora {path} returned HTTP {other}"
+            ))),
+        }
+    }
+
+    fn read_into(
+        &self,
+        stream: &mut DeadlineStream<EsploraStream>,
+        buf: &mut [u8],
+        path: &str,
+    ) -> Result<usize> {
+        stream
+            .read(buf)
+            .map_err(|e| EnclaveError::CrossCheck(format!("esplora read failed for {path}: {e}")))
+    }
+
+    fn push_capped(&self, dst: &mut Vec<u8>, src: &[u8], path: &str) -> Result<()> {
+        if dst.len() + src.len() > self.max_response_bytes {
+            return Err(EnclaveError::CrossCheck(format!(
+                "esplora response for {path} exceeds {} bytes",
+                self.max_response_bytes
+            )));
+        }
+        dst.extend_from_slice(src);
+        Ok(())
+    }
+
+    /// `GET /block-height/0` → the genesis block hash (chain-identity check).
+    pub fn genesis_block_hash(&self) -> Result<BlockHash> {
+        let body = self.get("/block-height/0")?.ok_or_else(|| {
+            EnclaveError::CrossCheck("esplora /block-height/0 returned 404".into())
+        })?;
+        let s = String::from_utf8_lossy(&body);
+        BlockHash::from_str(s.trim()).map_err(|e| {
+            EnclaveError::CrossCheck(format!(
+                "esplora /block-height/0 is not a block hash: {e} (got {:?})",
+                s.trim()
+            ))
+        })
+    }
+
+    /// `GET /tx/{txid}/raw` → the raw transaction, or `None` if unknown (404).
+    pub fn get_tx(&self, txid: &Txid) -> Result<Option<Transaction>> {
+        let Some(body) = self.get(&format!("/tx/{txid}/raw"))? else {
+            return Ok(None);
+        };
+        let tx = consensus_deserialize::<Transaction>(&body).map_err(|e| {
+            EnclaveError::CrossCheck(format!(
+                "esplora /tx/{txid}/raw is not a valid transaction: {e}"
+            ))
+        })?;
+        Ok(Some(tx))
+    }
+
+    /// `GET /tx/{txid}/status` → confirmation status.
+    pub fn get_tx_status(&self, txid: &Txid) -> Result<TxStatus> {
+        let body = self.get(&format!("/tx/{txid}/status"))?.ok_or_else(|| {
+            EnclaveError::CrossCheck(format!("esplora /tx/{txid}/status returned 404"))
+        })?;
+        serde_json::from_slice::<TxStatus>(&body).map_err(|e| {
+            EnclaveError::CrossCheck(format!("esplora /tx/{txid}/status is not valid JSON: {e}"))
+        })
+    }
+
+    /// `GET /fee-estimates` → confirmation-target → sat/vB map.
+    pub fn get_fee_estimates(&self) -> Result<HashMap<u16, f64>> {
+        let body = self.get("/fee-estimates")?.ok_or_else(|| {
+            EnclaveError::CrossCheck("esplora /fee-estimates returned 404".into())
+        })?;
+        serde_json::from_slice::<HashMap<u16, f64>>(&body).map_err(|e| {
+            EnclaveError::CrossCheck(format!("esplora /fee-estimates is not valid JSON: {e}"))
+        })
+    }
+}
+
+/// A `ResolveWitness` that answers consignment-bundled txs as tentative
+/// (mirroring rgb-ops' `AnyResolver::add_consignment_txes`) and delegates any
+/// other witness to the pinned typed client. Built per `validate()` call and
+/// owned privately by the RGB validator.
+pub struct ConsignmentResolver<'a> {
+    client: &'a TypedEsploraClient,
+    consignment_txes: HashMap<Txid, Transaction>,
+}
+
+impl<'a> ConsignmentResolver<'a> {
+    /// Build a resolver whose bundled witness txs come from `consignment_txes`
+    /// (the map the caller extracts from the transfer's bundles, exactly as
+    /// `AnyResolver::add_consignment_txes` does).
+    pub fn new(
+        client: &'a TypedEsploraClient,
+        consignment_txes: HashMap<Txid, Transaction>,
+    ) -> Self {
+        Self {
+            client,
+            consignment_txes,
+        }
+    }
+}
+
+impl ResolveWitness for ConsignmentResolver<'_> {
+    fn resolve_witness(
+        &self,
+        witness_id: Txid,
+    ) -> std::result::Result<WitnessStatus, WitnessResolverError> {
+        if let Some(tx) = self.consignment_txes.get(&witness_id) {
+            return Ok(WitnessStatus::Resolved(tx.clone(), WitnessOrd::Tentative));
+        }
+        let Some(tx) = self
+            .client
+            .get_tx(&witness_id)
+            .map_err(|e| WitnessResolverError::ResolverIssue(Some(witness_id), e.to_string()))?
+        else {
+            return Ok(WitnessStatus::Unresolved);
+        };
+        let status = self
+            .client
+            .get_tx_status(&witness_id)
+            .map_err(|e| WitnessResolverError::ResolverIssue(Some(witness_id), e.to_string()))?;
+        let ord = match status
+            .block_height
+            .and_then(|h| status.block_time.map(|t| (h, t)))
+        {
+            Some((h, t)) => {
+                let height = NonZeroU32::new(h).ok_or(WitnessResolverError::InvalidResolverData)?;
+                WitnessOrd::Mined(
+                    WitnessPos::bitcoin(height, t as i64)
+                        .ok_or(WitnessResolverError::InvalidResolverData)?,
+                )
+            }
+            None => WitnessOrd::Tentative,
+        };
+        Ok(WitnessStatus::Resolved(tx, ord))
+    }
+
+    fn check_chain_net(
+        &self,
+        chain_net: ChainNet,
+    ) -> std::result::Result<(), WitnessResolverError> {
+        let block_hash = self
+            .client
+            .genesis_block_hash()
+            .map_err(|e| WitnessResolverError::ResolverIssue(None, e.to_string()))?;
+        let chain_hash = bitcoin::constants::ChainHash::from_genesis_block_hash(block_hash);
+        if chain_net.chain_hash() != chain_hash {
+            return Err(WitnessResolverError::WrongChainNet);
+        }
+        Ok(())
+    }
+}
+
+fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Parse the numeric status code from the response's first line
+/// (`HTTP/1.1 <code> <reason>`).
+fn parse_status_code(head: &[u8]) -> Option<u16> {
+    let line = head.split(|&b| b == b'\n').next().unwrap_or(&[]);
+    String::from_utf8_lossy(line)
+        .split_whitespace()
+        .nth(1)
+        .and_then(|c| c.parse::<u16>().ok())
+}
+
+/// Decide how the body is delimited from the response headers. Per RFC 7230,
+/// `Transfer-Encoding: chunked` takes precedence over `Content-Length`.
+fn parse_body_framing(head: &[u8]) -> BodyFraming {
+    let text = String::from_utf8_lossy(head);
+    let mut content_length = None;
+    let mut chunked = false;
+    for line in text.split("\r\n").skip(1) {
+        if let Some((name, value)) = line.split_once(':') {
+            let name = name.trim().to_ascii_lowercase();
+            let value = value.trim();
+            if name == "content-length" {
+                content_length = value.parse::<usize>().ok();
+            } else if name == "transfer-encoding" && value.to_ascii_lowercase().contains("chunked")
+            {
+                chunked = true;
+            }
+        }
+    }
+    if chunked {
+        BodyFraming::Chunked
+    } else if let Some(len) = content_length {
+        BodyFraming::Length(len)
+    } else {
+        BodyFraming::Eof
+    }
+}
+
+/// Decode an HTTP/1.1 chunked transfer-encoded body. Each chunk is a hex size
+/// line (optionally with `;ext`), the data, and a trailing CRLF; a zero-size
+/// chunk terminates. Esplora sends no trailers.
+fn dechunk(data: &[u8]) -> std::result::Result<Vec<u8>, String> {
+    let mut out = Vec::new();
+    let mut rest = data;
+    loop {
+        let crlf = find_subsequence(rest, b"\r\n").ok_or("missing chunk-size CRLF")?;
+        let size_line =
+            std::str::from_utf8(&rest[..crlf]).map_err(|_| "non-utf8 chunk size".to_string())?;
+        let size_hex = size_line.split(';').next().unwrap_or("").trim();
+        let size = usize::from_str_radix(size_hex, 16)
+            .map_err(|_| format!("bad chunk size {size_hex:?}"))?;
+        rest = &rest[crlf + 2..];
+        if size == 0 {
+            break;
+        }
+        // Checked arithmetic: a hostile chunk-size (e.g. `ffffffffffffffff`
+        // parses to usize::MAX) must not overflow `size + 2` and slip past the
+        // bound check into an out-of-range slice — which would abort the whole
+        // enclave under `panic = "abort"`.
+        let advance = size.checked_add(2).ok_or("chunk size overflows usize")?;
+        if rest.len() < advance {
+            return Err("truncated chunk data".to_string());
+        }
+        out.extend_from_slice(&rest[..size]);
+        rest = &rest[advance..];
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn tcp_from_url_parses_host_port() {
+        match EsploraDest::tcp_from_url("http://127.0.0.1:3443").unwrap() {
+            EsploraDest::Tcp { host, port } => {
+                assert_eq!(host, "127.0.0.1");
+                assert_eq!(port, 3443);
+            }
+            #[allow(unreachable_patterns)]
+            _ => panic!("expected Tcp"),
+        }
+        assert!(EsploraDest::tcp_from_url("https://x:1").is_err());
+        assert!(EsploraDest::tcp_from_url("http://host:notaport").is_err());
+    }
+
+    /// Record every request line and answer each fixed path with a canned body.
+    fn spawn_recording_stub(seen: Arc<Mutex<Vec<String>>>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind stub");
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { break };
+                let mut buf = [0u8; 2048];
+                let n = stream.read(&mut buf).unwrap_or(0);
+                let first = String::from_utf8_lossy(&buf[..n])
+                    .lines()
+                    .next()
+                    .unwrap_or_default()
+                    .to_string();
+                seen.lock().unwrap().push(first.clone());
+                let body = if first.contains("/fee-estimates") {
+                    r#"{"6":12.0}"#.to_string()
+                } else if first.contains("/block-height/0") {
+                    // Mainnet genesis block hash.
+                    "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f".to_string()
+                } else {
+                    String::new()
+                };
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(resp.as_bytes());
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    #[test]
+    fn typed_client_issues_only_the_allowlisted_paths() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let url = spawn_recording_stub(seen.clone());
+        let client = TypedEsploraClient::new(
+            EsploraDest::tcp_from_url(&url).unwrap(),
+            Duration::from_secs(5),
+        );
+
+        assert!(client.genesis_block_hash().is_ok());
+        assert!(client.get_fee_estimates().is_ok());
+
+        let lines = seen.lock().unwrap().clone();
+        assert_eq!(lines.len(), 2);
+        for line in &lines {
+            let path = line.split_whitespace().nth(1).unwrap_or("");
+            assert!(
+                path == "/block-height/0" || path == "/fee-estimates",
+                "unexpected egress path: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn get_maps_404_to_none() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            if let Some(Ok(mut s)) = listener.incoming().next() {
+                let mut b = [0u8; 512];
+                let _ = s.read(&mut b);
+                let _ = s.write_all(
+                    b"HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+                );
+            }
+        });
+        let client = TypedEsploraClient::new(
+            EsploraDest::tcp_from_url(&format!("http://{addr}")).unwrap(),
+            Duration::from_secs(5),
+        );
+        let txid =
+            Txid::from_str("0000000000000000000000000000000000000000000000000000000000000001")
+                .unwrap();
+        assert!(client.get_tx(&txid).unwrap().is_none());
+    }
+
+    #[test]
+    fn get_errors_on_5xx() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            if let Some(Ok(mut s)) = listener.incoming().next() {
+                let mut b = [0u8; 512];
+                let _ = s.read(&mut b);
+                let _ = s.write_all(
+                    b"HTTP/1.1 503 Service Unavailable\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+                );
+            }
+        });
+        let client = TypedEsploraClient::new(
+            EsploraDest::tcp_from_url(&format!("http://{addr}")).unwrap(),
+            Duration::from_secs(5),
+        );
+        assert!(client.get_fee_estimates().is_err());
+    }
+
+    #[test]
+    fn decodes_chunked_response() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            if let Some(Ok(mut s)) = listener.incoming().next() {
+                let mut b = [0u8; 512];
+                let _ = s.read(&mut b);
+                // `{"6":12.0}` is 10 bytes (hex `a`): one chunk + the zero terminator.
+                let _ = s.write_all(
+                    b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nconnection: close\r\n\r\na\r\n{\"6\":12.0}\r\n0\r\n\r\n",
+                );
+            }
+        });
+        let client = TypedEsploraClient::new(
+            EsploraDest::tcp_from_url(&format!("http://{addr}")).unwrap(),
+            Duration::from_secs(5),
+        );
+        let fees = client.get_fee_estimates().unwrap();
+        assert_eq!(fees.get(&6), Some(&12.0));
+    }
+
+    #[test]
+    fn stops_reading_at_content_length() {
+        // Body is exactly Content-Length bytes; trailing bytes on the connection
+        // (a kept-alive / pipelining relay that ignores `Connection: close`) must
+        // be dropped — proving we frame by Content-Length, not read-to-EOF. If
+        // the garbage were included the JSON decode would fail.
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            if let Some(Ok(mut s)) = listener.incoming().next() {
+                let mut b = [0u8; 512];
+                let _ = s.read(&mut b);
+                let _ = s.write_all(
+                    b"HTTP/1.1 200 OK\r\ncontent-length: 10\r\n\r\n{\"6\":12.0}!!!TRAILING-GARBAGE!!!",
+                );
+            }
+        });
+        let client = TypedEsploraClient::new(
+            EsploraDest::tcp_from_url(&format!("http://{addr}")).unwrap(),
+            Duration::from_secs(5),
+        );
+        let fees = client.get_fee_estimates().unwrap();
+        assert_eq!(fees.get(&6), Some(&12.0));
+    }
+
+    #[test]
+    fn dechunk_reassembles_and_rejects_malformed() {
+        assert_eq!(
+            dechunk(b"4\r\nWiki\r\n5\r\npedia\r\n0\r\n\r\n").unwrap(),
+            b"Wikipedia"
+        );
+        assert!(dechunk(b"zz\r\nxx\r\n0\r\n\r\n").is_err());
+        assert!(dechunk(b"9\r\ntooshort\r\n0\r\n\r\n").is_err());
+        // A hostile chunk-size that overflows usize must error, never panic
+        // (would abort the enclave under panic = "abort").
+        assert!(dechunk(b"ffffffffffffffff\r\nx\r\n0\r\n\r\n").is_err());
+    }
+}

--- a/enclave/src/networks/rgb/esplora_egress.rs
+++ b/enclave/src/networks/rgb/esplora_egress.rs
@@ -429,10 +429,7 @@ impl ResolveWitness for ConsignmentResolver<'_> {
             .client
             .get_tx_status(&witness_id)
             .map_err(|e| WitnessResolverError::ResolverIssue(Some(witness_id), e.to_string()))?;
-        let ord = match status
-            .block_height
-            .and_then(|h| status.block_time.map(|t| (h, t)))
-        {
+        let ord = match status.block_height.zip(status.block_time) {
             Some((h, t)) => {
                 let height = NonZeroU32::new(h).ok_or(WitnessResolverError::InvalidResolverData)?;
                 WitnessOrd::Mined(

--- a/enclave/src/networks/rgb/mod.rs
+++ b/enclave/src/networks/rgb/mod.rs
@@ -1,4 +1,6 @@
 pub mod btc_crosscheck;
+#[cfg(feature = "rgb-validation")]
+pub mod esplora_egress;
 pub mod psbt_validation;
 pub mod signing;
 pub mod spv;

--- a/enclave/src/networks/rgb/validation.rs
+++ b/enclave/src/networks/rgb/validation.rs
@@ -14,13 +14,12 @@ use rgb_consignment::{
     ConsignmentInfo, FungibleAllocation, FungibleEntry, SealInfo, TransitionInfo, WitnessInfo,
 };
 use rgbstd::containers::{ConsignmentExt, FileContent, Transfer};
-use rgbstd::indexers::esplora_blocking::esplora_client;
-use rgbstd::indexers::AnyResolver;
 use rgbstd::schema::{MetaType, TransitionType};
 use rgbstd::validation::ValidationConfig;
 use rgbstd::ChainNet;
 use sha3::{Digest, Keccak256};
 
+use super::esplora_egress::{ConsignmentResolver, EsploraDest, TypedEsploraClient};
 use crate::config::BridgeConfig;
 use crate::error::{EnclaveError, Result};
 use crate::networks::ValidationContext;
@@ -424,13 +423,14 @@ pub enum OutputSeal {
     Confidential { secret_seal: String },
 }
 
-/// Hard cap on any single blocking Esplora HTTP call (connect + read), in
-/// seconds. The Esplora egress runs through the host-controlled vsock proxy,
-/// and consignment validation happens *on the signing path* — without a
-/// timeout a stalled host pins the worker thread indefinitely (audit final
-/// I-03 / #87). Aligned with `conn.rs`'s `TOTAL_REQUEST_TIMEOUT` so a single
-/// stalled egress call cannot outlive its enclosing request budget.
-/// Compile-time (PCR-attested), deliberately not host-tunable.
+/// Absolute per-call budget for a single Esplora fetch (connect + all reads),
+/// in seconds. The Esplora egress runs through the host-controlled vsock proxy
+/// and consignment validation happens *on the signing path*, so without a bound
+/// a stalled or slow-trickle host pins a worker thread. The typed client wraps
+/// each call in a `conn::DeadlineStream` with this budget, so the whole fetch —
+/// not just one read syscall — is bounded, matching `conn.rs`'s
+/// `TOTAL_REQUEST_TIMEOUT` for ingress. Compile-time (PCR-attested), deliberately
+/// not host-tunable.
 const ESPLORA_HTTP_TIMEOUT_SECS: u64 = 30;
 
 /// How long a fetched fee estimate stays fresh (#55). Fee markets move on
@@ -449,51 +449,73 @@ const FEE_ESTIMATE_TARGET: u16 = 6;
 /// valueless; it just keeps the path enforced against a runaway burn.
 const NON_MAINNET_FALLBACK_FEE_RATE_SAT_VB: f64 = 10.0;
 
-/// Validates RGB consignments using rgbstd and an Esplora-backed resolver.
+/// Validates RGB consignments using rgbstd and a typed, pinned Esplora client.
 #[derive(Debug)]
 pub struct RgbValidator {
-    esplora_url: String,
+    /// Typed, destination-pinned Esplora egress: exposes only the resolver's
+    /// genesis/tx/status calls plus the fee estimate, over a boot-pinned
+    /// destination with no retries — not a generic host egress.
+    client: TypedEsploraClient,
     chain_net: ChainNet,
     /// Cached `(fetched_at, sat/vB)` recommended fee rate (#55), guarded for
     /// the multi-threaded worker pool. `None` until the first fetch.
     fee_estimate_cache: std::sync::Mutex<Option<(std::time::Instant, f64)>>,
-    /// Per-request HTTP timeout, [`ESPLORA_HTTP_TIMEOUT_SECS`] in production.
-    /// Overridable only from tests (no env / host input reaches it).
-    http_timeout_secs: u64,
 }
 
 impl RgbValidator {
-    /// Create a new validator.
-    ///
-    /// - `esplora_url`: HTTP URL for the Esplora API (e.g., `http://127.0.0.1:3443`
-    ///   when using the vsock forwarder, or a direct URL in dev mode).
-    /// - `bitcoin_network`: One of "bitcoin", "testnet", "signet", "regtest".
-    pub fn new(esplora_url: String, bitcoin_network: &str) -> Result<Self> {
-        let chain_net = match bitcoin_network {
-            "bitcoin" | "mainnet" => ChainNet::BitcoinMainnet,
-            "testnet" | "testnet3" => ChainNet::BitcoinTestnet3,
-            "signet" => ChainNet::BitcoinSignet,
-            "regtest" => ChainNet::BitcoinRegtest,
-            other => {
-                return Err(EnclaveError::Internal(format!(
-                    "unknown bitcoin network: {other}"
-                )))
-            }
-        };
-        tracing::info!(%esplora_url, %bitcoin_network, "RGB validator configured");
-        Ok(Self {
-            esplora_url,
+    fn chain_net_for(bitcoin_network: &str) -> Result<ChainNet> {
+        match bitcoin_network {
+            "bitcoin" | "mainnet" => Ok(ChainNet::BitcoinMainnet),
+            "testnet" | "testnet3" => Ok(ChainNet::BitcoinTestnet3),
+            "signet" => Ok(ChainNet::BitcoinSignet),
+            "regtest" => Ok(ChainNet::BitcoinRegtest),
+            other => Err(EnclaveError::Internal(format!(
+                "unknown bitcoin network: {other}"
+            ))),
+        }
+    }
+
+    fn from_dest(dest: EsploraDest, chain_net: ChainNet) -> Self {
+        Self {
+            client: TypedEsploraClient::new(
+                dest,
+                std::time::Duration::from_secs(ESPLORA_HTTP_TIMEOUT_SECS),
+            ),
             chain_net,
             fee_estimate_cache: std::sync::Mutex::new(None),
-            http_timeout_secs: ESPLORA_HTTP_TIMEOUT_SECS,
-        })
+        }
+    }
+
+    /// Create a validator that reaches Esplora over a direct TCP `esplora_url`
+    /// (`http://host:port`). Used in dev / tests; production uses
+    /// [`Self::new_vsock`].
+    ///
+    /// - `bitcoin_network`: one of "bitcoin", "testnet", "signet", "regtest".
+    pub fn new(esplora_url: String, bitcoin_network: &str) -> Result<Self> {
+        let chain_net = Self::chain_net_for(bitcoin_network)?;
+        let dest = EsploraDest::tcp_from_url(&esplora_url)?;
+        tracing::info!(%esplora_url, %bitcoin_network, "RGB validator configured (pinned TCP Esplora)");
+        Ok(Self::from_dest(dest, chain_net))
+    }
+
+    /// Create a validator that reaches Esplora by dialing the parent vsock
+    /// directly (CID 3, `vsock_port`) — no loopback forwarder.
+    #[cfg(all(feature = "vsock", target_os = "linux"))]
+    pub fn new_vsock(vsock_port: u32, bitcoin_network: &str) -> Result<Self> {
+        let chain_net = Self::chain_net_for(bitcoin_network)?;
+        tracing::info!(vsock_port, %bitcoin_network, "RGB validator configured (pinned vsock Esplora)");
+        Ok(Self::from_dest(
+            EsploraDest::Vsock { port: vsock_port },
+            chain_net,
+        ))
     }
 
     /// Shrink the HTTP timeout so the stalled-host test doesn't wait the
     /// production budget. Test-only by construction.
     #[cfg(test)]
     fn with_http_timeout(mut self, secs: u64) -> Self {
-        self.http_timeout_secs = secs;
+        self.client
+            .set_timeout(std::time::Duration::from_secs(secs));
         self
     }
 
@@ -518,13 +540,10 @@ impl RgbValidator {
             }
         }
 
-        let client = esplora_client::Builder::new(&self.esplora_url)
-            .timeout(self.http_timeout_secs)
-            .build_blocking();
-        let estimates = client.get_fee_estimates().map_err(|e| {
+        let estimates = self.client.get_fee_estimates().map_err(|e| {
             EnclaveError::CrossCheck(format!(
                 "fee-estimate fetch failed — refusing to sign a send-RGB PSBT without a \
-                 fee-rate sanity bound (#55): {e}"
+                 fee-rate sanity bound: {e}"
             ))
         })?;
 
@@ -573,11 +592,7 @@ impl RgbValidator {
     pub fn validate_consignment(&self, consignment_bytes: &[u8]) -> Result<ValidatedConsignment> {
         let start = std::time::Instant::now();
         let bytes_len = consignment_bytes.len();
-        tracing::info!(
-            bytes_len,
-            esplora_url = %self.esplora_url,
-            "starting RGB consignment validation"
-        );
+        tracing::info!(bytes_len, "starting RGB consignment validation");
 
         // 1. Deserialize the consignment from its file format (magic + strict-encoded).
         let transfer = Transfer::load(Cursor::new(consignment_bytes)).map_err(|e| {
@@ -664,22 +679,19 @@ impl RgbValidator {
                 _ => (None, None, None),
             };
 
-        // 2. Create an Esplora-backed resolver. The `.timeout()` is
-        // load-bearing: this is a blocking call on the signing path through
-        // the host-controlled vsock proxy (audit final I-03 / #87). Transport
-        // errors (incl. timeouts) propagate immediately — esplora-client only
-        // retries on 429/5xx status codes — so one stalled call costs at most
-        // the timeout, never an unbounded hang.
-        let builder =
-            esplora_client::Builder::new(&self.esplora_url).timeout(self.http_timeout_secs);
-        let mut resolver = AnyResolver::esplora_blocking(builder).map_err(|e| {
-            tracing::error!(esplora_url = %self.esplora_url, "esplora resolver creation failed: {e}");
-            EnclaveError::CrossCheck(format!("esplora resolver creation failed: {e}"))
-        })?;
-
-        // Register transactions bundled in the consignment so the resolver
-        // treats them as tentative witnesses (not yet mined).
-        resolver.add_consignment_txes(&transfer);
+        // 2. Build the typed, pinned Esplora resolver. Transactions bundled in
+        // the consignment are answered locally as tentative witnesses (no
+        // egress); any other witness is fetched through the pinned client with a
+        // bounded, non-retrying blocking call, so a stalled or error-spamming
+        // host costs at most one timeout per fetch and can never amplify a
+        // single fetch or pin a signing worker.
+        let consignment_txes: std::collections::HashMap<_, _> = transfer
+            .bundles
+            .iter()
+            .filter_map(|bw| bw.pub_witness.tx().cloned())
+            .map(|tx| (tx.compute_txid(), tx))
+            .collect();
+        let resolver = ConsignmentResolver::new(&self.client, consignment_txes);
 
         // Pin the trusted type system (audit 4th W-01 / #92). Source it from
         // the canonical `rgb-schemas` definitions keyed on the consignment's

--- a/enclave/src/vsock_forwarder.rs
+++ b/enclave/src/vsock_forwarder.rs
@@ -1,20 +1,21 @@
-//! TCP-to-vsock forwarder for reaching external services (e.g., Esplora) from
-//! inside a Nitro enclave. Listens on localhost TCP and forwards each connection
-//! to the parent instance via vsock, where `vsock-proxy` relays to the real endpoint.
+//! TCP-to-vsock forwarder for reaching external services from inside a Nitro
+//! enclave. Listens on localhost TCP and forwards each connection to the parent
+//! instance via vsock, where `vsock-proxy` relays to the real endpoint.
 //!
-//! TRUST BOUNDARY (audit I-01 / Oxorio I-03, I-08): everything reachable
-//! through this forwarder is HOST-CONTROLLED and UNTRUSTED. The host runs the
-//! `vsock-proxy` on the far end and can drop, delay, reorder, or forge any
-//! bytes it returns. Data fetched over it (Esplora tx / merkle proof / chain
-//! tip) is EVIDENCE TO BE VERIFIED - by in-enclave SPV proof checking and
-//! rgbstd consignment validation - never trusted input. The listener binds
-//! only to loopback (`127.0.0.1`, not externally reachable), but it is a
-//! GENERIC egress primitive: any code inside the enclave process that can open
-//! a loopback socket can tunnel host-bound traffic through it. A future
-//! hardening (issue #87) would replace it with a typed Esplora client private
-//! to the RGB resolver path that only issues the specific calls the resolver
-//! makes (fetch tx / merkle proof / tip), so arbitrary traffic cannot be
-//! tunneled.
+//! TRUST BOUNDARY: everything reachable through this forwarder is
+//! HOST-CONTROLLED and UNTRUSTED. The host runs the `vsock-proxy` on the far
+//! end and can drop, delay, reorder, or forge any bytes it returns. Data
+//! fetched over it is EVIDENCE TO BE VERIFIED - by the in-enclave Helios light
+//! client for EVM data - never trusted input. The listener binds only to
+//! loopback (`127.0.0.1`, not externally reachable), but it is a GENERIC egress
+//! primitive: any code inside the enclave process that can open a loopback
+//! socket can tunnel host-bound traffic through it.
+//!
+//! The Esplora path no longer uses this forwarder: the RGB validator owns a
+//! typed, destination-pinned Esplora client that dials the parent vsock
+//! directly and exposes only the specific calls the resolver makes, so no
+//! Esplora traffic can be tunneled through a generic port. This forwarder now
+//! serves the EVM-RPC and Helios execution/consensus paths only.
 
 use std::io;
 use std::net::TcpListener;
@@ -29,7 +30,7 @@ const PARENT_CID: u32 = 3;
 ///
 /// See the module-level TRUST BOUNDARY note: this is an untrusted,
 /// host-controlled egress path. Anything fetched through it must be verified
-/// (SPV + rgbstd validation), never trusted as input (audit I-01).
+/// in-enclave (Helios light client for EVM data), never trusted as input.
 ///
 /// The forwarder is fire-and-forget — it logs errors but never crashes the enclave.
 pub fn start_forwarder(local_port: u16, vsock_port: u32) -> io::Result<()> {


### PR DESCRIPTION
The RGB validator reached Esplora through a generic loopback→vsock forwarder: a process-wide egress primitive any in-enclave code could tunnel arbitrary host traffic through, and one that inherited esplora-client's default 6-retry backoff (a host returning 429/5xx could amplify a single fetch past the per-call timeout).

Replace it, for the Esplora path only, with a typed client owned by the RGB validator:
- dials a boot-pinned destination (production: the parent vsock CID 3 directly, so no loopback Esplora port is bound; dev/tests: a fixed TCP host:port);
- exposes only the four GETs the resolver and the fee-rate check issue — no arbitrary-path method;
- bounds every call by an absolute deadline (over connect and all reads) with no retries, so a stalled, trickling, or error-spamming host can neither amplify a fetch nor pin a signing worker;
- parses HTTP framing (Content-Length / chunked / close) instead of relying on the peer to half-close.

Resolver semantics are unchanged (mirrors the previous rgb-ops resolver). The EVM-RPC and Helios forwarders are untouched. serde_json (already in the tree via esplora-client) becomes a direct dep to reuse its response decoders.

Closes #162
Closes #164