### PR TITLE
chore(build): pin the toolchain and base-image digests for reproducible PCRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,3 +237,29 @@ jobs:
             exit 1
           fi
           echo "OK: rgb-validation-without-spv correctly rejected via the compile_error guard"
+
+  build-input-pins:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Assert base images are digest-pinned and cargo builds are --locked
+        run: |
+          fail=0
+          for f in build/Dockerfile.enclave build/Dockerfile.parent build/Dockerfile.enclave-dev; do
+            while IFS= read -r line; do
+              case "$line" in
+                *"@sha256:"*) ;;
+                *) echo "::error file=$f::base image not digest-pinned (needs @sha256): $line"; fail=1 ;;
+              esac
+            done < <(grep -E '^FROM ' "$f")
+            while IFS= read -r line; do
+              case "$line" in
+                *"--locked"*) ;;
+                *) echo "::error file=$f::cargo build without --locked: $line"; fail=1 ;;
+              esac
+            done < <(grep -E '^[^#]*cargo build' "$f")
+          done
+          if [ "$fail" -ne 0 ]; then exit 1; fi
+          echo "OK: every Dockerfile FROM is digest-pinned and every cargo build is --locked"

--- a/build/Dockerfile.enclave
+++ b/build/Dockerfile.enclave
@@ -9,7 +9,11 @@
 # over SSH. The same SSH mount is also used for the private `rgb-consignment`
 # git dependency pulled by the `rgb-validation`/`spv` features.
 
-FROM rust:1.96-slim AS builder
+# Base images are digest-pinned so a rebuild from this source reproduces the
+# same PCR0/PCR1. Refresh a digest with:
+#   docker buildx imagetools inspect <image:tag>   # take the top-level Digest
+# The tag is kept alongside the digest for human readability; the digest wins.
+FROM rust:1.96-slim@sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523 AS builder
 
 # `git` + `openssh-client`: the workspace `[patch.crates-io]` uses public
 # git URLs for rgb-consensus / rgb-ops / rgb-invoicing / rgb-strict-encoding,
@@ -40,10 +44,10 @@ WORKDIR /build/enclave
 # alloy + tokio subtree, which grows the binary and therefore PCR0 - pinned via
 # Cargo.lock for reproducibility. Requires a second host vsock-proxy for the
 # EVM RPC (EVM_RPC_VSOCK_PORT, default 8002).
-RUN --mount=type=ssh cargo build --release --features vsock,rgb-validation,spv,evm-rpc
+RUN --mount=type=ssh cargo build --release --locked --features vsock,rgb-validation,spv,evm-rpc
 
 # --- Runtime ---
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal AS runtime
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal@sha256:97daa826f6597bd39ab9dee373290b6ce8220f1686fce5e83b51294a45f7484d AS runtime
 
 RUN dnf install -y socat iproute && dnf clean all
 

--- a/build/Dockerfile.enclave-dev
+++ b/build/Dockerfile.enclave-dev
@@ -12,7 +12,7 @@
 # loads the required deploy key.
 
 # ===== Builder Stage =====
-FROM rust:1.96-slim AS builder
+FROM rust:1.96-slim@sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523 AS builder
 
 # `git` + `openssh-client`: the workspace `[patch.crates-io]` uses public
 # git URLs for rgb-consensus / rgb-ops / rgb-invoicing / rgb-strict-encoding,
@@ -70,10 +70,10 @@ RUN --mount=type=ssh \
       git config --global url."ssh://git@github.com-federated/UTEXO-Protocol/federated-signer-proto.git".insteadOf "ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git"; \
       git config --global url."ssh://git@github.com-consignment/UTEXO-Protocol/rgb-consignment-parser.git".insteadOf "ssh://git@github.com/UTEXO-Protocol/rgb-consignment-parser.git"; \
     fi; \
-    cargo build --features allow-seed-import,spv,evm-rpc
+    cargo build --locked --features allow-seed-import,spv,evm-rpc
 
 # ===== Runtime Stage =====
-FROM debian:trixie-slim
+FROM debian:trixie-slim@sha256:3a39a0592364683e6bab97937b72cad5a8fa6dcbbee90edb3bb48c7f8e94f258
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \

--- a/build/Dockerfile.parent
+++ b/build/Dockerfile.parent
@@ -18,7 +18,7 @@
 #     utexo-bridge-parent
 
 # ===== Builder Stage =====
-FROM rust:1.96-slim AS builder
+FROM rust:1.96-slim@sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523 AS builder
 
 # `git` + `ca-certificates`: the workspace `[patch.crates-io]` rewrites
 # rgb-consensus / rgb-ops / rgb-invoicing / rgb-strict-encoding to public
@@ -66,10 +66,10 @@ RUN --mount=type=ssh \
       git config --global url."ssh://git@github.com-federated/UTEXO-Protocol/federated-signer-proto.git".insteadOf "ssh://git@github.com/UTEXO-Protocol/federated-signer-proto.git"; \
       git config --global url."ssh://git@github.com-consignment/UTEXO-Protocol/rgb-consignment-parser.git".insteadOf "ssh://git@github.com/UTEXO-Protocol/rgb-consignment-parser.git"; \
     fi; \
-    cargo build --release -p utexo-bridge-parent
+    cargo build --release --locked -p utexo-bridge-parent
 
 # ===== Runtime Stage =====
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# Single source of truth for the Rust toolchain across local dev, CI, and the
+# reproducible enclave image. Pinning here keeps `cargo`/`clippy`/`fmt`
+# identical everywhere: without it, a newer local toolchain surfaces lints the
+# (pinned) CI does not, or vice versa. Matches the digest-pinned `rust` base
+# image in build/Dockerfile.* and the version the CI workflows install.
+[toolchain]
+channel = "1.96.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Make the enclave image reproducible from source so a rebuild yields the same PCR0/PCR1:

- `rust-toolchain.toml` pinning the toolchain (1.96.0) so local dev, CI, and the image use the same rustc/clippy/fmt (also closes the gap where a newer local toolchain surfaces lints CI does not).
- Digest-pinned every base image (`FROM ...@sha256:`) in `build/Dockerfile.*`.
- `--locked` on the cargo builds so `Cargo.lock` is enforced.
- A CI guard (`build-input-pins`) that fails if any `FROM` isn't digest-pinned or any cargo build lacks `--locked`.

Heads-up: pinning the enclave base images changes the attested PCR0/PCR1, so merging needs a coordinated re-pin of the expected PCRs + KMS policy and a cluster re-bootstrap. Refresh a digest with `docker buildx imagetools inspect <image:tag>` (top-level Digest).

Remaining for full reproducibility (follow-up): pin OS package versions / a snapshot mirror, and add an independent clean-room rebuild + signed provenance.

Closes #166