### PR TITLE
ci: add Kimi and Claude AI code review workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,62 @@
+name: AI Review - Claude
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to review (for manual reruns)"
+        required: true
+        type: string
+
+jobs:
+  claude-review:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' &&
+       (github.event.label.name == 'ai-review/claude' || github.event.label.name == 'claude-review')) ||
+      (github.event_name == 'pull_request' && github.event.action == 'synchronize' &&
+       (contains(github.event.pull_request.labels.*.name, 'ai-review/claude') || contains(github.event.pull_request.labels.*.name, 'claude-review'))) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ai-review-claude-pr-${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          show_full_output: false
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
+
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            Use the repository's CLAUDE.md for guidance on style and conventions.
+            Be constructive and helpful in your feedback.
+
+            Use `gh pr comment` to publish your final review on the PR.
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/kimi-code-review.yml
+++ b/.github/workflows/kimi-code-review.yml
@@ -1,0 +1,47 @@
+name: AI Review - Kimi
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to review (for manual reruns)"
+        required: true
+        type: string
+
+jobs:
+  kimi-review:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' &&
+       github.event.label.name == 'ai-review/kimi') ||
+      (github.event_name == 'pull_request' && github.event.action == 'synchronize' &&
+       contains(github.event.pull_request.labels.*.name, 'ai-review/kimi')) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '@kimi'))
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ai-review-kimi-pr-${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run Kimi Code Review
+        uses: UTEXO-Protocol/kimi-actions@main
+        with:
+          kimi_api_key: ${{ secrets.KIMI_API_KEY }}
+          kimi_base_url: https://api.moonshot.ai/v1
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          model: kimi-k2.6
+          language: en-US
+          review_level: normal
+          pr_number: ${{ inputs.pr_number }}


### PR DESCRIPTION
Adds AI-powered code review workflows to the repository.

## Changes
- `kimi-code-review.yml` — Kimi (Moonshot AI) review, triggered by `ai-review/kimi` label or `@kimi` comment
- `claude-code-review.yml` — Claude review, triggered by `ai-review/claude` label or `@claude` comment

Both workflows also support `workflow_dispatch` for manual reruns with a `pr_number` input.

## Required secrets
- `KIMI_API_KEY`
- `ANTHROPIC_API_KEY`