### PR TITLE
fix(enclave): bind the send-RGB recipient seal to the deposits invoice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7837,6 +7837,7 @@ dependencies = [
  "rand 0.10.2",
  "rand_core 0.6.4",
  "rgb-consignment",
+ "rgb-invoicing",
  "rgb-ops",
  "rgb-schemas",
  "secrecy",

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -44,6 +44,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rgb-ops = { version = "0.11.1-rc.7", features = ["esplora_blocking", "electrum_blocking"], optional = true }
 rgb-consignment = { git = "https://github.com/UTEXO-Protocol/consignment-utils.git", rev = "6a792af035cc5b011a790831a0732d420a2413e0", default-features = false, optional = true }
 rgb-schemas = { version = "=0.11.1-rc.10", default-features = false, optional = true }
+# Invoice parsing for the send-RGB recipient bind. Sibling crate of `rgb-ops`
+# in the same repo and already in the lock at its rev, so this adds no new
+# third-party code.
+rgb-invoicing = { version = "0.11.1-rc.11", default-features = false, optional = true }
 attestation-verify = { path = "../attestation-verify" }
 serde = { version = "1", features = ["derive"] }
 
@@ -92,7 +96,7 @@ dev-mode = []
 # resolver, so a malicious host could have the enclave sign a release against a
 # fabricated Bitcoin anchor. Kept as a separate feature (rather than adding
 # `spv` to this list) to avoid a feature cycle with `spv` below.
-rgb-validation = ["rgb-ops", "rgb-consignment", "rgb-schemas"]
+rgb-validation = ["rgb-ops", "rgb-consignment", "rgb-schemas", "rgb-invoicing"]
 # Bitcoin SPV verification of consignment witness txids before signing EVM
 # transactions. Implies `rgb-validation` because SPV needs the consignment
 # parsed to extract witness txids. When the feature is OFF, handle_sign_evm

--- a/enclave/src/networks/evm/evm_event.rs
+++ b/enclave/src/networks/evm/evm_event.rs
@@ -72,6 +72,12 @@ const BFI_OPERATION_ID_TOPIC: usize = 1;
 const BFI_AMOUNT_OFF: usize = 32;
 const BFI_NET_AMOUNT_OFF: usize = 64;
 const BFI_TOKEN_COMMISSION_OFF: usize = 96;
+/// Word 7: the byte offset of the `string destinationAddress` tail, not the
+/// string itself.
+const BFI_DEST_ADDRESS_HEAD_OFF: usize = 224;
+/// Ceiling on the decoded `destinationAddress`. `Bridge.sol` caps it at 512
+/// on-chain; this bounds what a host-relayed receipt can make the enclave parse.
+const BFI_MAX_DEST_ADDRESS_LEN: usize = 2048;
 /// 7 static words + 1 dynamic-string offset word must be present.
 const BFI_MIN_DATA_LEN: usize = 8 * 32;
 
@@ -109,6 +115,15 @@ fn event_topic0(sig: &str) -> [u8; 32] {
     Keccak256::digest(sig.as_bytes()).into()
 }
 
+/// What a verified `BridgeFundsIn` deposit authorises. Only the fields later
+/// stages bind against; the rest is checked in [`verify_funds_in_event`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedFundsIn {
+    /// Verbatim from the log. For an RGB destination this is the user's
+    /// invoice, which the send-RGB recipient bind parses.
+    pub destination_address: String,
+}
+
 /// Independently verify the `FundsIn` deposit for a bridge-mode `signPsbt`.
 ///
 /// Fail-closed: a missing/failed receipt, no matching log, an ambiguous match,
@@ -130,7 +145,7 @@ pub fn verify_funds_in_event(
     expected_operation_id: &[u8],
     expected_gross_amount: u64,
     expected_commission: u64,
-) -> Result<()> {
+) -> Result<VerifiedFundsIn> {
     if expected_operation_id.len() != 32 {
         return Err(EnclaveError::CrossCheck(format!(
             "FundsIn expected operationId must be exactly 32 bytes (the contract-derived \
@@ -207,6 +222,10 @@ pub fn verify_funds_in_event(
     let gross = decode_u64_word(&log.data, BFI_AMOUNT_OFF, "amount")?;
     let net = decode_u64_word(&log.data, BFI_NET_AMOUNT_OFF, "netAmount")?;
     let commission = decode_u64_word(&log.data, BFI_TOKEN_COMMISSION_OFF, "tokenCommission")?;
+    // Decoded here, where the log is already proven to come from the pinned
+    // bridge contract, so later stages bind against authenticated evidence.
+    let destination_address =
+        decode_abi_string(&log.data, BFI_DEST_ADDRESS_HEAD_OFF, "destinationAddress")?;
 
     if expected_operation_id != operation_id.as_slice() {
         return Err(EnclaveError::CrossCheck(format!(
@@ -266,7 +285,9 @@ pub fn verify_funds_in_event(
         depth,
         "FundsIn event independently verified in-enclave"
     );
-    Ok(())
+    Ok(VerifiedFundsIn {
+        destination_address,
+    })
 }
 
 /// Read a 32-byte ABI word at `offset` in `data` as a `u64`, with a
@@ -280,6 +301,47 @@ fn decode_u64_word(data: &[u8], offset: usize, field: &str) -> Result<u64> {
              is rejected, never truncated)"
         ))
     })
+}
+
+/// Decode the ABI dynamic `string` whose head word sits at `head_off`: an
+/// offset into `data`, then a length word and the bytes, padded to 32.
+///
+/// Every bound is checked - a forged offset or length must fail, not read
+/// adjacent memory or panic.
+fn decode_abi_string(data: &[u8], head_off: usize, field: &str) -> Result<String> {
+    let err = |m: String| EnclaveError::CrossCheck(format!("BridgeFundsIn {field}: {m}"));
+
+    let offset =
+        usize::try_from(extract_uint256_as_u64(data, head_off).map_err(|e| err(e.to_string()))?)
+            .map_err(|_| err("tail offset exceeds usize".into()))?;
+    let len_off = offset
+        .checked_add(32)
+        .ok_or_else(|| err("tail offset overflow".into()))?;
+    if len_off > data.len() {
+        return Err(err(format!(
+            "tail offset {offset} is past the {} bytes of log data",
+            data.len()
+        )));
+    }
+    let len =
+        usize::try_from(extract_uint256_as_u64(data, offset).map_err(|e| err(e.to_string()))?)
+            .map_err(|_| err("tail length exceeds usize".into()))?;
+    if len > BFI_MAX_DEST_ADDRESS_LEN {
+        return Err(err(format!(
+            "tail length {len} exceeds the {BFI_MAX_DEST_ADDRESS_LEN}-byte cap"
+        )));
+    }
+    let end = len_off
+        .checked_add(len)
+        .ok_or_else(|| err("tail length overflow".into()))?;
+    if end > data.len() {
+        return Err(err(format!(
+            "tail claims {len} bytes at {len_off} but the log data is {} bytes",
+            data.len()
+        )));
+    }
+    String::from_utf8(data[len_off..end].to_vec())
+        .map_err(|_| err("tail is not valid UTF-8".into()))
 }
 
 /// Equality assertion with a field-named fail-closed error.
@@ -634,17 +696,104 @@ mod tests {
         id
     }
 
-    /// BridgeFundsIn `data`: senderNonce, gross, net, commission, then
-    /// nativeCommission/srcChain/destChain/string-offset zero-filled.
-    /// `operationId` is NOT here any more - it is an indexed topic.
+    /// An RGB invoice in the shape the pinned `rgb-invoicing` accepts:
+    /// `rgb:<contract>/<schema>/<state>/bc:utxob:<seal>`. Shared with
+    /// [`crate::networks::rgb::invoice`], whose tests parse this same string,
+    /// so the ABI half and the parsing half cannot drift apart.
+    const SAMPLE_INVOICE: &str = "rgb:fuhLYX9G-eC8gDvf-V0XpYFH-ceSafoc-lGutAYq-~SExGU4/\
+                                  XvmU3d4_nQQ8S7oagbXi07x5vjMm7P~ERukQNX6SC4M/BF/bc:utxob:\
+                                  UzR~73lD-JyzirTn-engdWia-qjd5NyV-mndAmmo-EbxdVEG-L6OiP";
+
+    /// BridgeFundsIn `data`: senderNonce, gross, net, commission,
+    /// nativeCommission, srcChain, destChain, then the `destinationAddress`
+    /// head word and its tail. `operationId` is NOT here - it is an indexed
+    /// topic.
     fn bridge_data(gross: u64, net: u64, commission: u64) -> Vec<u8> {
+        bridge_data_with_dest(gross, net, commission, SAMPLE_INVOICE)
+    }
+
+    /// The real ABI shape: 8 head words, the last one the tail offset, then a
+    /// length word and padded bytes.
+    fn bridge_data_with_dest(gross: u64, net: u64, commission: u64, dest: &str) -> Vec<u8> {
         let mut d = Vec::new();
         d.extend_from_slice(&word(0)); // senderNonce
         d.extend_from_slice(&word(gross));
         d.extend_from_slice(&word(net));
         d.extend_from_slice(&word(commission));
-        d.extend_from_slice(&[0u8; 32 * 4]); // nativeCommission, src, dest, str offset
+        d.extend_from_slice(&[0u8; 32 * 3]); // nativeCommission, sourceChainId, destinationChainId
+        d.extend_from_slice(&word(8 * 32)); // tail offset: just past the head words
+        d.extend_from_slice(&word(dest.len() as u64));
+        let mut bytes = dest.as_bytes().to_vec();
+        bytes.resize(bytes.len().div_ceil(32) * 32, 0);
+        d.extend_from_slice(&bytes);
         d
+    }
+
+    // --- destinationAddress tail decoding ---
+    //
+    // Attacker-shaped data on a host-relayed receipt, so every bound is
+    // asserted.
+
+    #[test]
+    fn decodes_the_destination_address_tail() {
+        let d = bridge_data_with_dest(1000, 950, 50, SAMPLE_INVOICE);
+        let got = decode_abi_string(&d, BFI_DEST_ADDRESS_HEAD_OFF, "destinationAddress").unwrap();
+        assert_eq!(got, SAMPLE_INVOICE);
+    }
+
+    #[test]
+    fn decodes_an_empty_destination_address() {
+        let d = bridge_data_with_dest(1000, 950, 50, "");
+        let got = decode_abi_string(&d, BFI_DEST_ADDRESS_HEAD_OFF, "destinationAddress").unwrap();
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn rejects_a_tail_offset_past_the_data() {
+        let mut d = bridge_data_with_dest(1000, 950, 50, SAMPLE_INVOICE);
+        d[BFI_DEST_ADDRESS_HEAD_OFF..BFI_DEST_ADDRESS_HEAD_OFF + 32]
+            .copy_from_slice(&word(1_000_000));
+        let err =
+            decode_abi_string(&d, BFI_DEST_ADDRESS_HEAD_OFF, "destinationAddress").unwrap_err();
+        assert!(err.to_string().contains("past the"), "{err}");
+    }
+
+    #[test]
+    fn rejects_a_tail_length_past_the_data() {
+        let mut d = bridge_data_with_dest(1000, 950, 50, SAMPLE_INVOICE);
+        let len_at = 8 * 32;
+        // Under the size cap, so the bounds check is what must catch it.
+        d[len_at..len_at + 32].copy_from_slice(&word(1_000));
+        let err =
+            decode_abi_string(&d, BFI_DEST_ADDRESS_HEAD_OFF, "destinationAddress").unwrap_err();
+        assert!(err.to_string().contains("log data is"), "{err}");
+    }
+
+    #[test]
+    fn rejects_a_tail_over_the_size_cap() {
+        let huge = "x".repeat(BFI_MAX_DEST_ADDRESS_LEN + 1);
+        let d = bridge_data_with_dest(1000, 950, 50, &huge);
+        let err =
+            decode_abi_string(&d, BFI_DEST_ADDRESS_HEAD_OFF, "destinationAddress").unwrap_err();
+        assert!(err.to_string().contains("cap"), "{err}");
+    }
+
+    #[test]
+    fn rejects_a_non_utf8_tail() {
+        let mut d = bridge_data_with_dest(1000, 950, 50, "abcd");
+        let at = 9 * 32; // first byte of the string body
+        d[at] = 0xFF;
+        let err =
+            decode_abi_string(&d, BFI_DEST_ADDRESS_HEAD_OFF, "destinationAddress").unwrap_err();
+        assert!(err.to_string().contains("not valid UTF-8"), "{err}");
+    }
+
+    /// Without this the recipient bind has nothing to compare against.
+    #[test]
+    fn verified_funds_in_carries_the_destination_address() {
+        let p = happy_provider();
+        let v = verify_funds_in_event(&p, &BRIDGE, 12, &TX, &op_id(7), 1000, 50).unwrap();
+        assert_eq!(v.destination_address, SAMPLE_INVOICE);
     }
 
     /// topics: [topic0, operationId, sourceSender, sender].
@@ -693,7 +842,7 @@ mod tests {
 
     /// Verify with the operationId bound - the only supported call shape.
     fn verify(p: &FakeProvider) -> Result<()> {
-        verify_funds_in_event(p, &BRIDGE, 12, &TX, &op_id(7), 1000, 50)
+        verify_funds_in_event(p, &BRIDGE, 12, &TX, &op_id(7), 1000, 50).map(|_| ())
     }
 
     #[test]

--- a/enclave/src/networks/evm/evm_event.rs
+++ b/enclave/src/networks/evm/evm_event.rs
@@ -77,9 +77,28 @@ const BFI_TOKEN_COMMISSION_OFF: usize = 96;
 const BFI_DEST_ADDRESS_HEAD_OFF: usize = 224;
 /// Ceiling on the decoded `destinationAddress`. `Bridge.sol` caps it at 512
 /// on-chain; this bounds what a host-relayed receipt can make the enclave parse.
-const BFI_MAX_DEST_ADDRESS_LEN: usize = 2048;
+/// The single cap on this string: the invoice parser reuses it rather than
+/// declaring a second one that could drift.
+pub(crate) const BFI_MAX_DEST_ADDRESS_LEN: usize = 2048;
 /// 7 static words + 1 dynamic-string offset word must be present.
 const BFI_MIN_DATA_LEN: usize = 8 * 32;
+
+/// An RGB invoice in the shape the pinned `rgb-invoicing` accepts:
+/// `rgb:<contract>/<schema>/<state>/bc:utxob:<seal>`.
+///
+/// Lives here, outside the test module, so [`crate::networks::rgb::invoice`]'s
+/// tests parse the very string this module's tests ABI-encode. One literal, so
+/// the ABI half and the parsing half cannot drift apart.
+#[cfg(test)]
+pub(crate) const SAMPLE_INVOICE: &str = "rgb:fuhLYX9G-eC8gDvf-V0XpYFH-ceSafoc-lGutAYq-~SExGU4/\
+                                         XvmU3d4_nQQ8S7oagbXi07x5vjMm7P~ERukQNX6SC4M/BF/bc:utxob:\
+                                         UzR~73lD-JyzirTn-engdWia-qjd5NyV-mndAmmo-EbxdVEG-L6OiP";
+
+/// The beneficiary [`SAMPLE_INVOICE`] names, in the form a confidential
+/// recipient leg carries.
+#[cfg(test)]
+pub(crate) const SAMPLE_INVOICE_SEAL: &str =
+    "utxob:UzR~73lD-JyzirTn-engdWia-qjd5NyV-mndAmmo-EbxdVEG-L6OiP";
 
 /// One decoded EVM log, enclave-local so no RPC-client types leak past this
 /// module boundary (keeps the predicate unit-testable without a live RPC).
@@ -311,21 +330,23 @@ fn decode_u64_word(data: &[u8], offset: usize, field: &str) -> Result<u64> {
 fn decode_abi_string(data: &[u8], head_off: usize, field: &str) -> Result<String> {
     let err = |m: String| EnclaveError::CrossCheck(format!("BridgeFundsIn {field}: {m}"));
 
-    let offset =
-        usize::try_from(extract_uint256_as_u64(data, head_off).map_err(|e| err(e.to_string()))?)
-            .map_err(|_| err("tail offset exceeds usize".into()))?;
+    let word_at = |off: usize, what: &str| -> Result<usize> {
+        let raw = extract_uint256_as_u64(data, off).map_err(|e| err(e.to_string()))?;
+        usize::try_from(raw).map_err(|_| err(format!("{what} exceeds usize")))
+    };
+
+    let offset = word_at(head_off, "tail offset")?;
     let len_off = offset
         .checked_add(32)
         .ok_or_else(|| err("tail offset overflow".into()))?;
+    // Ahead of the read below: it is what keeps `offset + 32` in range.
     if len_off > data.len() {
         return Err(err(format!(
             "tail offset {offset} is past the {} bytes of log data",
             data.len()
         )));
     }
-    let len =
-        usize::try_from(extract_uint256_as_u64(data, offset).map_err(|e| err(e.to_string()))?)
-            .map_err(|_| err("tail length exceeds usize".into()))?;
+    let len = word_at(offset, "tail length")?;
     if len > BFI_MAX_DEST_ADDRESS_LEN {
         return Err(err(format!(
             "tail length {len} exceeds the {BFI_MAX_DEST_ADDRESS_LEN}-byte cap"
@@ -695,14 +716,6 @@ mod tests {
         id[0] = 0xF0 | (tag & 0x0F); // high bytes set: cannot fit a u64
         id
     }
-
-    /// An RGB invoice in the shape the pinned `rgb-invoicing` accepts:
-    /// `rgb:<contract>/<schema>/<state>/bc:utxob:<seal>`. Shared with
-    /// [`crate::networks::rgb::invoice`], whose tests parse this same string,
-    /// so the ABI half and the parsing half cannot drift apart.
-    const SAMPLE_INVOICE: &str = "rgb:fuhLYX9G-eC8gDvf-V0XpYFH-ceSafoc-lGutAYq-~SExGU4/\
-                                  XvmU3d4_nQQ8S7oagbXi07x5vjMm7P~ERukQNX6SC4M/BF/bc:utxob:\
-                                  UzR~73lD-JyzirTn-engdWia-qjd5NyV-mndAmmo-EbxdVEG-L6OiP";
 
     /// BridgeFundsIn `data`: senderNonce, gross, net, commission,
     /// nativeCommission, srcChain, destChain, then the `destinationAddress`

--- a/enclave/src/networks/mod.rs
+++ b/enclave/src/networks/mod.rs
@@ -94,7 +94,6 @@ pub struct DestinationProof {
     /// `utxob:...` seals of the send-RGB confidential recipient legs. Bound
     /// against the deposit's invoice once that receipt is verified. Empty for
     /// EVM destinations and builds without the bind.
-    #[cfg(feature = "rgb-validation")]
     pub rgb_recipient_seals: Vec<String>,
 }
 
@@ -117,7 +116,6 @@ pub fn validate_destination(
             Ok(DestinationProof {
                 proof,
                 evm_funds_out,
-                #[cfg(feature = "rgb-validation")]
                 rgb_recipient_seals: Vec::new(),
             })
         }
@@ -133,9 +131,8 @@ pub fn validate_destination(
             let (destination_amount, rgb_recipient_seals) =
                 rgb::validate_destination_anchor(destination, amount, source_commission, ctx)?;
             #[cfg(not(all(feature = "rgb-validation", not(feature = "dev-mode"))))]
-            let destination_amount = destination.psbt_output_amount;
-            #[cfg(all(feature = "rgb-validation", feature = "dev-mode"))]
-            let rgb_recipient_seals: Vec<String> = Vec::new();
+            let (destination_amount, rgb_recipient_seals) =
+                (destination.psbt_output_amount, Vec::new());
 
             Ok(DestinationProof {
                 proof: RouteProof {
@@ -149,7 +146,6 @@ pub fn validate_destination(
                     operation_id: None,
                 },
                 evm_funds_out: None,
-                #[cfg(feature = "rgb-validation")]
                 rgb_recipient_seals,
             })
         }

--- a/enclave/src/networks/mod.rs
+++ b/enclave/src/networks/mod.rs
@@ -91,6 +91,11 @@ pub fn validate_source(
 pub struct DestinationProof {
     pub proof: RouteProof,
     pub evm_funds_out: Option<crate::networks::evm::validation::FundsOutParams>,
+    /// `utxob:...` seals of the send-RGB confidential recipient legs. Bound
+    /// against the deposit's invoice once that receipt is verified. Empty for
+    /// EVM destinations and builds without the bind.
+    #[cfg(feature = "rgb-validation")]
+    pub rgb_recipient_seals: Vec<String>,
 }
 
 /// Dispatch destination-network validation to the owning network module.
@@ -112,6 +117,8 @@ pub fn validate_destination(
             Ok(DestinationProof {
                 proof,
                 evm_funds_out,
+                #[cfg(feature = "rgb-validation")]
+                rgb_recipient_seals: Vec::new(),
             })
         }
         DestinationNetwork::RgbDestination(destination) => {
@@ -123,10 +130,12 @@ pub fn validate_destination(
             // binding fall back to the wire field, and they run no destination
             // cross-checks at all.
             #[cfg(all(feature = "rgb-validation", not(feature = "dev-mode")))]
-            let destination_amount =
+            let (destination_amount, rgb_recipient_seals) =
                 rgb::validate_destination_anchor(destination, amount, source_commission, ctx)?;
             #[cfg(not(all(feature = "rgb-validation", not(feature = "dev-mode"))))]
             let destination_amount = destination.psbt_output_amount;
+            #[cfg(all(feature = "rgb-validation", feature = "dev-mode"))]
+            let rgb_recipient_seals: Vec<String> = Vec::new();
 
             Ok(DestinationProof {
                 proof: RouteProof {
@@ -140,6 +149,8 @@ pub fn validate_destination(
                     operation_id: None,
                 },
                 evm_funds_out: None,
+                #[cfg(feature = "rgb-validation")]
+                rgb_recipient_seals,
             })
         }
     }

--- a/enclave/src/networks/rgb/invoice.rs
+++ b/enclave/src/networks/rgb/invoice.rs
@@ -1,0 +1,205 @@
+//! The RGB recipient an EVM deposit authorises.
+//!
+//! `BridgeFundsIn.destinationAddress` carries the user's invoice verbatim, in a
+//! log the enclave verifies itself. The consignment comes from the coordinator,
+//! so only the invoice says who the deposit meant to pay.
+
+use std::str::FromStr;
+
+use rgbinvoice::{Beneficiary, RgbInvoice};
+
+use crate::error::{EnclaveError, Result};
+
+/// Ceiling on the invoice string handed to the parser.
+const MAX_INVOICE_LEN: usize = 2048;
+
+/// The destination a verified deposit authorises paying.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthorizedRecipient {
+    /// `utxob:...` - the form a confidential recipient leg carries.
+    BlindedSeal(String),
+}
+
+/// Parse `BridgeFundsIn.destinationAddress` into the recipient it authorises.
+///
+/// A witness-vout beneficiary is refused, not skipped: its recipient leg is a
+/// revealed seal, which the per-output bind already rejects unless bridge-owned.
+pub fn parse_authorized_recipient(destination_address: &str) -> Result<AuthorizedRecipient> {
+    let trimmed = destination_address.trim();
+    if trimmed.is_empty() {
+        return Err(EnclaveError::CrossCheck(
+            "BridgeFundsIn.destinationAddress is empty - the deposit names no RGB recipient to \
+             bind the consignment against"
+                .into(),
+        ));
+    }
+    if trimmed.len() > MAX_INVOICE_LEN {
+        return Err(EnclaveError::CrossCheck(format!(
+            "BridgeFundsIn.destinationAddress is {} bytes (max {MAX_INVOICE_LEN})",
+            trimmed.len()
+        )));
+    }
+
+    let invoice = RgbInvoice::from_str(trimmed).map_err(|e| {
+        EnclaveError::CrossCheck(format!(
+            "BridgeFundsIn.destinationAddress is not a valid RGB invoice: {e}"
+        ))
+    })?;
+
+    match invoice.beneficiary.into_inner() {
+        Beneficiary::BlindedSeal(seal) => Ok(AuthorizedRecipient::BlindedSeal(seal.to_string())),
+        Beneficiary::WitnessVout(..) => Err(EnclaveError::CrossCheck(
+            "BridgeFundsIn.destinationAddress names a witness-vout beneficiary; the send-RGB \
+             recipient bind supports blinded seals only"
+                .into(),
+        )),
+    }
+}
+
+/// Require the consignment's confidential recipient legs to be the authorised
+/// seal, and only it.
+///
+/// Exactly one leg: the amount bind pins their total, so a second would split an
+/// authorised payment.
+pub fn assert_recipient_authorized(
+    seals: &[String],
+    authorized: &AuthorizedRecipient,
+) -> Result<()> {
+    let AuthorizedRecipient::BlindedSeal(expected) = authorized;
+
+    match seals {
+        [] => Err(EnclaveError::CrossCheck(
+            "send-RGB consignment pays no confidential recipient leg, but the deposit authorised \
+             a blinded seal - refusing to sign"
+                .into(),
+        )),
+        [only] if only == expected => Ok(()),
+        [only] => Err(EnclaveError::CrossCheck(format!(
+            "send-RGB recipient seal mismatch: the consignment pays {only}, but the on-chain \
+             deposit authorised {expected} - refusing to sign a correct amount to the wrong \
+             destination"
+        ))),
+        many => Err(EnclaveError::CrossCheck(format!(
+            "send-RGB consignment pays {} confidential recipient legs; exactly one is \
+             authorised by the deposit ({expected})",
+            many.len()
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn blinded(seal: &str) -> AuthorizedRecipient {
+        AuthorizedRecipient::BlindedSeal(seal.into())
+    }
+
+    /// Byte-identical to `evm_event`'s `SAMPLE_INVOICE`, so the ABI half and the
+    /// parsing half cannot drift apart.
+    const BLINDED_INVOICE: &str = "rgb:fuhLYX9G-eC8gDvf-V0XpYFH-ceSafoc-lGutAYq-~SExGU4/\
+                                   XvmU3d4_nQQ8S7oagbXi07x5vjMm7P~ERukQNX6SC4M/BF/bc:utxob:\
+                                   UzR~73lD-JyzirTn-engdWia-qjd5NyV-mndAmmo-EbxdVEG-L6OiP";
+
+    /// The beneficiary of [`BLINDED_INVOICE`]. Also the recipient leg of the
+    /// in-tree transfer fixture, so both sources of the string are one value.
+    const INVOICE_SEAL: &str = "utxob:UzR~73lD-JyzirTn-engdWia-qjd5NyV-mndAmmo-EbxdVEG-L6OiP";
+
+    /// [`BLINDED_INVOICE`] with a `wvout:` beneficiary.
+    const WITNESS_VOUT_INVOICE: &str = "rgb:fuhLYX9G-eC8gDvf-V0XpYFH-ceSafoc-lGutAYq-~SExGU4/\
+                                        XvmU3d4_nQQ8S7oagbXi07x5vjMm7P~ERukQNX6SC4M/Sa/bc:wvout:\
+                                        A8cJ7Ww3-NIzADo3-Tzp_5aD-7CTBWmA-AAAAAAA-AAAAAAA-ALSQkcw";
+
+    /// A parser that refused every real invoice would still pass the negative
+    /// tests below.
+    #[test]
+    fn a_real_invoice_yields_its_blinded_seal() {
+        assert_eq!(
+            parse_authorized_recipient(BLINDED_INVOICE).unwrap(),
+            blinded(INVOICE_SEAL)
+        );
+    }
+
+    /// Both sides render `SecretSeal`. A format change on either breaks here
+    /// instead of refusing every deposit in production.
+    #[test]
+    fn a_real_invoice_binds_the_consignment_seal_it_names() {
+        let authorized = parse_authorized_recipient(BLINDED_INVOICE).unwrap();
+        assert!(assert_recipient_authorized(&[INVOICE_SEAL.to_string()], &authorized).is_ok());
+    }
+
+    #[test]
+    fn a_witness_vout_invoice_is_refused() {
+        let err = parse_authorized_recipient(WITNESS_VOUT_INVOICE).unwrap_err();
+        assert!(err.to_string().contains("witness-vout"), "{err}");
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_tolerated() {
+        assert_eq!(
+            parse_authorized_recipient(&format!("  {BLINDED_INVOICE}\n")).unwrap(),
+            blinded(INVOICE_SEAL)
+        );
+    }
+
+    #[test]
+    fn empty_destination_address_is_refused() {
+        let err = parse_authorized_recipient("   ").unwrap_err();
+        assert!(err.to_string().contains("names no RGB recipient"), "{err}");
+    }
+
+    #[test]
+    fn non_invoice_destination_address_is_refused() {
+        let err = parse_authorized_recipient("0xdeadbeef").unwrap_err();
+        assert!(err.to_string().contains("not a valid RGB invoice"), "{err}");
+    }
+
+    #[test]
+    fn oversized_destination_address_is_refused() {
+        let err = parse_authorized_recipient(&"a".repeat(MAX_INVOICE_LEN + 1)).unwrap_err();
+        assert!(err.to_string().contains("max"), "{err}");
+    }
+
+    /// The finding itself: right amount, wrong destination.
+    #[test]
+    fn a_seal_the_deposit_did_not_authorise_is_refused() {
+        let err = assert_recipient_authorized(
+            &["utxob:attacker-seal".to_string()],
+            &blinded("utxob:real-recipient"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("recipient seal mismatch"), "{err}");
+    }
+
+    #[test]
+    fn the_authorised_seal_binds() {
+        assert!(assert_recipient_authorized(
+            &["utxob:real-recipient".to_string()],
+            &blinded("utxob:real-recipient"),
+        )
+        .is_ok());
+    }
+
+    /// A split would route part of an authorised payment elsewhere.
+    #[test]
+    fn a_second_confidential_leg_is_refused() {
+        let err = assert_recipient_authorized(
+            &[
+                "utxob:real-recipient".to_string(),
+                "utxob:attacker-seal".to_string(),
+            ],
+            &blinded("utxob:real-recipient"),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("2 confidential recipient legs"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn no_confidential_leg_at_all_is_refused() {
+        let err = assert_recipient_authorized(&[], &blinded("utxob:real-recipient")).unwrap_err();
+        assert!(err.to_string().contains("pays no confidential"), "{err}");
+    }
+}

--- a/enclave/src/networks/rgb/invoice.rs
+++ b/enclave/src/networks/rgb/invoice.rs
@@ -9,16 +9,14 @@ use std::str::FromStr;
 use rgbinvoice::{Beneficiary, RgbInvoice};
 
 use crate::error::{EnclaveError, Result};
+use crate::networks::evm::evm_event::BFI_MAX_DEST_ADDRESS_LEN as MAX_INVOICE_LEN;
 
-/// Ceiling on the invoice string handed to the parser.
-const MAX_INVOICE_LEN: usize = 2048;
-
-/// The destination a verified deposit authorises paying.
+/// The `utxob:...` blinded seal a verified deposit authorises paying.
+///
+/// A newtype, not a bare `String`: [`assert_recipient_authorized`] compares it
+/// against consignment seals, and the two must not be swappable at a call site.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum AuthorizedRecipient {
-    /// `utxob:...` - the form a confidential recipient leg carries.
-    BlindedSeal(String),
-}
+pub struct AuthorizedRecipient(String);
 
 /// Parse `BridgeFundsIn.destinationAddress` into the recipient it authorises.
 ///
@@ -47,7 +45,7 @@ pub fn parse_authorized_recipient(destination_address: &str) -> Result<Authorize
     })?;
 
     match invoice.beneficiary.into_inner() {
-        Beneficiary::BlindedSeal(seal) => Ok(AuthorizedRecipient::BlindedSeal(seal.to_string())),
+        Beneficiary::BlindedSeal(seal) => Ok(AuthorizedRecipient(seal.to_string())),
         Beneficiary::WitnessVout(..) => Err(EnclaveError::CrossCheck(
             "BridgeFundsIn.destinationAddress names a witness-vout beneficiary; the send-RGB \
              recipient bind supports blinded seals only"
@@ -65,45 +63,37 @@ pub fn assert_recipient_authorized(
     seals: &[String],
     authorized: &AuthorizedRecipient,
 ) -> Result<()> {
-    let AuthorizedRecipient::BlindedSeal(expected) = authorized;
+    let AuthorizedRecipient(expected) = authorized;
 
-    match seals {
-        [] => Err(EnclaveError::CrossCheck(
-            "send-RGB consignment pays no confidential recipient leg, but the deposit authorised \
-             a blinded seal - refusing to sign"
-                .into(),
-        )),
-        [only] if only == expected => Ok(()),
-        [only] => Err(EnclaveError::CrossCheck(format!(
+    let [only] = seals else {
+        return Err(EnclaveError::CrossCheck(format!(
+            "send-RGB consignment pays {} confidential recipient legs; exactly one is \
+             authorised by the deposit ({expected})",
+            seals.len()
+        )));
+    };
+    if only != expected {
+        return Err(EnclaveError::CrossCheck(format!(
             "send-RGB recipient seal mismatch: the consignment pays {only}, but the on-chain \
              deposit authorised {expected} - refusing to sign a correct amount to the wrong \
              destination"
-        ))),
-        many => Err(EnclaveError::CrossCheck(format!(
-            "send-RGB consignment pays {} confidential recipient legs; exactly one is \
-             authorised by the deposit ({expected})",
-            many.len()
-        ))),
+        )));
     }
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// The one literal the ABI half encodes and this half parses.
+    use crate::networks::evm::evm_event::{
+        SAMPLE_INVOICE as BLINDED_INVOICE, SAMPLE_INVOICE_SEAL as INVOICE_SEAL,
+    };
+
     fn blinded(seal: &str) -> AuthorizedRecipient {
-        AuthorizedRecipient::BlindedSeal(seal.into())
+        AuthorizedRecipient(seal.into())
     }
-
-    /// Byte-identical to `evm_event`'s `SAMPLE_INVOICE`, so the ABI half and the
-    /// parsing half cannot drift apart.
-    const BLINDED_INVOICE: &str = "rgb:fuhLYX9G-eC8gDvf-V0XpYFH-ceSafoc-lGutAYq-~SExGU4/\
-                                   XvmU3d4_nQQ8S7oagbXi07x5vjMm7P~ERukQNX6SC4M/BF/bc:utxob:\
-                                   UzR~73lD-JyzirTn-engdWia-qjd5NyV-mndAmmo-EbxdVEG-L6OiP";
-
-    /// The beneficiary of [`BLINDED_INVOICE`]. Also the recipient leg of the
-    /// in-tree transfer fixture, so both sources of the string are one value.
-    const INVOICE_SEAL: &str = "utxob:UzR~73lD-JyzirTn-engdWia-qjd5NyV-mndAmmo-EbxdVEG-L6OiP";
 
     /// [`BLINDED_INVOICE`] with a `wvout:` beneficiary.
     const WITNESS_VOUT_INVOICE: &str = "rgb:fuhLYX9G-eC8gDvf-V0XpYFH-ceSafoc-lGutAYq-~SExGU4/\
@@ -217,6 +207,10 @@ mod tests {
     #[test]
     fn no_confidential_leg_at_all_is_refused() {
         let err = assert_recipient_authorized(&[], &blinded("utxob:real-recipient")).unwrap_err();
-        assert!(err.to_string().contains("pays no confidential"), "{err}");
+        assert!(
+            err.to_string()
+                .contains("pays 0 confidential recipient legs"),
+            "{err}"
+        );
     }
 }

--- a/enclave/src/networks/rgb/invoice.rs
+++ b/enclave/src/networks/rgb/invoice.rs
@@ -128,6 +128,23 @@ mod tests {
         assert!(assert_recipient_authorized(&[INVOICE_SEAL.to_string()], &authorized).is_ok());
     }
 
+    /// The shape the frontend actually emits: no contract/schema/state, plus
+    /// `expiry` and `endpoints` query params. Signet (`sb:`) as well as mainnet.
+    #[test]
+    fn the_frontend_invoice_shape_parses() {
+        for chain in ["bc", "sb"] {
+            let inv = format!(
+                "rgb:~/~/~/{chain}:utxob:dYwB28dy-yD6EBgm-MO~UKN_-FyEEdBL-E9hw8Oj-i9KxH5b-e9vZL\
+                 ?expiry=2073313268&endpoints=rpcs://rgb-proxy-utexo.utexo.com/json-rpc"
+            );
+            assert_eq!(
+                parse_authorized_recipient(&inv).unwrap(),
+                blinded("utxob:dYwB28dy-yD6EBgm-MO~UKN_-FyEEdBL-E9hw8Oj-i9KxH5b-e9vZL"),
+                "{chain}"
+            );
+        }
+    }
+
     #[test]
     fn a_witness_vout_invoice_is_refused() {
         let err = parse_authorized_recipient(WITNESS_VOUT_INVOICE).unwrap_err();

--- a/enclave/src/networks/rgb/mod.rs
+++ b/enclave/src/networks/rgb/mod.rs
@@ -230,7 +230,9 @@ pub fn validate_destination_anchor(
                 .into(),
         )
     })?;
-    let recipient_amount = psbt_validation::validate_psbt_anchors_transition(
+    // `legs.recipient_seals` is surfaced, not compared here: the invoice is
+    // only authenticated once the FundsIn receipt is verified, in `handle_sign`.
+    let legs = psbt_validation::validate_psbt_anchors_transition(
         &psbt,
         &validated,
         source_amount,
@@ -244,12 +246,7 @@ pub fn validate_destination_anchor(
     let recommended = validator.recommended_fee_rate_sat_vb()?;
     psbt_validation::check_psbt_fee_rate(&psbt, recommended)?;
 
-    // Surfaced, not compared here: the invoice is only authenticated once the
-    // FundsIn receipt is verified, later in `handle_sign`.
-    let recipient_seals =
-        psbt_validation::confidential_recipient_seals(&validated, psbt.unsigned_tx.compute_txid());
-
-    Ok((recipient_amount, recipient_seals))
+    Ok((legs.recipient, legs.recipient_seals))
 }
 
 #[cfg(all(test, feature = "rgb-validation"))]

--- a/enclave/src/networks/rgb/mod.rs
+++ b/enclave/src/networks/rgb/mod.rs
@@ -1,5 +1,7 @@
 pub mod btc_crosscheck;
 pub mod btc_ownership;
+#[cfg(feature = "rgb-validation")]
+pub mod invoice;
 pub mod psbt_validation;
 pub mod signing;
 pub mod spv;
@@ -146,7 +148,7 @@ pub fn validate_destination_anchor(
     source_amount: u64,
     source_commission: u64,
     ctx: &ValidationContext<'_>,
-) -> Result<u64> {
+) -> Result<(u64, Vec<String>)> {
     use crate::error::EnclaveError;
 
     if destination.consignment.is_empty() {
@@ -242,7 +244,12 @@ pub fn validate_destination_anchor(
     let recommended = validator.recommended_fee_rate_sat_vb()?;
     psbt_validation::check_psbt_fee_rate(&psbt, recommended)?;
 
-    Ok(recipient_amount)
+    // Surfaced, not compared here: the invoice is only authenticated once the
+    // FundsIn receipt is verified, later in `handle_sign`.
+    let recipient_seals =
+        psbt_validation::confidential_recipient_seals(&validated, psbt.unsigned_tx.compute_txid());
+
+    Ok((recipient_amount, recipient_seals))
 }
 
 #[cfg(all(test, feature = "rgb-validation"))]
@@ -481,7 +488,7 @@ mod tests {
                 header_chain: &chain,
                 self_owned_psbt_outputs: Some(&self_owned),
             };
-            validate_destination_anchor(destination, 0, 0, &ctx)
+            validate_destination_anchor(destination, 0, 0, &ctx).map(|(amount, _)| amount)
         }
 
         /// Happy path (old `binds_when_contract_id_matches_pin`): validated

--- a/enclave/src/networks/rgb/psbt_validation.rs
+++ b/enclave/src/networks/rgb/psbt_validation.rs
@@ -332,6 +332,30 @@ pub type SelfOwnedOutpoint<'a> = &'a dyn Fn(&Psbt, bitcoin::OutPoint) -> Result<
 #[cfg(feature = "rgb-validation")]
 pub const MAX_OFF_TX_CHANGE_OUTPOINTS: usize = 4;
 
+/// The `utxob:...` seals of every confidential `OS_ASSET` leg `psbt_txid`
+/// commits, in consignment order.
+///
+/// [`validate_psbt_anchors_transition`] pins the recipient *amount*; these are
+/// what [`crate::networks::rgb::invoice`] binds to prove *who* is paid.
+#[cfg(feature = "rgb-validation")]
+pub fn confidential_recipient_seals(
+    validated: &ValidatedConsignment,
+    psbt_txid: bitcoin::Txid,
+) -> Vec<String> {
+    use super::validation::OutputSeal;
+
+    validated
+        .transitions_committed_by(psbt_txid)
+        .iter()
+        .flat_map(|t| t.outputs.iter())
+        .filter(|o| o.assignment_type == ifa::OS_ASSET)
+        .filter_map(|o| match &o.seal {
+            OutputSeal::Confidential { secret_seal } => Some(secret_seal.clone()),
+            OutputSeal::Revealed { .. } => None,
+        })
+        .collect()
+}
+
 /// The two legs an `OS_ASSET` output assignment can belong to, in asset units.
 #[cfg(feature = "rgb-validation")]
 struct AssetLegs {
@@ -849,11 +873,16 @@ mod tests {
 
         /// A recipient leg: paid to a blinded (`utxob:...`) seal.
         fn confidential(amount: u64) -> TransitionOutput {
+            confidential_to(amount, "utxob:test-seal")
+        }
+
+        /// [`confidential`] with the seal named.
+        fn confidential_to(amount: u64, seal: &str) -> TransitionOutput {
             TransitionOutput {
                 assignment_type: ifa::OS_ASSET,
                 amount,
                 seal: OutputSeal::Confidential {
-                    secret_seal: "utxob:test-seal".into(),
+                    secret_seal: seal.into(),
                 },
             }
         }
@@ -1433,6 +1462,83 @@ mod tests {
                 err.to_string().contains("non-ALL sighash"),
                 "expected sighash rejection, got: {err}"
             );
+        }
+
+        // --- confidential_recipient_seals ---
+        //
+        // What the invoice bind compares against, so each filter is tested:
+        // a leg wrongly included or dropped makes the bind check the wrong thing.
+
+        #[test]
+        fn collects_the_blinded_seal_of_a_recipient_leg() {
+            let psbt = psbt_with_two_inputs();
+            let validated = validated_with(&psbt, vec![confidential_to(1_000, "utxob:recipient")]);
+            assert_eq!(
+                confidential_recipient_seals(&validated, psbt.unsigned_tx.compute_txid()),
+                vec!["utxob:recipient".to_string()]
+            );
+        }
+
+        /// Change is revealed. Including it would compare the invoice against
+        /// a bridge-owned output.
+        #[test]
+        fn skips_revealed_change_legs() {
+            let psbt = psbt_with_two_inputs();
+            let validated = validated_with(
+                &psbt,
+                vec![
+                    revealed(400, 1),
+                    confidential_to(600, "utxob:recipient"),
+                    revealed_off_tx(200),
+                ],
+            );
+            assert_eq!(
+                confidential_recipient_seals(&validated, psbt.unsigned_tx.compute_txid()),
+                vec!["utxob:recipient".to_string()]
+            );
+        }
+
+        /// Only `OS_ASSET` legs are recipient legs.
+        #[test]
+        fn skips_non_asset_assignments() {
+            let psbt = psbt_with_two_inputs();
+            let mut inflation = confidential_to(500, "utxob:inflation");
+            inflation.assignment_type = ifa::OS_INFLATION;
+            let validated = validated_with(
+                &psbt,
+                vec![inflation, confidential_to(1_000, "utxob:recipient")],
+            );
+            assert_eq!(
+                confidential_recipient_seals(&validated, psbt.unsigned_tx.compute_txid()),
+                vec!["utxob:recipient".to_string()]
+            );
+        }
+
+        /// The split shape the bind refuses: both seals must be surfaced.
+        #[test]
+        fn collects_every_confidential_leg_in_order() {
+            let psbt = psbt_with_two_inputs();
+            let validated = validated_with(
+                &psbt,
+                vec![
+                    confidential_to(600, "utxob:recipient"),
+                    confidential_to(400, "utxob:attacker"),
+                ],
+            );
+            assert_eq!(
+                confidential_recipient_seals(&validated, psbt.unsigned_tx.compute_txid()),
+                vec!["utxob:recipient".to_string(), "utxob:attacker".to_string()]
+            );
+        }
+
+        /// Another transaction's legs are not this signature's recipients.
+        #[test]
+        fn ignores_transitions_committed_by_another_txid() {
+            let psbt = psbt_with_two_inputs();
+            let validated = validated_with(&psbt, vec![confidential_to(1_000, "utxob:recipient")]);
+            let other =
+                Txid::from_raw_hash(bitcoin::hashes::sha256d::Hash::from_byte_array([0x99; 32]));
+            assert!(confidential_recipient_seals(&validated, other).is_empty());
         }
 
         #[test]

--- a/enclave/src/networks/rgb/psbt_validation.rs
+++ b/enclave/src/networks/rgb/psbt_validation.rs
@@ -122,9 +122,9 @@ pub fn validate_psbt_bytes(psbt_bytes: &[u8]) -> Result<()> {
 /// a callback rather than a `&KeyManager` so the caller holds the key lock only
 /// for that resolution, never across consignment validation's network calls.
 ///
-/// Returns the recipient leg in asset units. The route-level amount
-/// cross-check is built from this, not from the wire-supplied
-/// `psbt_output_amount`.
+/// Returns the [`AssetLegs`] this walk classified: the recipient leg in asset
+/// units, which the route-level amount cross-check is built from rather than
+/// the wire-supplied `psbt_output_amount`, and the seals it was paid to.
 #[cfg(feature = "rgb-validation")]
 pub fn validate_psbt_anchors_transition(
     psbt: &Psbt,
@@ -132,7 +132,7 @@ pub fn validate_psbt_anchors_transition(
     source_amount: u64,
     source_commission: u64,
     self_owned: SelfOwnedOutpoint<'_>,
-) -> Result<u64> {
+) -> Result<AssetLegs> {
     use std::collections::BTreeSet;
 
     let last = validated.last_transition.as_ref().ok_or_else(|| {
@@ -309,7 +309,7 @@ pub fn validate_psbt_anchors_transition(
         )));
     }
 
-    Ok(legs.recipient)
+    Ok(legs)
 }
 
 /// Resolves whether a Bitcoin outpoint pays back to this enclave.
@@ -332,38 +332,20 @@ pub type SelfOwnedOutpoint<'a> = &'a dyn Fn(&Psbt, bitcoin::OutPoint) -> Result<
 #[cfg(feature = "rgb-validation")]
 pub const MAX_OFF_TX_CHANGE_OUTPOINTS: usize = 4;
 
-/// The `utxob:...` seals of every confidential `OS_ASSET` leg `psbt_txid`
-/// commits, in consignment order.
-///
-/// [`validate_psbt_anchors_transition`] pins the recipient *amount*; these are
-/// what [`crate::networks::rgb::invoice`] binds to prove *who* is paid.
-#[cfg(feature = "rgb-validation")]
-pub fn confidential_recipient_seals(
-    validated: &ValidatedConsignment,
-    psbt_txid: bitcoin::Txid,
-) -> Vec<String> {
-    use super::validation::OutputSeal;
-
-    validated
-        .transitions_committed_by(psbt_txid)
-        .iter()
-        .flat_map(|t| t.outputs.iter())
-        .filter(|o| o.assignment_type == ifa::OS_ASSET)
-        .filter_map(|o| match &o.seal {
-            OutputSeal::Confidential { secret_seal } => Some(secret_seal.clone()),
-            OutputSeal::Revealed { .. } => None,
-        })
-        .collect()
-}
-
 /// The two legs an `OS_ASSET` output assignment can belong to, in asset units.
 #[cfg(feature = "rgb-validation")]
-struct AssetLegs {
+#[derive(Debug)]
+pub struct AssetLegs {
     /// Paid to confidential (blinded) seals - the recipient.
-    recipient: u64,
+    pub recipient: u64,
     /// Returned to revealed seals on Bitcoin outputs this enclave provably
     /// controls - bridge change.
-    change: u64,
+    pub change: u64,
+    /// The `utxob:...` seals behind `recipient`, in consignment order. Carried
+    /// out of this one walk so the amount bind and
+    /// [`crate::networks::rgb::invoice`]'s identity bind cannot classify a leg
+    /// differently.
+    pub recipient_seals: Vec<String>,
 }
 
 /// Split the `OS_ASSET` outputs of every transition the signed tx commits into
@@ -404,15 +386,17 @@ fn split_asset_legs(
     let mut legs = AssetLegs {
         recipient: 0,
         change: 0,
+        recipient_seals: Vec::new(),
     };
     for (i, out) in asset_outputs.iter().enumerate() {
         match &out.seal {
-            OutputSeal::Confidential { .. } => {
+            OutputSeal::Confidential { secret_seal } => {
                 legs.recipient = legs.recipient.checked_add(out.amount).ok_or_else(|| {
                     EnclaveError::CrossCheck(
                         "send-RGB recipient leg total overflows u64 asset units".into(),
                     )
                 })?;
+                legs.recipient_seals.push(secret_seal.clone());
             }
             OutputSeal::Revealed { txid, vout } => {
                 // `None` means the witness tx of this bundle, which the
@@ -1086,10 +1070,10 @@ mod tests {
         fn passes_when_change_lands_on_an_existing_bridge_utxo() {
             let psbt = psbt_with_two_inputs();
             let validated = validated_with(&psbt, vec![confidential(900), revealed_off_tx(4_100)]);
-            let recipient =
+            let legs =
                 validate_psbt_anchors_transition(&psbt, &validated, 900, 0, &owns_off_tx_outpoint)
                     .expect("off-tx change on a bridge-owned UTXO binds");
-            assert_eq!(recipient, 900);
+            assert_eq!(legs.recipient, 900);
         }
 
         /// Same shape, outpoint we cannot prove. Accepting it unconditionally
@@ -1464,19 +1448,20 @@ mod tests {
             );
         }
 
-        // --- confidential_recipient_seals ---
+        // --- AssetLegs::recipient_seals ---
         //
-        // What the invoice bind compares against, so each filter is tested:
-        // a leg wrongly included or dropped makes the bind check the wrong thing.
+        // What the invoice bind compares against. The same walk that sums the
+        // recipient amount collects these, so each classification rule is
+        // asserted here too: a leg wrongly included or dropped would make the
+        // bind check the wrong thing.
 
         #[test]
-        fn collects_the_blinded_seal_of_a_recipient_leg() {
+        fn carries_the_blinded_seal_of_a_recipient_leg() {
             let psbt = psbt_with_two_inputs();
             let validated = validated_with(&psbt, vec![confidential_to(1_000, "utxob:recipient")]);
-            assert_eq!(
-                confidential_recipient_seals(&validated, psbt.unsigned_tx.compute_txid()),
-                vec!["utxob:recipient".to_string()]
-            );
+            let legs = validate_psbt_anchors_transition(&psbt, &validated, 1_000, 0, &owns_vout_1)
+                .expect("single recipient leg binds");
+            assert_eq!(legs.recipient_seals, vec!["utxob:recipient".to_string()]);
         }
 
         /// Change is revealed. Including it would compare the invoice against
@@ -1492,10 +1477,11 @@ mod tests {
                     revealed_off_tx(200),
                 ],
             );
-            assert_eq!(
-                confidential_recipient_seals(&validated, psbt.unsigned_tx.compute_txid()),
-                vec!["utxob:recipient".to_string()]
-            );
+            let owns_both =
+                |p: &Psbt, o: OutPoint| Ok(owns_vout_1(p, o)? || owns_off_tx_outpoint(p, o)?);
+            let legs = validate_psbt_anchors_transition(&psbt, &validated, 600, 0, &owns_both)
+                .expect("both change legs are bridge-owned");
+            assert_eq!(legs.recipient_seals, vec!["utxob:recipient".to_string()]);
         }
 
         /// Only `OS_ASSET` legs are recipient legs.
@@ -1508,15 +1494,15 @@ mod tests {
                 &psbt,
                 vec![inflation, confidential_to(1_000, "utxob:recipient")],
             );
-            assert_eq!(
-                confidential_recipient_seals(&validated, psbt.unsigned_tx.compute_txid()),
-                vec!["utxob:recipient".to_string()]
-            );
+            let legs = validate_psbt_anchors_transition(&psbt, &validated, 1_000, 0, &owns_vout_1)
+                .expect("the inflation assignment is not a recipient leg");
+            assert_eq!(legs.recipient_seals, vec!["utxob:recipient".to_string()]);
         }
 
-        /// The split shape the bind refuses: both seals must be surfaced.
+        /// The split shape the invoice bind refuses: both seals must be
+        /// surfaced, in consignment order, for it to see the second one.
         #[test]
-        fn collects_every_confidential_leg_in_order() {
+        fn carries_every_confidential_leg_in_order() {
             let psbt = psbt_with_two_inputs();
             let validated = validated_with(
                 &psbt,
@@ -1525,20 +1511,12 @@ mod tests {
                     confidential_to(400, "utxob:attacker"),
                 ],
             );
+            let legs = validate_psbt_anchors_transition(&psbt, &validated, 1_000, 0, &owns_vout_1)
+                .expect("the amount bind sees only the 1_000 total");
             assert_eq!(
-                confidential_recipient_seals(&validated, psbt.unsigned_tx.compute_txid()),
+                legs.recipient_seals,
                 vec!["utxob:recipient".to_string(), "utxob:attacker".to_string()]
             );
-        }
-
-        /// Another transaction's legs are not this signature's recipients.
-        #[test]
-        fn ignores_transitions_committed_by_another_txid() {
-            let psbt = psbt_with_two_inputs();
-            let validated = validated_with(&psbt, vec![confidential_to(1_000, "utxob:recipient")]);
-            let other =
-                Txid::from_raw_hash(bitcoin::hashes::sha256d::Hash::from_byte_array([0x99; 32]));
-            assert!(confidential_recipient_seals(&validated, other).is_empty());
         }
 
         #[test]

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -447,18 +447,15 @@ fn handle_sign(ctx: &ServerContext, req: SignRequest) -> Result<EnclaveResponse>
 
         // Recipient bind: the checks above prove how much the recipient leg
         // pays, not who it pays. The invoice in the log just verified says
-        // which seal the deposit authorised.
-        #[cfg(feature = "rgb-validation")]
-        {
-            use crate::networks::rgb::invoice;
-            let authorized = invoice::parse_authorized_recipient(&verified.destination_address)?;
-            invoice::assert_recipient_authorized(
-                &destination_proof.rgb_recipient_seals,
-                &authorized,
-            )?;
-        }
-        #[cfg(not(feature = "rgb-validation"))]
-        let _ = verified;
+        // which seal the deposit authorised. Ungated: `evm-rpc` implies
+        // `rgb-validation`, so reaching here means the bind is compiled in.
+        let authorized = crate::networks::rgb::invoice::parse_authorized_recipient(
+            &verified.destination_address,
+        )?;
+        crate::networks::rgb::invoice::assert_recipient_authorized(
+            &destination_proof.rgb_recipient_seals,
+            &authorized,
+        )?;
     }
 
     // Fail-closed when the FundsIn verifier is not compiled in. Without

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -433,7 +433,7 @@ fn handle_sign(ctx: &ServerContext, req: SignRequest) -> Result<EnclaveResponse>
         })?;
         // Binds to the source's BridgeFundsIn.operationId, not
         // destination.operation_idx, which is a different id-space.
-        crate::networks::evm::evm_event::verify_funds_in_event(
+        let verified = crate::networks::evm::evm_event::verify_funds_in_event(
             &**client,
             // FundsIn is emitted by the bridge entry contract, which may differ
             // from the MultisigProxy pinned in EVM_PROXY_CONTRACT_ADDRESS (see config.rs).
@@ -444,6 +444,21 @@ fn handle_sign(ctx: &ServerContext, req: SignRequest) -> Result<EnclaveResponse>
             req.amount,
             source.commission,
         )?;
+
+        // Recipient bind: the checks above prove how much the recipient leg
+        // pays, not who it pays. The invoice in the log just verified says
+        // which seal the deposit authorised.
+        #[cfg(feature = "rgb-validation")]
+        {
+            use crate::networks::rgb::invoice;
+            let authorized = invoice::parse_authorized_recipient(&verified.destination_address)?;
+            invoice::assert_recipient_authorized(
+                &destination_proof.rgb_recipient_seals,
+                &authorized,
+            )?;
+        }
+        #[cfg(not(feature = "rgb-validation"))]
+        let _ = verified;
     }
 
     // Fail-closed when the FundsIn verifier is not compiled in. Without


### PR DESCRIPTION

Closes the ["blinded recipient seal is not tied to an invoice" .](https://github.com/UTEXO-Protocol/project-tasks/issues/1168) 

## Why

The send-RGB path binds the recipient **amount** exactly, but not the **destination**. A confidential recipient leg is accepted on the consignment's own say-so, so a compromised coordinator can pay the right amount to a seal the depositor never named.

## What

`BridgeFundsIn`'s last field is `string destinationAddress`. For an RGB destination the bridge writes the user's invoice there verbatim, and the enclave already fetches and verifies that receipt - it decoded 7 static words and stopped at the string's offset word.

Now it:

1. decodes the tail from the already-verified log;
2. parses it with `rgb-invoicing` and takes the `utxob:` beneficiary;
3. requires the consignment's confidential recipient leg to equal it.

**Exactly one** confidential leg is allowed. The amount bind pins their total, so a second would split an authorised payment.