### PR TITLE
 feat(enclave): require trustless Helios EVM source in production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,13 +71,14 @@ jobs:
       - name: Test (default features)
         run: cargo test --workspace
 
-      # Production build profile: vsock + rgb-validation + spv + evm-rpc.
-      # Catches any regression on the actual feature combination shipped in the EIF.
+      # Production build profile: the exact feature set shipped in the EIF
+      # (build/Dockerfile.enclave). `helios` is required in production (#77) and
+      # makes this a heavy build (2nd alloy major, revm, BLS, vendored OpenSSL).
       - name: Build (production combo)
-        run: cargo build -p utexo-bridge-enclave --features vsock,rgb-validation,spv,evm-rpc
+        run: cargo build -p utexo-bridge-enclave --features vsock,rgb-validation,spv,evm-rpc,helios
 
       - name: Clippy (production combo)
-        run: cargo clippy -p utexo-bridge-enclave --features vsock,rgb-validation,spv,evm-rpc --all-targets -- -D warnings
+        run: cargo clippy -p utexo-bridge-enclave --features vsock,rgb-validation,spv,evm-rpc,helios --all-targets -- -D warnings
 
       # SPV path coverage. Cannot use vsock here (Linux runner without
       # vsock support); spv pulls in rgb-validation transitively, which is
@@ -116,16 +117,6 @@ jobs:
       # separately by the `release-guards` job.
       - name: Test (mock-attestation integration — cloning + attestation)
         run: cargo test -p utexo-bridge-enclave --features mock-attestation,allow-seed-import
-
-      # Trustless Helios path (#77) - EXPERIMENTAL, default-OFF, NOT in the
-      # shipped EIF. Compile + clippy only: a live light-client sync needs real
-      # execution + consensus RPCs, unavailable in CI (the predicate itself is
-      # already covered by the evm-rpc FakeProvider tests). Heavy build: a second
-      # alloy major, revm, BLS, and vendored OpenSSL.
-      - name: Build (--features helios)
-        run: cargo build -p utexo-bridge-enclave --features vsock,helios
-      - name: Clippy (--features helios)
-        run: cargo clippy -p utexo-bridge-enclave --features vsock,helios --all-targets -- -D warnings
 
   # Assert the dev-only features `compile_error!` in a release build, so a
   # misconfigured Dockerfile / CI matrix can never ship one. Each feature is

--- a/build/Dockerfile.enclave
+++ b/build/Dockerfile.enclave
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-# Production enclave image (vsock + rgb-validation + spv + evm-rpc).
+# Production enclave image (vsock + rgb-validation + spv + evm-rpc + helios).
 # Usage:
 #   DOCKER_BUILDKIT=1 docker build --ssh default \
 #     -f build/Dockerfile.enclave -t utexo-bridge-enclave .
@@ -40,7 +40,11 @@ WORKDIR /build/enclave
 # alloy + tokio subtree, which grows the binary and therefore PCR0 - pinned via
 # Cargo.lock for reproducibility. Requires a second host vsock-proxy for the
 # EVM RPC (EVM_RPC_VSOCK_PORT, default 8002).
-RUN --mount=type=ssh cargo build --release --features vsock,rgb-validation,spv,evm-rpc
+# `helios` makes FundsIn verification trustless (#77) and is now REQUIRED: the
+# production policy refuses to boot on the host-relayed RawRpc source. Operator
+# must set HELIOS_EXECUTION_RPC / HELIOS_CONSENSUS_RPC and run the exec+consensus
+# vsock-proxies (default ports 8003 / 8004).
+RUN --mount=type=ssh cargo build --release --features vsock,rgb-validation,spv,evm-rpc,helios
 
 # --- Runtime ---
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal AS runtime

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -153,13 +153,12 @@ mock-attestation = ["attestation-verify/mock"]
 # is the predicate + plumbing layer and only becomes trustless once Helios (#77)
 # verifies the RPC.
 evm-rpc = ["rgb-validation", "dep:alloy", "dep:tokio"]
-# Trustless variant of `evm-rpc` (#77, EXPERIMENTAL, default-OFF): embed the
-# Helios light client so the enclave cryptographically verifies the EVM RPC
-# against a pinned weak-subjectivity checkpoint before accepting a FundsIn
-# receipt. Extends `evm-rpc` (reuses the EvmReceiptProvider seam, predicate, and
-# EVM_MIN_CONFIRMATIONS). Runtime-selectable: with HELIOS_EXECUTION_RPC set the
-# enclave uses the verified path, else the raw alloy path. HEAVY build (2 alloy
-# majors, revm, BLS, vendored OpenSSL) - not in the shipped EIF yet.
+# Trustless variant of `evm-rpc` (#77): the Helios light client verifies the EVM
+# RPC against a pinned weak-subjectivity checkpoint before accepting a FundsIn
+# receipt. Runtime-selectable: with HELIOS_EXECUTION_RPC set the enclave uses the
+# verified path, else the raw alloy path - which a release rgb-validation build
+# rejects at boot (production policy requires the trustless source). Shipped in
+# the production EIF. HEAVY build (2 alloy majors, revm, BLS, vendored OpenSSL).
 helios = ["evm-rpc", "dep:helios-ethereum"]
 
 [dev-dependencies]

--- a/enclave/src/policy.rs
+++ b/enclave/src/policy.rs
@@ -209,13 +209,8 @@ impl SecurityPolicy {
 
 impl ProductionPolicy {
     /// Invariants that must hold before a production enclave signs anything.
-    ///
-    /// The EVM data source is deliberately NOT gated here: a `Disabled` source
-    /// fails closed *per request* (see `server::handle_sign`) rather than being
-    /// unsafe, and its value is attested for the external verifier to check
-    /// against the operator's expected posture. What must hold at boot is that
-    /// the identity pins are complete, the attestation is real, and Bitcoin
-    /// anchors are SPV-verified.
+    /// Both evidence sources must be trustless: Bitcoin anchors via SPV, EVM
+    /// FundsIn deposits via Helios. `RawRpc`/`Disabled` are rejected (audit #77).
     pub fn check_invariants(&self) -> Result<(), String> {
         if self.chain_id == 0 || self.bridge_contract == [0u8; 20] || self.rgb_asset_id.is_empty() {
             return Err(
@@ -231,6 +226,13 @@ impl ProductionPolicy {
             return Err(
                 "production policy must anchor Bitcoin witness txs via the SPV header chain".into(),
             );
+        }
+        if self.evm_source != EvmDataSource::HeliosVerified {
+            return Err(format!(
+                "production policy must verify EVM FundsIn via the trustless Helios path, not \
+                 {:?}. Build with `--features helios` and set HELIOS_EXECUTION_RPC. See #77.",
+                self.evm_source
+            ));
         }
         Ok(())
     }
@@ -265,18 +267,37 @@ mod tests {
         let p = SecurityPolicy::resolve(
             &release_bridge_ctx(),
             &pinned_config(),
-            EvmDataSource::RawRpc,
+            EvmDataSource::HeliosVerified,
         );
         match &p {
             SecurityPolicy::Production(pp) => {
                 assert_eq!(pp.chain_id, 1);
-                assert_eq!(pp.evm_source, EvmDataSource::RawRpc);
+                assert_eq!(pp.evm_source, EvmDataSource::HeliosVerified);
                 assert_eq!(pp.attestation, AttestationMode::Real);
                 assert_eq!(pp.btc_source, BtcDataSource::SpvVerified);
             }
             other => panic!("expected Production, got {other:?}"),
         }
         assert!(p.assert_valid_for_build(&release_bridge_ctx()).is_ok());
+    }
+
+    #[test]
+    fn production_requires_the_trustless_helios_evm_source() {
+        let ctx = release_bridge_ctx();
+        // Non-Helios sources still resolve to Production (recorded + attested)
+        // but must not pass the boot gate.
+        for source in [EvmDataSource::Disabled, EvmDataSource::RawRpc] {
+            let p = SecurityPolicy::resolve(&ctx, &pinned_config(), source);
+            assert!(
+                matches!(p, SecurityPolicy::Production(_)),
+                "expected Production for {source:?}"
+            );
+            let err = p.assert_valid_for_build(&ctx).unwrap_err();
+            assert!(err.contains("Helios"), "got: {err}");
+        }
+        // Only Helios-verified passes the boot gate.
+        let p = SecurityPolicy::resolve(&ctx, &pinned_config(), EvmDataSource::HeliosVerified);
+        assert!(p.assert_valid_for_build(&ctx).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
A release rgb-validation build now fails the boot gate unless FundsIn deposits are verified via the Helios light client. This closes the asymmetry with the Bitcoin side, which already requires SPV: production must not fall back to the host-relayed RawRpc source.

- policy: ProductionPolicy::check_invariants rejects any evm_source other than HeliosVerified; add production_requires_the_trustless_helios_evm_source
- build: compile helios into the shipped EIF (Dockerfile.enclave); operator must set HELIOS_EXECUTION_RPC / HELIOS_CONSENSUS_RPC + host vsock-proxies
- ci: production combo build/clippy now cover the full helios feature set; drop the redundant standalone helios step

Closes: https://github.com/UTEXO-Protocol/enclave-signer/issues/158