### PR TITLE
feat(enclave): pin the Helios checkpoint into the attested policy (M-06)

### DIFF
--- a/attestation-verify/src/policy.rs
+++ b/attestation-verify/src/policy.rs
@@ -78,6 +78,13 @@ pub enum AttestedPolicy {
         chain_id: u64,
         bridge_contract: [u8; 20],
         rgb_asset_id: String,
+        /// The Helios weak-subjectivity checkpoint (beacon block root) the
+        /// enclave trust-roots EVM verification on. `Some` only for
+        /// [`EvmDataSource::HeliosVerified`]; pinned here so a verifier confirms
+        /// WHICH checkpoint the enclave synced from, not merely that it runs in
+        /// Helios mode (audit M-06). Two enclaves with identical PCRs but
+        /// different checkpoints therefore commit different `user_data`.
+        evm_checkpoint: Option<[u8; 32]>,
     },
     Development,
 }
@@ -91,6 +98,7 @@ impl AttestedPolicy {
     /// Production:  [0x01][allow_vanilla u8][attestation u8][evm_source u8]
     ///              [btc_source u8][chain_id u64 BE][bridge_contract 20]
     ///              [len(asset) u32 BE][asset bytes]
+    ///              [evm_checkpoint: 0x00 | 0x01 ++ 32 bytes]
     /// Development: [0x00]
     /// ```
     pub fn to_bytes(&self) -> Vec<u8> {
@@ -105,6 +113,7 @@ impl AttestedPolicy {
                 chain_id,
                 bridge_contract,
                 rgb_asset_id,
+                evm_checkpoint,
             } => {
                 out.push(0x01);
                 out.push(*allow_vanilla_psbt as u8);
@@ -115,6 +124,17 @@ impl AttestedPolicy {
                 out.extend_from_slice(bridge_contract);
                 out.extend_from_slice(&(rgb_asset_id.len() as u32).to_be_bytes());
                 out.extend_from_slice(rgb_asset_id.as_bytes());
+                // EVM verification checkpoint (M-06): a presence byte plus, when
+                // present, the 32-byte Helios beacon block root. Pins WHICH
+                // checkpoint, so an attacker-chosen trust root is visible to a
+                // verifier instead of hiding behind an identical mode byte.
+                match evm_checkpoint {
+                    Some(cp) => {
+                        out.push(0x01);
+                        out.extend_from_slice(cp);
+                    }
+                    None => out.push(0x00),
+                }
             }
             AttestedPolicy::Development => {
                 out.push(0x00);
@@ -144,6 +164,7 @@ mod tests {
             chain_id,
             bridge_contract: [contract; 20],
             rgb_asset_id: asset.into(),
+            evm_checkpoint: None,
         }
     }
 
@@ -181,6 +202,34 @@ mod tests {
                 "posture change must alter the commitment"
             );
         }
+    }
+
+    #[test]
+    fn evm_checkpoint_presence_and_value_change_the_bytes() {
+        // No checkpoint vs a pinned checkpoint must differ (M-06): a verifier
+        // expecting a specific trust root rejects one that pins none.
+        let none = base();
+        let mut with_cp = base();
+        if let AttestedPolicy::Production {
+            ref mut evm_checkpoint,
+            ..
+        } = with_cp
+        {
+            *evm_checkpoint = Some([0xAB; 32]);
+        }
+        assert_ne!(none.to_bytes(), with_cp.to_bytes());
+
+        // Two different checkpoints must also differ — the value is bound, not
+        // just its presence.
+        let mut other_cp = base();
+        if let AttestedPolicy::Production {
+            ref mut evm_checkpoint,
+            ..
+        } = other_cp
+        {
+            *evm_checkpoint = Some([0xCD; 32]);
+        }
+        assert_ne!(with_cp.to_bytes(), other_cp.to_bytes());
     }
 
     #[test]

--- a/enclave/src/main.rs
+++ b/enclave/src/main.rs
@@ -73,14 +73,24 @@ fn main() {
     // client is selected below: `evm-rpc` off => none; `helios` +
     // HELIOS_EXECUTION_RPC set => trustless; otherwise the raw host-relayed RPC.
     #[cfg(not(feature = "evm-rpc"))]
-    let evm_source = EvmDataSource::Disabled;
+    let (evm_source, evm_checkpoint) = (EvmDataSource::Disabled, None);
     #[cfg(all(feature = "evm-rpc", not(feature = "helios")))]
-    let evm_source = EvmDataSource::RawRpc;
+    let (evm_source, evm_checkpoint) = (EvmDataSource::RawRpc, None);
     #[cfg(all(feature = "evm-rpc", feature = "helios"))]
-    let evm_source = if std::env::var("HELIOS_EXECUTION_RPC").is_ok() {
-        EvmDataSource::HeliosVerified
+    let (evm_source, evm_checkpoint) = if std::env::var("HELIOS_EXECUTION_RPC").is_ok() {
+        // The pinned weak-subjectivity checkpoint is Helios's trust root, so
+        // commit it into the attested policy — a verifier then confirms WHICH
+        // checkpoint the enclave synced from, not merely that it is in Helios
+        // mode (audit M-06). Reads the SAME `HELIOS_CHECKPOINT` that
+        // `HeliosConfig` / `HeliosEvmClient` sync against. A missing/malformed
+        // value yields `None`, and the boot gate below then refuses to boot.
+        let checkpoint = std::env::var("HELIOS_CHECKPOINT")
+            .ok()
+            .and_then(|s| hex::decode(s.strip_prefix("0x").unwrap_or(&s)).ok())
+            .and_then(|b| <[u8; 32]>::try_from(b).ok());
+        (EvmDataSource::HeliosVerified, checkpoint)
     } else {
-        EvmDataSource::RawRpc
+        (EvmDataSource::RawRpc, None)
     };
 
     // Resolve the enclave's single, explicit security posture once (audit C-01),
@@ -89,7 +99,7 @@ fn main() {
     // `server::handle_get_attested_public_key`) and consulted by the signing
     // handlers instead of re-deriving posture from features and empty fields.
     let build_ctx = BuildContext::current();
-    let policy = SecurityPolicy::resolve(&build_ctx, &bridge_config, evm_source);
+    let policy = SecurityPolicy::resolve(&build_ctx, &bridge_config, evm_source, evm_checkpoint);
     match &policy {
         SecurityPolicy::Production(p) => tracing::info!(
             chain_id = p.chain_id,

--- a/enclave/src/policy.rs
+++ b/enclave/src/policy.rs
@@ -61,6 +61,12 @@ pub struct ProductionPolicy {
     /// disabled). Recorded and attested so a verifier can tell a trustless
     /// deployment apart from a host-relayed one.
     pub evm_source: EvmDataSource,
+    /// The Helios weak-subjectivity checkpoint (beacon block root) EVM
+    /// verification trust-roots on. `Some` only when `evm_source` is
+    /// [`EvmDataSource::HeliosVerified`]; required in that case and attested, so
+    /// a verifier confirms WHICH checkpoint the enclave synced from — not just
+    /// that it is in Helios mode (audit M-06).
+    pub evm_checkpoint: Option<[u8; 32]>,
     /// Bitcoin anchor-verification source. Always SPV in a production build.
     pub btc_source: BtcDataSource,
 }
@@ -120,7 +126,12 @@ impl SecurityPolicy {
     /// non-bridge build, or an unpinned config yields
     /// [`SecurityPolicy::Development`]. Only a release bridge build with all
     /// three pins set becomes [`SecurityPolicy::Production`].
-    pub fn resolve(ctx: &BuildContext, bridge: &BridgeConfig, evm_source: EvmDataSource) -> Self {
+    pub fn resolve(
+        ctx: &BuildContext,
+        bridge: &BridgeConfig,
+        evm_source: EvmDataSource,
+        evm_checkpoint: Option<[u8; 32]>,
+    ) -> Self {
         // Any dev feature collapses the posture regardless of everything else.
         // (These are `compile_error!` in a release build — lib.rs — so in a real
         // production binary they are all false; the checks make dev/test builds
@@ -152,6 +163,7 @@ impl SecurityPolicy {
             allow_vanilla_psbt: bridge.allows_vanilla_btc(),
             attestation: AttestationMode::Real,
             evm_source,
+            evm_checkpoint,
             // `rgb-validation` implies `spv` (lib.rs `compile_error!`), so a
             // bridge build always anchors witness txs via the SPV header chain.
             btc_source: BtcDataSource::SpvVerified,
@@ -173,6 +185,7 @@ impl SecurityPolicy {
                 chain_id: p.chain_id,
                 bridge_contract: p.bridge_contract,
                 rgb_asset_id: p.rgb_asset_id.clone(),
+                evm_checkpoint: p.evm_checkpoint,
             },
             Self::Development { .. } => AttestedPolicy::Development,
         }
@@ -234,6 +247,18 @@ impl ProductionPolicy {
                 self.evm_source
             ));
         }
+        // Helios's trust root MUST be pinned and attested (audit M-06): without a
+        // checkpoint the light client would bootstrap from an untrusted source,
+        // and a verifier could not tell which chain the enclave synced. Fail
+        // closed at boot rather than attesting Helios mode with no trust root.
+        if self.evm_checkpoint.is_none() {
+            return Err(
+                "production policy uses the Helios EVM source but pins no weak-subjectivity \
+                 checkpoint. Set HELIOS_CHECKPOINT to a recent beacon block root so the trust \
+                 root is fixed and attested (audit M-06)."
+                    .into(),
+            );
+        }
         Ok(())
     }
 }
@@ -262,17 +287,25 @@ mod tests {
         }
     }
 
+    /// A pinned Helios checkpoint for tests that resolve a valid production
+    /// Helios policy (a real beacon block root is 32 bytes).
+    fn a_checkpoint() -> Option<[u8; 32]> {
+        Some([0x0c; 32])
+    }
+
     #[test]
     fn release_bridge_with_full_pins_is_production() {
         let p = SecurityPolicy::resolve(
             &release_bridge_ctx(),
             &pinned_config(),
             EvmDataSource::HeliosVerified,
+            a_checkpoint(),
         );
         match &p {
             SecurityPolicy::Production(pp) => {
                 assert_eq!(pp.chain_id, 1);
                 assert_eq!(pp.evm_source, EvmDataSource::HeliosVerified);
+                assert_eq!(pp.evm_checkpoint, a_checkpoint());
                 assert_eq!(pp.attestation, AttestationMode::Real);
                 assert_eq!(pp.btc_source, BtcDataSource::SpvVerified);
             }
@@ -287,7 +320,7 @@ mod tests {
         // Non-Helios sources still resolve to Production (recorded + attested)
         // but must not pass the boot gate.
         for source in [EvmDataSource::Disabled, EvmDataSource::RawRpc] {
-            let p = SecurityPolicy::resolve(&ctx, &pinned_config(), source);
+            let p = SecurityPolicy::resolve(&ctx, &pinned_config(), source, None);
             assert!(
                 matches!(p, SecurityPolicy::Production(_)),
                 "expected Production for {source:?}"
@@ -295,15 +328,35 @@ mod tests {
             let err = p.assert_valid_for_build(&ctx).unwrap_err();
             assert!(err.contains("Helios"), "got: {err}");
         }
-        // Only Helios-verified passes the boot gate.
-        let p = SecurityPolicy::resolve(&ctx, &pinned_config(), EvmDataSource::HeliosVerified);
+        // Only Helios-verified WITH a pinned checkpoint passes the boot gate.
+        let p = SecurityPolicy::resolve(
+            &ctx,
+            &pinned_config(),
+            EvmDataSource::HeliosVerified,
+            a_checkpoint(),
+        );
         assert!(p.assert_valid_for_build(&ctx).is_ok());
+    }
+
+    #[test]
+    fn production_helios_without_a_pinned_checkpoint_is_rejected_at_boot() {
+        // M-06: Helios is the trustless source, but with no weak-subjectivity
+        // checkpoint its trust root is unpinned and unattested. Such a build
+        // resolves to Production (so the missing pin is visible) but must NOT
+        // pass the boot gate.
+        let ctx = release_bridge_ctx();
+        let p =
+            SecurityPolicy::resolve(&ctx, &pinned_config(), EvmDataSource::HeliosVerified, None);
+        assert!(matches!(p, SecurityPolicy::Production(_)));
+        let err = p.assert_valid_for_build(&ctx).unwrap_err();
+        assert!(err.contains("checkpoint"), "got: {err}");
     }
 
     #[test]
     fn release_bridge_unconfigured_is_rejected_at_boot() {
         let ctx = release_bridge_ctx();
-        let p = SecurityPolicy::resolve(&ctx, &BridgeConfig::default(), EvmDataSource::RawRpc);
+        let p =
+            SecurityPolicy::resolve(&ctx, &BridgeConfig::default(), EvmDataSource::RawRpc, None);
         assert_eq!(
             p,
             SecurityPolicy::Development {
@@ -322,7 +375,7 @@ mod tests {
             chain_id: 1,
             ..Default::default()
         };
-        let p = SecurityPolicy::resolve(&ctx, &partial, EvmDataSource::RawRpc);
+        let p = SecurityPolicy::resolve(&ctx, &partial, EvmDataSource::RawRpc, None);
         assert!(matches!(p, SecurityPolicy::Development { .. }));
         assert!(p.assert_valid_for_build(&ctx).is_err());
     }
@@ -354,7 +407,12 @@ mod tests {
             ),
         ];
         for (ctx, reason) in cases {
-            let p = SecurityPolicy::resolve(&ctx, &pinned_config(), EvmDataSource::HeliosVerified);
+            let p = SecurityPolicy::resolve(
+                &ctx,
+                &pinned_config(),
+                EvmDataSource::HeliosVerified,
+                a_checkpoint(),
+            );
             assert_eq!(p, SecurityPolicy::Development { reason });
             // Even fully pinned, a dev feature in a release rgb build must not boot.
             assert!(p.assert_valid_for_build(&ctx).is_err());
@@ -367,7 +425,7 @@ mod tests {
             debug_or_test: true,
             ..release_bridge_ctx()
         };
-        let p = SecurityPolicy::resolve(&ctx, &pinned_config(), EvmDataSource::RawRpc);
+        let p = SecurityPolicy::resolve(&ctx, &pinned_config(), EvmDataSource::RawRpc, None);
         assert_eq!(
             p,
             SecurityPolicy::Development {
@@ -383,7 +441,12 @@ mod tests {
             rgb_validation: false,
             ..release_bridge_ctx()
         };
-        let p = SecurityPolicy::resolve(&ctx, &BridgeConfig::default(), EvmDataSource::Disabled);
+        let p = SecurityPolicy::resolve(
+            &ctx,
+            &BridgeConfig::default(),
+            EvmDataSource::Disabled,
+            None,
+        );
         assert_eq!(
             p,
             SecurityPolicy::Development {
@@ -399,7 +462,7 @@ mod tests {
         let ctx = release_bridge_ctx();
         let mut cfg = pinned_config();
         // Unset BTC pins -> vanilla disabled (fail-closed).
-        let p = SecurityPolicy::resolve(&ctx, &cfg, EvmDataSource::RawRpc);
+        let p = SecurityPolicy::resolve(&ctx, &cfg, EvmDataSource::RawRpc, None);
         assert!(matches!(
             p,
             SecurityPolicy::Production(ProductionPolicy {
@@ -409,7 +472,7 @@ mod tests {
         ));
         // Operator sets the cap -> vanilla enabled and attested.
         cfg.btc_max_total_sats = 100_000;
-        let p = SecurityPolicy::resolve(&ctx, &cfg, EvmDataSource::RawRpc);
+        let p = SecurityPolicy::resolve(&ctx, &cfg, EvmDataSource::RawRpc, None);
         assert!(matches!(
             p,
             SecurityPolicy::Production(ProductionPolicy {
@@ -422,11 +485,37 @@ mod tests {
     #[test]
     fn evm_source_is_carried_into_the_commitment() {
         let ctx = release_bridge_ctx();
-        let raw = SecurityPolicy::resolve(&ctx, &pinned_config(), EvmDataSource::RawRpc);
-        let helios = SecurityPolicy::resolve(&ctx, &pinned_config(), EvmDataSource::HeliosVerified);
+        let raw = SecurityPolicy::resolve(&ctx, &pinned_config(), EvmDataSource::RawRpc, None);
+        let helios = SecurityPolicy::resolve(
+            &ctx,
+            &pinned_config(),
+            EvmDataSource::HeliosVerified,
+            a_checkpoint(),
+        );
         // A raw-RPC deployment and a Helios deployment commit to different bytes,
         // so a verifier expecting one rejects the other (audit C-01 data source).
         assert_ne!(raw.commitment_bytes(), helios.commitment_bytes());
+    }
+
+    #[test]
+    fn evm_checkpoint_is_carried_into_the_commitment() {
+        // M-06: two Helios deployments identical except for the pinned checkpoint
+        // commit different bytes, so a verifier bound to one trust root rejects
+        // an enclave that synced from another.
+        let ctx = release_bridge_ctx();
+        let a = SecurityPolicy::resolve(
+            &ctx,
+            &pinned_config(),
+            EvmDataSource::HeliosVerified,
+            Some([0xAA; 32]),
+        );
+        let b = SecurityPolicy::resolve(
+            &ctx,
+            &pinned_config(),
+            EvmDataSource::HeliosVerified,
+            Some([0xBB; 32]),
+        );
+        assert_ne!(a.commitment_bytes(), b.commitment_bytes());
     }
 
     #[test]
@@ -445,7 +534,8 @@ mod tests {
             SecurityPolicy::resolve(
                 &release_bridge_ctx(),
                 &pinned_config(),
-                EvmDataSource::RawRpc
+                EvmDataSource::RawRpc,
+                None,
             )
             .commitment_bytes()
         );

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -116,6 +116,7 @@ impl ServerContext {
             &crate::policy::BuildContext::current(),
             &bridge_config,
             crate::policy::EvmDataSource::Disabled,
+            None,
         );
         Self {
             state,

--- a/enclave/tests/common/mod.rs
+++ b/enclave/tests/common/mod.rs
@@ -52,6 +52,7 @@ pub fn start_test_server_with_config(
         &BuildContext::current(),
         &bridge_config,
         EvmDataSource::Disabled,
+        None,
     );
     let ctx = Arc::new(ServerContext {
         state,

--- a/parent/src/attest_verify.rs
+++ b/parent/src/attest_verify.rs
@@ -39,6 +39,12 @@ pub enum ExpectedPolicy {
     Production {
         allow_vanilla_psbt: bool,
         evm_source: EvmDataSource,
+        /// The Helios weak-subjectivity checkpoint the operator expects the
+        /// enclave to have pinned. `Some` (required) when `evm_source` is
+        /// [`EvmDataSource::HeliosVerified`]; folded into the reconstructed
+        /// commitment so an enclave that trust-rooted on a different checkpoint
+        /// fails verification (audit M-06).
+        evm_checkpoint: Option<[u8; 32]>,
     },
     /// Expect a dev/mock enclave (e.g. behind `--mock`). Never for production.
     Development,
@@ -179,6 +185,7 @@ fn expected_attested_policy(
         ExpectedPolicy::Production {
             allow_vanilla_psbt,
             evm_source,
+            evm_checkpoint,
         } => {
             let bridge_contract: [u8; 20] = resp
                 .bridge_contract
@@ -201,6 +208,7 @@ fn expected_attested_policy(
                 chain_id: resp.chain_id,
                 bridge_contract,
                 rgb_asset_id: resp.rgb_asset_id.clone(),
+                evm_checkpoint: *evm_checkpoint,
             })
         }
     }

--- a/parent/src/bin/attest_verify.rs
+++ b/parent/src/bin/attest_verify.rs
@@ -68,6 +68,26 @@ struct Cli {
     /// verification if the enclave is only on raw RPC. Ignored with --mock.
     #[arg(long, default_value = "raw")]
     expect_evm_source: String,
+
+    /// Expected Helios weak-subjectivity checkpoint (0x-prefixed 32-byte beacon
+    /// block root) the enclave must have trust-rooted on. REQUIRED when
+    /// `--expect-evm-source helios`: the verifier reconstructs the committed
+    /// posture with this value, so an enclave that synced from a different
+    /// checkpoint fails the `user_data` hash (audit M-06). Ignored otherwise.
+    #[arg(long)]
+    expect_helios_checkpoint: Option<String>,
+}
+
+/// Parse the `--expect-helios-checkpoint` flag into a 32-byte beacon block root.
+fn parse_checkpoint(s: &str) -> Result<[u8; 32]> {
+    let bytes = hex::decode(s.strip_prefix("0x").unwrap_or(s))
+        .context("--expect-helios-checkpoint is not valid hex")?;
+    bytes.try_into().map_err(|v: Vec<u8>| {
+        anyhow::anyhow!(
+            "--expect-helios-checkpoint must be 32 bytes (a beacon block root), got {}",
+            v.len()
+        )
+    })
 }
 
 /// Parse the `--expect-evm-source` flag into an [`EvmDataSource`].
@@ -112,9 +132,25 @@ async fn run(cli: Cli) -> Result<()> {
         let pcr2 = cli.pcr2.context("--pcr2 required (or pass --mock)")?;
         let pcrs = attestation_verify::ExpectedPcrs::from_hex(&pcr0, &pcr1, &pcr2)
             .context("invalid PCR hex")?;
+        let evm_source = parse_evm_source(&cli.expect_evm_source)?;
+        let evm_checkpoint = cli
+            .expect_helios_checkpoint
+            .as_deref()
+            .map(parse_checkpoint)
+            .transpose()?;
+        // A Helios expectation without a pinned checkpoint could never match a
+        // real trustless enclave (which always commits one), so refuse early
+        // with a clear message rather than a downstream hash mismatch (M-06).
+        if evm_source == EvmDataSource::HeliosVerified && evm_checkpoint.is_none() {
+            anyhow::bail!(
+                "--expect-evm-source helios requires --expect-helios-checkpoint \
+                 (the beacon block root the enclave pinned)"
+            );
+        }
         let expected_policy = ExpectedPolicy::Production {
             allow_vanilla_psbt: cli.expect_vanilla_psbt,
-            evm_source: parse_evm_source(&cli.expect_evm_source)?,
+            evm_source,
+            evm_checkpoint,
         };
         (pcrs, VerifyMode::Real, expected_policy)
     };

--- a/parent/tests/test_attest_verify_e2e.rs
+++ b/parent/tests/test_attest_verify_e2e.rs
@@ -211,6 +211,7 @@ async fn e2e_attest_verify_fails_on_policy_mismatch() {
         ExpectedPolicy::Production {
             allow_vanilla_psbt: false,
             evm_source: EvmDataSource::RawRpc,
+            evm_checkpoint: None,
         },
     )
     .await


### PR DESCRIPTION
The attested posture committed Helios *mode* but not the weak-subjectivity checkpoint it trust-roots on, so a verifier could confirm an enclave ran Helios but not which chain it synced from — an operator could point it at an attacker-chosen checkpoint invisibly.

Bind the checkpoint into attestation user_data so the trust root is verifiable, and refuse to boot a production Helios enclave that pins none.

 - attestation-verify: AttestedPolicy::Production carries evm_checkpoint; folded into the commitment to_bytes (presence byte + 32-byte root)
 - policy: ProductionPolicy records the checkpoint; check_invariants rejects a Helios source with no checkpoint (fail-closed at boot)
 - main: parse the same HELIOS_CHECKPOINT Helios syncs against into the policy
 - parent: attest-verify gains --expect-helios-checkpoint; the verifier reconstructs the commitment with it, so a different checkpoint fails the user_data hash