### PR TITLE
feat(enclave): split RGB send/receive and mint/burn validation behind exclusive flow features

### DIFF
--- a/.github/workflows/build-eif.yml
+++ b/.github/workflows/build-eif.yml
@@ -57,12 +57,20 @@ jobs:
             eif_name: utexo-bridge-enclave.eif
             s3_subpath: ""
             artifact_suffix: ""
-          # RGB-only single-network EIF.
+          # RGB-only single-network EIF, send/receive flow (`rgb-swap`).
           - variant: rgb
             dockerfile: Dockerfile.enclave.rgb
             eif_name: utexo-bridge-enclave-rgb.eif
             s3_subpath: "rgb/"
             artifact_suffix: "-rgb"
+          # RGB-only single-network EIF, mint/burn flow (`rgb-mint-burn`). The
+          # second enclave instance: same stack, the other set of RGB rules,
+          # its own PCR0.
+          - variant: rgb-mint-burn
+            dockerfile: Dockerfile.enclave.mint-burn
+            eif_name: utexo-bridge-enclave-mint-burn.eif
+            s3_subpath: "rgb-mint-burn/"
+            artifact_suffix: "-mint-burn"
           # Concordium-only single-network EIF.
           - variant: ccd
             dockerfile: Dockerfile.enclave.ccd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,26 +85,37 @@ jobs:
       # (build/Dockerfile.enclave). `helios` is shipped but optional at boot,
       # and makes this a heavy build (alloy major, revm, BLS, vendored OpenSSL).
       - name: Build (production combo)
-        run: cargo build -p utexo-bridge-enclave --features vsock,rgb,ccd,evm-rpc,helios
+        run: cargo build -p utexo-bridge-enclave --features vsock,rgb,rgb-swap,ccd,evm-rpc,helios
 
       - name: Clippy (production combo)
-        run: cargo clippy -p utexo-bridge-enclave --features vsock,rgb,ccd,evm-rpc,helios --all-targets -- -D warnings
+        run: cargo clippy -p utexo-bridge-enclave --features vsock,rgb,rgb-swap,ccd,evm-rpc,helios --all-targets -- -D warnings
 
       # SPV path coverage. Cannot use vsock here (Linux runner without
       # vsock support); spv pulls in rgb-validation transitively, which is
       # what the SPV unit + integration tests exercise.
-      - name: Test (--features spv)
-        run: cargo test -p utexo-bridge-enclave --features spv
+      - name: Test (--features spv,rgb-swap)
+        run: cargo test -p utexo-bridge-enclave --features spv,rgb-swap
 
       # RGB-only EIF profile, `ccd` dropped. Mirrors Dockerfile.enclave.rgb;
       # keeps helios (this build still has the bridge-signing path).
       # CCD requests (SignCcd / CcdSource) must be refused here.
       - name: Build (rgb-only)
-        run: cargo build -p utexo-bridge-enclave --no-default-features --features vsock,rgb,evm-rpc,helios
+        run: cargo build -p utexo-bridge-enclave --no-default-features --features vsock,rgb,rgb-swap,evm-rpc,helios
       - name: Clippy (rgb-only)
-        run: cargo clippy -p utexo-bridge-enclave --no-default-features --features vsock,rgb,evm-rpc,helios --all-targets -- -D warnings
+        run: cargo clippy -p utexo-bridge-enclave --no-default-features --features vsock,rgb,rgb-swap,evm-rpc,helios --all-targets -- -D warnings
       - name: Test (rgb-only)
-        run: cargo test -p utexo-bridge-enclave --no-default-features --features rgb,evm-rpc,helios,mock-attestation,allow-seed-import
+        run: cargo test -p utexo-bridge-enclave --no-default-features --features rgb,rgb-swap,evm-rpc,helios,mock-attestation,allow-seed-import
+
+      # Mint/burn RGB EIF profile - the second enclave instance. Same stack as
+      # the rgb-only lane above with the other flow selected, so the mint and
+      # burn rules in networks/rgb/flow/mint_burn.rs are actually compiled and
+      # exercised. Mirrors Dockerfile.enclave.mint-burn.
+      - name: Build (rgb mint/burn)
+        run: cargo build -p utexo-bridge-enclave --no-default-features --features vsock,rgb,rgb-mint-burn,evm-rpc,helios
+      - name: Clippy (rgb mint/burn)
+        run: cargo clippy -p utexo-bridge-enclave --no-default-features --features vsock,rgb,rgb-mint-burn,evm-rpc,helios --all-targets -- -D warnings
+      - name: Test (rgb mint/burn)
+        run: cargo test -p utexo-bridge-enclave --no-default-features --features rgb,rgb-mint-burn,evm-rpc,helios,mock-attestation,allow-seed-import
 
       # CCD-only single-network EIF profile: ccd + shared EVM signing, no RGB
       # stack (no rgb-ops/rgb-consignment/rgb-schemas/spv). Mirrors
@@ -243,3 +254,32 @@ jobs:
             exit 1
           fi
           echo "OK: rgb-validation-without-spv correctly rejected via the compile_error guard"
+
+      # The two RGB flows ship as two enclave instances. Enabling both would put
+      # two sets of value-moving rules in one binary; enabling neither would
+      # leave the build with no rule at all. Both must fail to compile.
+      - name: Assert both RGB flows at once is rejected
+        run: |
+          if cargo build -p utexo-bridge-enclave --no-default-features --features spv,rgb-swap,rgb-mint-burn 2>build.log; then
+            echo "::error::build unexpectedly SUCCEEDED with both rgb-swap and rgb-mint-burn — the compile_error guard is missing or not firing"
+            exit 1
+          fi
+          if ! grep -q "mutually exclusive" build.log; then
+            echo "::error::build failed, but not via the expected compile_error guard (rgb-swap / rgb-mint-burn are mutually exclusive)"
+            cat build.log
+            exit 1
+          fi
+          echo "OK: both-flows build correctly rejected via the compile_error guard"
+
+      - name: Assert rgb-validation with no flow is rejected
+        run: |
+          if cargo build -p utexo-bridge-enclave --no-default-features --features spv 2>build.log; then
+            echo "::error::build unexpectedly SUCCEEDED with rgb-validation but no flow — the compile_error guard is missing or not firing"
+            exit 1
+          fi
+          if ! grep -q "rgb-validation requires a flow" build.log; then
+            echo "::error::build failed, but not via the expected compile_error guard (rgb-validation requires a flow)"
+            cat build.log
+            exit 1
+          fi
+          echo "OK: no-flow build correctly rejected via the compile_error guard"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "rust-analyzer.cargo.features": ["rgb-validation", "allow-seed-import", "spv"]
+  "rust-analyzer.cargo.features": ["rgb-validation", "allow-seed-import", "spv", "rgb-swap"]
 }

--- a/README.md
+++ b/README.md
@@ -123,15 +123,16 @@ need Nitro hardware to *run* the enclave.
 # Build everything
 cargo build
 
-# Build with RGB validation support
-cargo build -p utexo-bridge-enclave --features rgb-validation
+# Build with RGB validation support. `rgb-swap` picks the send/receive RGB
+# flow; every rgb-validation build must name exactly one flow (see below).
+cargo build -p utexo-bridge-enclave --features rgb-validation,rgb-swap
 
 # Build with SPV verification (implies rgb-validation). With --features spv,
 # the enclave refuses to sign EVM transactions unless the request carries
 # valid Bitcoin SPV proofs for every consignment-anchor witness tx.
 # Without the feature, the enclave fails-closed if the request supplies
 # merkle_proofs at all (catches build mismatches against the listener).
-cargo build -p utexo-bridge-enclave --features spv
+cargo build -p utexo-bridge-enclave --features spv,rgb-swap
 
 # Build only the gRPC server (Parent Adapter)
 cargo build --manifest-path parent/Cargo.toml
@@ -140,8 +141,13 @@ cargo build --manifest-path parent/Cargo.toml
 ### Production (Nitro Enclave)
 
 ```bash
-# Build the enclave binary with vsock + RGB validation + SPV
-cargo build --release -p utexo-bridge-enclave --features vsock,rgb-validation,spv
+# Build the enclave binary with vsock + RGB validation + SPV, send/receive flow
+cargo build --release -p utexo-bridge-enclave --features vsock,rgb-validation,spv,rgb-swap
+
+# The mint/burn enclave is the same stack with the other flow. It is a separate
+# instance with its own PCR0, never a runtime switch. `--no-default-features` is
+# required: the default set carries `rgb-swap`.
+cargo build --release -p utexo-bridge-enclave --no-default-features --features vsock,rgb,rgb-mint-burn
 
 # Or build the full Enclave Image Format (EIF). No credentials needed --
 # this is the command a third party runs to reproduce PCR0.
@@ -291,11 +297,14 @@ nitro-cli terminate-enclave --enclave-id <enclave-id>
 # Run all tests
 cargo test
 
-# Run with RGB validation tests
-cargo test -p utexo-bridge-enclave --features rgb-validation
+# Run with RGB validation tests (send/receive flow)
+cargo test -p utexo-bridge-enclave --features rgb-validation,rgb-swap
+
+# Same, for the mint/burn flow
+cargo test -p utexo-bridge-enclave --no-default-features --features rgb,rgb-mint-burn
 
 # Run with SPV tests (implies rgb-validation; covers the full sign-path gate)
-cargo test -p utexo-bridge-enclave --features spv
+cargo test -p utexo-bridge-enclave --features spv,rgb-swap
 
 # Run with seed import tests
 cargo test -p utexo-bridge-enclave --features allow-seed-import
@@ -320,8 +329,20 @@ cargo test --manifest-path parent/Cargo.toml
 | `vsock` | Enable vsock transport (production, Linux only) |
 | `rgb-validation` | In-enclave RGB consignment validation via rgbstd + Esplora |
 | `spv` | Bitcoin SPV verification of consignment witness txids before signing EVM transactions. Implies `rgb-validation` (needed to extract witness txids). When OFF, `handle_sign_evm` additionally **rejects** any request that carries a non-empty `merkle_proofs` field — fail-closed against build mismatches between listener and enclave. |
+| `rgb-swap` | **RGB flow selection** — send/receive (pools): the bridge holds an allocation and moves it with IFA `Transfer` in both directions. In the default feature set. |
+| `rgb-mint-burn` | **RGB flow selection** — the bridge owns the contract's inflation rights: deposits mint with IFA `Inflation`, withdrawals destroy with IFA `Burn`. Needs `--no-default-features`. |
 | `allow-seed-import` | Allow raw 64-byte seed or BIP-39 mnemonic import (testing only, never enable in production) |
 | `dev-mode` | Skip cross-check validation on signing requests (development only) |
+
+**Exactly one RGB flow.** An `rgb-validation` build must enable `rgb-swap` or
+`rgb-mint-burn`, never both and never neither — a `compile_error!` pair in
+`enclave/src/lib.rs` enforces it, and CI asserts both guards fire. The two flows
+differ only in which RGB transition types they accept and how the amounts bind,
+but those are the checks that authorize value to move, so they are split per
+file (`enclave/src/networks/rgb/flow/`) and per image rather than branched at
+runtime: a send/receive enclave carries no mint rule to reach. Everything else
+about consignment validation — parsing, SPV anchoring, the PSBT txid bind,
+sighash guard, leg split and fee bound — is shared.
 
 ## Protocol
 

--- a/build/Dockerfile.enclave
+++ b/build/Dockerfile.enclave
@@ -75,7 +75,10 @@ ENV CARGO_INCREMENTAL=0 \
 # production policy refuses to boot on the host-relayed RawRpc source. Operator
 # must set HELIOS_EXECUTION_RPC / HELIOS_CONSENSUS_RPC and run the exec+consensus
 # vsock-proxies (default ports 8003 / 8004).
-RUN cargo build --release --locked --features vsock,rgb,ccd,evm-rpc,helios
+# `rgb-swap` picks the send/receive RGB flow (see enclave/src/networks/rgb/flow/).
+# It is in the default feature set, but named here so the shipped flow is
+# explicit in the image that measures into PCR0.
+RUN cargo build --release --locked --features vsock,rgb,rgb-swap,ccd,evm-rpc,helios
 
 # --- Runtime ---
 # Pinned by digest (see header) - this rootfs is what ends up in the EIF, so its

--- a/build/Dockerfile.enclave-dev
+++ b/build/Dockerfile.enclave-dev
@@ -38,7 +38,9 @@ WORKDIR /build/enclave
 # `make` (not installed in this stage) and fails. Keep the list below explicit.
 # `ccd` is listed because Concordium signing sits behind that feature; without it
 # every CCD request answers "not compiled in".
-RUN cargo build --no-default-features --features allow-seed-import,spv,ccd,evm-rpc
+# `rgb-swap` is the RGB flow this dev image carries; `--no-default-features`
+# drops it along with the rest of the default set, so it must be named.
+RUN cargo build --no-default-features --features allow-seed-import,spv,rgb-swap,ccd,evm-rpc
 
 # ===== Runtime Stage =====
 FROM debian:trixie-slim

--- a/build/Dockerfile.enclave.mint-burn
+++ b/build/Dockerfile.enclave.mint-burn
@@ -1,10 +1,16 @@
 # syntax=docker/dockerfile:1.7
-# RGB-only enclave image (vsock + rgb + evm-rpc + helios) - handles the RGB/BTC bridge
-# only; Concordium (SignCcd / CcdSource) is not compiled in and its requests are
-# refused. For the Concordium bridge use Dockerfile.enclave.ccd; for both in one
-# binary use Dockerfile.enclave.
+# Mint/burn RGB enclave image (vsock + rgb + rgb-mint-burn + evm-rpc + helios).
+#
+# Same RGB-only shape as Dockerfile.enclave.rgb - Concordium (SignCcd /
+# CcdSource) is not compiled in and its requests are refused - but it selects
+# the OTHER RGB flow: deposits mint with an IFA `Inflation`, withdrawals destroy
+# with an IFA `Burn`. The send/receive rules are not in this binary, so this
+# enclave cannot sign a pools transfer even if one reached it.
+#
+# This is the second of the two enclave instances. It measures to its own PCR0
+# and runs alongside the swap enclave, never instead of it.
 # Usage:
-#   DOCKER_BUILDKIT=1 docker build -f build/Dockerfile.enclave.rgb -t utexo-bridge-enclave-rgb .
+#   DOCKER_BUILDKIT=1 docker build -f build/Dockerfile.enclave.mint-burn -t utexo-bridge-enclave-mint-burn .
 #
 # NO CREDENTIALS REQUIRED, same as Dockerfile.enclave: `enclave-proto/` is a
 # vendored in-tree slice of federated-signer-proto, and `rgb-consignment` now
@@ -44,8 +50,9 @@ WORKDIR /build/enclave
 #   -C debuginfo=0 / strip=symbols  drop debug info + symbol tables
 ENV CARGO_INCREMENTAL=0 \
     RUSTFLAGS="--remap-path-prefix=/build=/src -C debuginfo=0 -C strip=symbols"
-# `rgb` implies `spv` + `rgb-validation`. `--no-default-features` drops `ccd` so
-# this binary is RGB-only. `evm-rpc` adds in-enclave FundsIn verification,
+# `rgb` implies `spv` + `rgb-validation`. `--no-default-features` drops `ccd`
+# (so this binary is RGB-only) and also drops the default `rgb-swap`, which is
+# what lets the mint/burn flow be selected instead. `evm-rpc` adds in-enclave FundsIn verification,
 # pulling the alloy + tokio subtree; requires a second host vsock-proxy
 # (EVM_RPC_VSOCK_PORT, default 8002).
 #
@@ -55,9 +62,12 @@ ENV CARGO_INCREMENTAL=0 \
 # HELIOS_CONSENSUS_RPC / HELIOS_CHECKPOINT and run the exec+consensus
 # vsock-proxies (default ports 8003 / 8004).
 #
-# `rgb-swap` selects the send/receive RGB flow. Exactly one flow is required
-# under `rgb-validation`; the mint/burn image is Dockerfile.enclave.mint-burn.
-RUN cargo build --release --locked --no-default-features --features vsock,rgb,rgb-swap,evm-rpc,helios
+# `rgb-mint-burn` selects the mint/burn RGB flow: deposits mint with an IFA
+# `Inflation`, withdrawals destroy with an IFA `Burn`. Exactly one flow is
+# required under `rgb-validation`, and this image carries no send/receive rule
+# at all - the swap image is Dockerfile.enclave.rgb. Two flows, two PCR0s, two
+# running enclaves.
+RUN cargo build --release --locked --no-default-features --features vsock,rgb,rgb-mint-burn,evm-rpc,helios
 
 # --- Runtime ---
 # Pinned by DIGEST: this rootfs is what ends up in the EIF, so its digest drives

--- a/build/build-enclave.sh
+++ b/build/build-enclave.sh
@@ -41,7 +41,8 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 OUT_DIR="${OUT_DIR:-$SCRIPT_DIR}"
 IMAGE_TAG="${IMAGE_TAG:-utexo-bridge-enclave:latest}"
 # Which enclave image to build. Defaults to the combined (rgb+ccd) image; set
-# DOCKERFILE=Dockerfile.enclave.rgb or Dockerfile.enclave.ccd for a lean
+# DOCKERFILE=Dockerfile.enclave.rgb (send/receive RGB flow),
+# Dockerfile.enclave.mint-burn (mint/burn RGB flow) or Dockerfile.enclave.ccd for a lean
 # single-network EIF. EIF_NAME names the output .eif (and thus the SHA256SUMS
 # entry); default keeps the historical artifact name.
 DOCKERFILE="${DOCKERFILE:-Dockerfile.enclave}"

--- a/docs/diagrams/03-seq-sign-evm.md
+++ b/docs/diagrams/03-seq-sign-evm.md
@@ -31,7 +31,7 @@ sequenceDiagram
     Esplora-->>Rgb: witness tx data
     Rgb->>Rgb: rgbstd validate(chain_net, trusted_typesystem)
     Rgb->>Rgb: contract_id == declared asset_id<br/>(== pinned RGB_ASSET_ID when configured)
-    Rgb-->>Srv: SourceProof (amount from consignment —<br/>TS_TRANSFER total_output / TS_BURN burned amount —<br/>host rgb_amount is NOT used)
+    Rgb-->>Srv: SourceProof (amount from consignment, per build flow —<br/>rgb-swap ⇒ TS_TRANSFER total_output /<br/>rgb-mint-burn ⇒ TS_BURN burned amount —<br/>host rgb_amount is NOT used)
 
     Note over Srv,Chain: SPV gate (inside validate_source, feature spv)
     Srv->>Chain: lock chain
@@ -66,8 +66,8 @@ sequenceDiagram
     opt calldata proof slot populated
         Srv->>Cx: verify_btc_relay_agreement:<br/>decode (blockHeight, commitmentHash),<br/>enclave header at that height must match<br/>(inert while the listener sends an empty proof)
     end
-    Srv->>Cx: validate_funds_out_transfer:<br/>last transition == TS_TRANSFER AND<br/>consignment total_output ≥ amount read from calldata bytes
-    Note right of Cx: burnId / fundsInIds are preserved as received —<br/>the in-enclave OpId rewrite exists but is dormant<br/>until flows are routed by network id.<br/>Mint/burn unlock is not wired yet.
+    Srv->>Cx: validate_funds_out_amount:<br/>last transition == the build flow's unlock shape AND<br/>consignment-derived amount ≥ amount read from calldata bytes
+    Note right of Cx: burnId / fundsInIds are preserved as received —<br/>the in-enclave OpId rewrite exists but is dormant<br/>until flows are routed by network id.
     Cx-->>Srv: Ok / CrossCheck err
 
     Note over Srv,Sign: 5 — Sign

--- a/docs/diagrams/04-seq-sign-psbt.md
+++ b/docs/diagrams/04-seq-sign-psbt.md
@@ -49,7 +49,7 @@ sequenceDiagram
     Srv->>Anchor: keccak256(consignment) == consignment_hash (integrity)
     Srv->>Anchor: asset pin: declared asset_id == validated contract_id<br/>== pinned RGB_ASSET_ID (unconditional on this path)
     Srv->>Anchor: PSBT unsigned txid == last witness txid —<br/>input prevouts == witness prevouts —<br/>sighash ALL / taproot DEFAULT only
-    Srv->>Anchor: last transition TS_TRANSFER or TS_INFLATION (mint-RGB) —<br/>asset_output_amount (OS_ASSET only)<br/>≥ amount − commission
+    Srv->>Anchor: last transition == the build flow's deposit shape:<br/>rgb-swap ⇒ TS_TRANSFER, asset_output_amount ≥ amount − commission<br/>rgb-mint-burn ⇒ TS_INFLATION, asset_output_amount == amount − commission<br/>(OS_ASSET only; OS_INFLATION allowance excluded)
     Srv->>Anchor: fee sanity: implied fee rate ≤ 3x the<br/>enclave-fetched Esplora estimate, fail-closed<br/>(compile-time floor only on non-mainnet)
     Anchor-->>Srv: Ok / CrossCheck err
 

--- a/docs/diagrams/10-signing-gate.md
+++ b/docs/diagrams/10-signing-gate.md
@@ -14,7 +14,7 @@ flowchart TD
         p1q -->|no| p1r[REFUSE — invalid consignment]:::refuse
         p1q -->|yes| p1c{"contract_id == declared asset_id<br/>(== pinned RGB_ASSET_ID when configured)?"}
         p1c -->|no| p1cr[REFUSE — asset mismatch]:::refuse
-        p1c -->|yes| p1e["source amount from consignment:<br/>TS_TRANSFER total_output /<br/>TS_BURN burned amount<br/>(host rgb_amount NOT used);<br/>other transition ⇒ REFUSE"]
+        p1c -->|yes| p1e["source amount from consignment, per build flow:<br/>rgb-swap ⇒ TS_TRANSFER total_output /<br/>rgb-mint-burn ⇒ TS_BURN burned amount<br/>(host rgb_amount NOT used);<br/>any other transition ⇒ REFUSE"]
     end
     start --> p1w
 
@@ -54,8 +54,8 @@ flowchart TD
         p4b -->|yes| p4bv{"decoded (blockHeight, commitmentHash)<br/>matches enclave header at that height?"}
         p4bv -->|no| p4bvr[REFUSE — BtcRelay disagreement]:::refuse
         p4b -->|"no (inert)"| p4t
-        p4bv -->|yes| p4t{"last transition == TS_TRANSFER AND<br/>consignment total_output ≥<br/>amount read from calldata bytes?"}
-        p4t -->|no| p4tr[REFUSE — transfer bind]:::refuse
+        p4bv -->|yes| p4t{"last transition == the build flow's unlock shape<br/>(TS_TRANSFER / TS_BURN) AND<br/>consignment-derived amount ≥<br/>amount read from calldata bytes?"}
+        p4t -->|no| p4tr[REFUSE — fundsOut amount bind]:::refuse
     end
     p2d -->|yes| p4r
 
@@ -75,8 +75,11 @@ flowchart TD
 - `burnId` / `fundsInIds` inside the calldata are **preserved as received**
 . The in-enclave OpId rewrite (`burnId` derived from the validated
   consignment OpId) is implemented but dormant until flows are
-  routed by network id; mint/burn unlock (`TS_BURN` consignments) cannot
-  complete this gate — only the swap flow (`TS_TRANSFER`) signs.
+  routed by network id.
+- Which unlock shape completes this gate is chosen at build time: an
+  `rgb-swap` enclave signs `TS_TRANSFER` only, an `rgb-mint-burn` enclave
+  `TS_BURN` only. They are separate instances with separate PCR0s; neither
+  binary contains the other's rules.
 - `dev-mode` builds bypass the validation subgraphs entirely; every dev
   feature is a `compile_error!` in release builds, and a release bridge build
   refuses to boot without a valid attested `Production` policy.

--- a/docs/tee-spec.md
+++ b/docs/tee-spec.md
@@ -116,8 +116,9 @@ SecurityPolicy = Production {
 - **Boot gate:** a release `rgb-validation` build that does not resolve to a
   valid `Production` policy MUST refuse to boot (panic). Independently, each
   dev feature is a `compile_error!` in any shipped release binary (non-test
-  build with debug assertions off), and `rgb-validation` without `spv` is a
-  `compile_error!` in every profile.
+  build with debug assertions off); `rgb-validation` without `spv` is a
+  `compile_error!` in every profile, as is `rgb-validation` with both RGB flows
+  (`rgb-swap` + `rgb-mint-burn`) or with neither.
 - **Attestation:** `user_data = sha256(canonical_pubkey_bundle ||
   policy_commitment)`. The commitment encoding is versioned and shared
   (`attestation-verify/src/policy.rs`), so the enclave and every verifier
@@ -197,9 +198,12 @@ chainId, verifyingContract)`. The domain separator is pinned by a regression
 test against the deployed `MultisigProxy`, and a second test reproduces the
 backend's digest -- domain drift breaks the build.
 
-The current rollout signs the **swap flow** (`TS_TRANSFER` consignments) only.
-The mint/burn unlock flow is deliberately not wired yet: the enclave preserves
-the backend-provided `burnId` / `fundsInIds`, and the in-enclave OpId
+Which consignment shape a build signs is chosen at compile time by its RGB
+flow feature (`rgb-swap` or `rgb-mint-burn`, exactly one). A **swap** enclave
+signs `TS_TRANSFER` unlocks; a **mint/burn** enclave signs `TS_BURN` unlocks and
+nothing else. The two are separate instances with separate PCR0s -- neither
+binary contains the other's rules. Independently of the flow, the enclave
+preserves the backend-provided `burnId` / `fundsInIds`, and the in-enclave OpId
 rewrite stays dormant until flows are routed by network id (Sec 9, P6).
 
 [Sign EVM](diagrams/03-seq-sign-evm.md)
@@ -229,8 +233,10 @@ enclave establishes validity and finality itself, fail-closed
 The PSBT itself is bound to the validated consignment: unsigned txid ==
 witness txid, input prevouts == witness prevouts, `SIGHASH_ALL` / taproot
 `DEFAULT` only, and the consignment's asset outputs must cover the credited
-amount. `TS_TRANSFER` and `TS_INFLATION` (mint-RGB) transitions are accepted
-. A fee sanity check rejects a PSBT whose fee rate exceeds 3x the
+amount. Which transition is accepted is the build's RGB flow: `TS_TRANSFER`
+under `rgb-swap` (coverage `>=`, since the surplus is bridge change),
+`TS_INFLATION` under `rgb-mint-burn` (strict `==`, since any surplus is an
+over-mint). A fee sanity check rejects a PSBT whose fee rate exceeds 3x the
 enclave's own Esplora estimate, fail-closed on a missing estimate (a
 compile-time floor applies only on non-mainnet chains).
 
@@ -409,7 +415,7 @@ MUST refuse to sign (fail closed) if any fails.
 | #   | Predicate                                                   | Status                                                                                                                                                            |
 |-----|-------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | P1  | submitted RGB consignment is valid (`rgbstd` full validation) | OK                                                                                                                                                               |
-| P2  | consignment proves the expected transition                  | OK for the live swap flow: last transition MUST be `TS_TRANSFER`. `TS_BURN` is classified and amount-extracted, but mint/burn unlock is not wired yet       |
+| P2  | consignment proves the expected transition                  | OK -- the last transition MUST be the one this build's RGB flow unlocks with: `TS_TRANSFER` under `rgb-swap`, `TS_BURN` (amount from `MS_BURNED_ASSET`) under `rgb-mint-burn`. Any other shape is refused |
 | P3  | unlock amount is covered by the consignment-derived amount  | OK -- the amount comes from the consignment (host `rgb_amount` is ignored); comparison is coverage (`>=`), strict `==` pending per-output binding (**`[OPEN]`**) |
 | P4  | calldata is well-formed                                     | OK -- single pinned selector, 64 KiB cap, canonical ABI decode + re-encode byte-equality                                                            |
 | P5  | payload binds destination chain / contract / **recipient**  | chain + contract pinned; **`[OPEN]`** recipient not bound -- blocked on an EVM-destination commitment in the RGB burn schema (cross-repo)             |
@@ -472,7 +478,7 @@ MUST refuse to sign (fail closed) if any fails.
 | **SI-8**  | SPV depth MUST be verified for **every** anchoring tx in the consignment history, with no header pruning below it. OK                             |
 | **SI-9**  | Signing MUST be possible only in `Active`; other phases MUST reject signing and key-export RPCs (except the donor's sealed export). OK                    |
 | **SI-10** | On any validation failure the path MUST fail closed -- no partial signature, no fallback, no silent downgrade (including Helios -> raw RPC). OK           |
-| **SI-11** | A feature/build mismatch MUST cause refusal, never sign-without-verification (no `evm-rpc` => no bridge PSBTs; `rgb-validation` without `spv` does not compile). OK |
+| **SI-11** | A feature/build mismatch MUST cause refusal, never sign-without-verification (no `evm-rpc` => no bridge PSBTs; `rgb-validation` without `spv`, or without exactly one RGB flow, does not compile). OK |
 | **SI-12** | Cross-network consignments MUST be rejected. OK                                                                                                          |
 | **SI-13** | Bridge PSBT signing MUST independently verify the EVM deposit (receipt success, pinned contract, unique event, on-chain `operationId` + amount + commission binding, depth >= `EVM_MIN_CONFIRMATIONS`); listener flags MUST NOT authorize. OK |
 | **SI-14** | A release bridge build MUST refuse to boot unless it resolves to a valid `Production` security policy. OK                                         |

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -64,7 +64,7 @@ aws-nitro-enclaves-nsm-api = "0.4"
 # Single-network EIFs: `--no-default-features --features vsock,rgb,evm-rpc,helios`
 # (RGB) or `--no-default-features --features vsock,ccd` (Concordium — no
 # bridge-signing path, so no Helios). Both are covered in CI.
-default = ["rgb", "ccd", "helios"]
+default = ["rgb", "rgb-swap", "ccd", "helios"]
 
 # Network-selection umbrellas. Additive: enable one for a lean single-network
 # EIF, or both for the combined build. They gate only the request-handling
@@ -80,6 +80,27 @@ rgb = ["spv"]
 # `ccd` = the Concordium bridge stack. Light: no extra deps (ed25519 is always
 # on to keep key derivation / the attestation bundle uniform across builds).
 ccd = []
+
+# RGB flow selection. EXACTLY ONE is required whenever `rgb-validation` is on;
+# a `compile_error!` pair in lib.rs enforces it. The two flows ship as two
+# separate enclave instances with two PCR0s, so the choice is made at build
+# time and measured into the image - a send/receive enclave contains no mint
+# rule to reach.
+#
+# Both are `default = false` in the additive sense cargo means it, so a
+# mint/burn image MUST be built with `--no-default-features` (the default set
+# carries `rgb-swap`), exactly like the existing single-network EIFs:
+#   `--no-default-features --features vsock,rgb-mint-burn,evm-rpc,helios`
+#
+# The per-flow rules live in `enclave/src/networks/rgb/flow/{swap,mint_burn}.rs`;
+# everything else about consignment validation is shared.
+#
+# `rgb-swap` = pools/send-receive: the bridge holds an allocation and moves it
+# with IFA `Transfer` in both directions.
+rgb-swap = ["rgb"]
+# `rgb-mint-burn` = the bridge owns the contract's inflation rights: deposits
+# mint with IFA `Inflation`, withdrawals destroy with IFA `Burn`.
+rgb-mint-burn = ["rgb"]
 
 vsock = []
 # DANGER: allows importing a raw seed over the wire. Testing only.

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -65,9 +65,13 @@ aws-nitro-enclaves-nsm-api = "0.4"
 # `helios` is default but not mandatory: it has no L2 light client, so an
 # Arbitrum deployment runs on plain `evm-rpc`. It implies `evm-rpc`.
 #
-# Single-network EIFs: `--no-default-features --features vsock,rgb,evm-rpc,helios`
-# (RGB) or `--no-default-features --features vsock,ccd` (Concordium — no
-# bridge-signing path, so no Helios). Both are covered in CI.
+# Single-network EIFs, one flow each (see the RGB flow selection block below):
+#   RGB send/receive: `--no-default-features --features vsock,rgb,rgb-swap,evm-rpc,helios`
+#   RGB mint/burn:    `--no-default-features --features vsock,rgb,rgb-mint-burn,evm-rpc,helios`
+#   Concordium:       `--no-default-features --features vsock,ccd` (no
+#                     bridge-signing path, so no Helios).
+# All three are covered in CI. Naming no RGB flow does not build: the
+# `compile_error!` pair in lib.rs requires exactly one.
 default = ["rgb", "rgb-swap", "ccd", "helios"]
 
 # Network-selection umbrellas. Additive: enable one for a lean single-network

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -55,11 +55,10 @@ compile_error!(
 // both would be a glob-import collision, and enabling neither leaves every
 // `flow::` call unresolved. Both are caught here with a message that says what
 // to do instead of a wall of name-resolution errors.
-#[cfg(all(
-    feature = "rgb-validation",
-    feature = "rgb-swap",
-    feature = "rgb-mint-burn"
-))]
+// No `rgb-validation` term: either flow feature already implies it
+// (`rgb-swap` -> `rgb` -> `spv` -> `rgb-validation`), and both flows on is
+// wrong in any build.
+#[cfg(all(feature = "rgb-swap", feature = "rgb-mint-burn"))]
 compile_error!(
     "rgb-swap and rgb-mint-burn are mutually exclusive: the send/receive and mint/burn flows \
      ship as separate enclave instances. Build one image per flow - the default feature set \

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -49,6 +49,34 @@ compile_error!(
      pulls in rgb-validation)"
 );
 
+// RGB flow selection is mutually exclusive and mandatory. The two flows are two
+// separate enclave instances with two PCR0s; the per-flow rules in
+// `networks/rgb/flow/` deliberately expose the same item names, so enabling
+// both would be a glob-import collision, and enabling neither leaves every
+// `flow::` call unresolved. Both are caught here with a message that says what
+// to do instead of a wall of name-resolution errors.
+#[cfg(all(
+    feature = "rgb-validation",
+    feature = "rgb-swap",
+    feature = "rgb-mint-burn"
+))]
+compile_error!(
+    "rgb-swap and rgb-mint-burn are mutually exclusive: the send/receive and mint/burn flows \
+     ship as separate enclave instances. Build one image per flow - the default feature set \
+     carries `rgb-swap`, so a mint/burn image needs `--no-default-features --features \
+     vsock,rgb-mint-burn,evm-rpc,helios`"
+);
+#[cfg(all(
+    feature = "rgb-validation",
+    not(feature = "rgb-swap"),
+    not(feature = "rgb-mint-burn")
+))]
+compile_error!(
+    "rgb-validation requires a flow: enable exactly one of `rgb-swap` (send/receive) or \
+     `rgb-mint-burn`. Without one the enclave has no rule for which RGB transition types it \
+     may sign, and refusing to build is safer than defaulting to either"
+);
+
 pub mod attestation;
 pub mod cloning;
 pub mod config;

--- a/enclave/src/networks/evm/crosscheck.rs
+++ b/enclave/src/networks/evm/crosscheck.rs
@@ -436,9 +436,13 @@ mod tests {
     }
 
     fn mock_funds_out_calldata_with_proof(amount: u64, proof: Bytes) -> Vec<u8> {
+        mock_funds_out_calldata_to(Address::ZERO, amount, proof)
+    }
+
+    fn mock_funds_out_calldata_to(recipient: Address, amount: u64, proof: Bytes) -> Vec<u8> {
         fundsOutCall {
             params: FundsOutParams {
-                recipient: Address::ZERO,
+                recipient,
                 amount: U256::from(amount),
                 burnId: U256::ZERO,
                 sourceChainId: U256::ZERO,
@@ -449,6 +453,28 @@ mod tests {
             },
         }
         .abi_encode()
+    }
+
+    /// A `ValidatedConsignment` carrying nothing but `transition` as its last.
+    /// The `fundsOut` cross-checks read `last_transition` only; the per-witness
+    /// grouping is the send-RGB PSBT bind's input.
+    #[cfg(feature = "rgb-validation")]
+    fn validated_with_last(
+        transition: crate::networks::rgb::validation::TransitionSummary,
+    ) -> crate::networks::rgb::validation::ValidatedConsignment {
+        crate::networks::rgb::validation::ValidatedConsignment {
+            contract_id: "rgb:test".into(),
+            chain_net: "bc".into(),
+            witness_txids: vec![],
+            all_op_ids: vec![transition.op_id.clone()],
+            mint_op_ids: vec![],
+            last_transition: Some(transition),
+            last_witness_txid: None,
+            last_transfer_witness_prevouts: None,
+            last_transfer_op_id: None,
+            non_mined_witness_txids: vec![],
+            transitions_by_witness: vec![],
+        }
     }
 
     /// The tuple encoding must round-trip through the decoder the cross-checks
@@ -506,41 +532,9 @@ mod tests {
     #[cfg(feature = "rgb-mint-burn")]
     mod burn {
         use super::*;
-        use crate::networks::rgb::validation::{ifa, TransitionSummary, ValidatedConsignment};
+        use crate::networks::rgb::validation::{ifa, TransitionSummary};
 
         const RECIPIENT: [u8; 20] = [0x42; 20];
-
-        fn calldata_to(recipient: Address, amount: u64) -> Vec<u8> {
-            fundsOutCall {
-                params: FundsOutParams {
-                    recipient,
-                    amount: U256::from(amount),
-                    burnId: U256::ZERO,
-                    sourceChainId: U256::ZERO,
-                    destinationChainId: U256::ZERO,
-                    sourceAddress: String::new(),
-                    proof: Bytes::new(),
-                    settlementData: Bytes::new(),
-                },
-            }
-            .abi_encode()
-        }
-
-        fn validated_with_last(transition: TransitionSummary) -> ValidatedConsignment {
-            ValidatedConsignment {
-                contract_id: "rgb:test".into(),
-                chain_net: "bc".into(),
-                witness_txids: vec![],
-                all_op_ids: vec![transition.op_id.clone()],
-                mint_op_ids: vec![],
-                last_transition: Some(transition),
-                last_witness_txid: None,
-                last_transfer_witness_prevouts: None,
-                last_transfer_op_id: None,
-                non_mined_witness_txids: vec![],
-                transitions_by_witness: vec![],
-            }
-        }
 
         fn burn_transition(burned: Option<u64>, recipient: Option<Vec<u8>>) -> TransitionSummary {
             TransitionSummary {
@@ -565,7 +559,7 @@ mod tests {
 
         #[test]
         fn passes_when_the_burn_names_the_calldata_recipient() {
-            let cd = calldata_to(Address::from(RECIPIENT), 1000);
+            let cd = mock_funds_out_calldata_to(Address::from(RECIPIENT), 1000, Bytes::new());
             let validated =
                 validated_with_last(burn_transition(Some(1000), Some(padded(RECIPIENT))));
             assert!(validate_funds_out_burn_recipient(&params_of(&cd), &validated).is_ok());
@@ -573,7 +567,7 @@ mod tests {
 
         #[test]
         fn rejects_an_ifa_burn_that_names_no_recipient() {
-            let cd = calldata_to(Address::from(RECIPIENT), 1000);
+            let cd = mock_funds_out_calldata_to(Address::from(RECIPIENT), 1000, Bytes::new());
             let validated = validated_with_last(burn_transition(Some(1000), None));
             assert!(validate_funds_out_burn_recipient(&params_of(&cd), &validated).is_err());
         }
@@ -582,7 +576,7 @@ mod tests {
         /// burner did not commit to.
         #[test]
         fn rejects_a_recipient_the_burn_did_not_commit_to() {
-            let cd = calldata_to(Address::from([0x99; 20]), 1000);
+            let cd = mock_funds_out_calldata_to(Address::from([0x99; 20]), 1000, Bytes::new());
             let validated =
                 validated_with_last(burn_transition(Some(1000), Some(padded(RECIPIENT))));
             assert!(validate_funds_out_burn_recipient(&params_of(&cd), &validated).is_err());
@@ -593,7 +587,7 @@ mod tests {
         /// target nobody signed.
         #[test]
         fn rejects_a_recipient_with_a_dirty_high_half() {
-            let cd = calldata_to(Address::from(RECIPIENT), 1000);
+            let cd = mock_funds_out_calldata_to(Address::from(RECIPIENT), 1000, Bytes::new());
             let mut dirty = padded(RECIPIENT);
             dirty[0] = 1;
             let validated = validated_with_last(burn_transition(Some(1000), Some(dirty)));
@@ -603,25 +597,7 @@ mod tests {
 
     mod transfer {
         use super::*;
-        use crate::networks::rgb::validation::{ifa, TransitionSummary, ValidatedConsignment};
-
-        fn validated_with_last(transition: TransitionSummary) -> ValidatedConsignment {
-            ValidatedConsignment {
-                contract_id: "rgb:test".into(),
-                chain_net: "bc".into(),
-                witness_txids: vec![],
-                all_op_ids: vec![transition.op_id.clone()],
-                mint_op_ids: vec![],
-                last_transition: Some(transition),
-                last_witness_txid: None,
-                last_transfer_witness_prevouts: None,
-                last_transfer_op_id: None,
-                non_mined_witness_txids: vec![],
-                // The fundsOut cross-check reads `last_transition` only; the
-                // per-witness grouping is the send-RGB PSBT bind's input.
-                transitions_by_witness: vec![],
-            }
-        }
+        use crate::networks::rgb::validation::{ifa, TransitionSummary};
 
         /// The last transition this build's RGB flow accepts on a `fundsOut`,
         /// carrying `amount` where that flow reads it: a Transfer's output

--- a/enclave/src/networks/evm/crosscheck.rs
+++ b/enclave/src/networks/evm/crosscheck.rs
@@ -38,45 +38,44 @@ pub fn assert_witnesses_confirmed(validated: &ValidatedConsignment) -> Result<()
     Ok(())
 }
 
-/// Pools-side amount cross-check for the `fundsOut` transfer flow. Binds the
-/// release `amount` to the consignment's actual asset value:
+/// Amount cross-check for the `fundsOut` direction. Binds the release `amount`
+/// to the consignment's actual asset value:
 ///
-///   1. The consignment's most recent transition must be an IFA `Transfer`
-///      (`transition_type == ifa::TS_TRANSFER`).
-///   2. The transition's `total_output_amount` must cover the EVM-side release
-///      `amount`.
+///   1. The consignment's most recent transition must be the type this build's
+///      RGB flow accepts on a withdrawal - an IFA `Transfer` under `rgb-swap`,
+///      an IFA `Burn` under `rgb-mint-burn`.
+///   2. The amount that transition proves left the source must cover the
+///      EVM-side release `amount`.
+///
+/// Both legs come from [`crate::networks::rgb::flow::funds_out_source_amount`],
+/// the same function the route proof is built from, so the two cannot disagree
+/// about which transition authorized the release.
 ///
 /// Takes the decoded intent, which also replaces the old selector
 /// guard: `FundsOutParams` only exists after a successful `fundsOut` decode.
-pub fn validate_funds_out_transfer(
+pub fn validate_funds_out_amount(
     params: &FundsOutParams,
     validated: &ValidatedConsignment,
 ) -> Result<()> {
-    use crate::networks::rgb::validation::ifa;
+    use crate::networks::rgb::flow;
 
     let last = validated.last_transition.as_ref().ok_or_else(|| {
         EnclaveError::CrossCheck(
-            "pools fundsOut requires a consignment with at least one transition".into(),
+            "fundsOut requires a consignment with at least one transition".into(),
         )
     })?;
-    if last.transition_type != ifa::TS_TRANSFER {
-        return Err(EnclaveError::CrossCheck(format!(
-            "pools fundsOut requires a Transfer transition (last transition_type = {}, want {})",
-            last.transition_type,
-            ifa::TS_TRANSFER
-        )));
-    }
-
     // The consignment, not the listener-supplied `calldata_amount`, is the
     // authority on how much RGB moved.
+    let source_amount = flow::funds_out_source_amount(last)?;
+
     let calldata_amount: u64 = params
         .amount
         .try_into()
         .map_err(|_| EnclaveError::CrossCheck("fundsOut amount exceeds u64 range".into()))?;
-    if last.total_output_amount < calldata_amount {
+    if source_amount < calldata_amount {
         return Err(EnclaveError::CrossCheck(format!(
-            "transfer amount mismatch: consignment total_output_amount ({}) < calldata amount ({})",
-            last.total_output_amount, calldata_amount
+            "fundsOut amount mismatch: consignment proves {source_amount} asset units left the \
+             source, below the calldata amount ({calldata_amount})"
         )));
     }
     Ok(())
@@ -445,7 +444,7 @@ mod tests {
         assert!(decode_funds_out_params(&legacy_flat_calldata(recipient)).is_err());
     }
 
-    // Pools fundsOut tests - `validate_funds_out_transfer` (+ the witness
+    // fundsOut amount tests - `validate_funds_out_amount` (+ the witness
     // recency guard `assert_witnesses_confirmed`).
 
     mod transfer {
@@ -470,28 +469,47 @@ mod tests {
             }
         }
 
-        fn transfer_transition(total_output_amount: u64) -> TransitionSummary {
+        /// The last transition this build's RGB flow accepts on a `fundsOut`,
+        /// carrying `amount` where that flow reads it: a Transfer's output
+        /// assignments under `rgb-swap`, a Burn's `MS_BURNED_ASSET` metadata
+        /// under `rgb-mint-burn`. Keeps the shared cases below flow-agnostic.
+        #[cfg(feature = "rgb-swap")]
+        fn source_transition(amount: u64) -> TransitionSummary {
             TransitionSummary {
                 op_id: "transfer-op".into(),
                 transition_type: ifa::TS_TRANSFER,
-                total_output_amount,
-                asset_output_amount: total_output_amount,
+                total_output_amount: amount,
+                asset_output_amount: amount,
                 outputs: Vec::new(),
                 burned_asset_amount: None,
             }
         }
 
+        #[cfg(feature = "rgb-mint-burn")]
+        fn source_transition(amount: u64) -> TransitionSummary {
+            TransitionSummary {
+                op_id: "burn-op".into(),
+                // A burn destroys units; it has no output assignments carrying
+                // them, so the amount lives in the metadata field only.
+                transition_type: ifa::TS_BURN,
+                total_output_amount: 0,
+                asset_output_amount: 0,
+                outputs: Vec::new(),
+                burned_asset_amount: Some(amount),
+            }
+        }
+
         #[test]
-        fn passes_when_total_output_covers_calldata_amount() {
+        fn passes_when_source_amount_covers_calldata_amount() {
             let cd = mock_funds_out_calldata(1000);
-            let validated = validated_with_last(transfer_transition(1000));
-            assert!(validate_funds_out_transfer(&params_of(&cd), &validated).is_ok());
+            let validated = validated_with_last(source_transition(1000));
+            assert!(validate_funds_out_amount(&params_of(&cd), &validated).is_ok());
         }
 
         #[test]
         fn witnesses_confirmed_passes_when_all_mined() {
             // No non-mined witnesses surfaced -> the recency guard is a no-op.
-            let validated = validated_with_last(transfer_transition(1000));
+            let validated = validated_with_last(source_transition(1000));
             assert!(super::super::assert_witnesses_confirmed(&validated).is_ok());
         }
 
@@ -499,7 +517,7 @@ mod tests {
         fn witnesses_confirmed_rejects_non_mined() {
             // A tentative/ignored witness in the RGB->EVM direction is an
             // anomaly: the unlock settles an already-confirmed transfer.
-            let mut validated = validated_with_last(transfer_transition(1000));
+            let mut validated = validated_with_last(source_transition(1000));
             validated.non_mined_witness_txids = vec![[0xABu8; 32]];
             let err = super::super::assert_witnesses_confirmed(&validated).unwrap_err();
             assert!(
@@ -509,40 +527,41 @@ mod tests {
         }
 
         #[test]
-        fn passes_when_total_output_exceeds_calldata_amount() {
+        fn passes_when_source_amount_exceeds_calldata_amount() {
             let cd = mock_funds_out_calldata(1000);
-            let validated = validated_with_last(transfer_transition(2000));
-            assert!(validate_funds_out_transfer(&params_of(&cd), &validated).is_ok());
+            let validated = validated_with_last(source_transition(2000));
+            assert!(validate_funds_out_amount(&params_of(&cd), &validated).is_ok());
         }
 
         /// P0 regression: even with a valid consignment that deserializes
-        /// and validates, the EVM-side release cannot exceed the RGB-side
-        /// transfer total. A consignment for 1 unit must not authorise a
-        /// withdrawal for 10^9.
+        /// and validates, the EVM-side release cannot exceed what the RGB side
+        /// proves left the source. A consignment for 1 unit must not authorise
+        /// a withdrawal for 10^9.
         #[test]
-        fn rejects_when_total_output_less_than_calldata_amount() {
+        fn rejects_when_source_amount_less_than_calldata_amount() {
             let cd = mock_funds_out_calldata(1_000_000_000);
-            let validated = validated_with_last(transfer_transition(1));
-            let err = validate_funds_out_transfer(&params_of(&cd), &validated).unwrap_err();
+            let validated = validated_with_last(source_transition(1));
+            let err = validate_funds_out_amount(&params_of(&cd), &validated).unwrap_err();
             assert!(
-                err.to_string().contains("transfer amount mismatch"),
-                "expected transfer amount mismatch, got: {err}"
+                err.to_string().contains("fundsOut amount mismatch"),
+                "expected fundsOut amount mismatch, got: {err}"
             );
         }
 
-        /// A burn consignment arriving on the (single) `fundsOut`
-        /// selector must be rejected by the transfer check - this is how
-        /// mint/burn stays off until it's wired by contract address.
+        /// A consignment whose last transition is not the one this build's
+        /// flow withdraws with must be refused. `TS_INFLATION` is a deposit
+        /// shape in both flows, so it is wrong for either build - which is
+        /// also how a mint-shaped consignment stays out of a swap enclave.
         #[test]
-        fn rejects_when_last_transition_is_not_transfer() {
+        fn rejects_when_last_transition_is_not_the_flow_shape() {
             let cd = mock_funds_out_calldata(500);
-            let mut t = transfer_transition(500);
-            t.transition_type = ifa::TS_BURN;
+            let mut t = source_transition(500);
+            t.transition_type = ifa::TS_INFLATION;
             let validated = validated_with_last(t);
-            let err = validate_funds_out_transfer(&params_of(&cd), &validated).unwrap_err();
+            let err = validate_funds_out_amount(&params_of(&cd), &validated).unwrap_err();
             assert!(
-                err.to_string().contains("requires a Transfer transition"),
-                "expected Transfer-required rejection, got: {err}"
+                err.to_string().contains("this enclave is built for the"),
+                "expected flow-shape rejection, got: {err}"
             );
         }
 
@@ -562,7 +581,7 @@ mod tests {
                 non_mined_witness_txids: vec![],
                 transitions_by_witness: vec![],
             };
-            let err = validate_funds_out_transfer(&params_of(&cd), &validated).unwrap_err();
+            let err = validate_funds_out_amount(&params_of(&cd), &validated).unwrap_err();
             assert!(
                 err.to_string().contains("at least one transition"),
                 "expected no-transition rejection, got: {err}"

--- a/enclave/src/networks/evm/evm_event.rs
+++ b/enclave/src/networks/evm/evm_event.rs
@@ -141,6 +141,14 @@ fn event_topic0(sig: &str) -> [u8; 32] {
     Keccak256::digest(sig.as_bytes()).into()
 }
 
+/// `topic0` of the two events this module selects logs by. Hashed once: both
+/// are looked up per log, and the BFA path loops over a whole mint ancestry.
+static BRIDGE_FUNDS_IN_TOPIC0: std::sync::LazyLock<[u8; 32]> =
+    std::sync::LazyLock::new(|| event_topic0(BRIDGE_FUNDS_IN_SIG));
+#[cfg(feature = "bfa-mint")]
+static FUNDS_IN_TOPIC0: std::sync::LazyLock<[u8; 32]> =
+    std::sync::LazyLock::new(|| event_topic0(FUNDS_IN_SIG));
+
 /// What a verified `BridgeFundsIn` deposit authorises. Only the fields later
 /// stages bind against; the rest is checked in [`verify_funds_in_event`].
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -189,7 +197,7 @@ pub fn verify_funds_in_event(
     let log = select_unique_log(
         &receipt,
         bridge_contract,
-        &event_topic0(BRIDGE_FUNDS_IN_SIG),
+        &BRIDGE_FUNDS_IN_TOPIC0,
         "BridgeFundsIn",
         evm_tx_hash,
     )?;
@@ -421,7 +429,7 @@ fn check_confirmation_depth(
 /// first data word and the amount the second.
 #[cfg(feature = "bfa-mint")]
 fn decode_funds_in(log: &LogEntry, expected_rgb_opid: &[u8; 32]) -> Result<u64> {
-    if log.topics.first() != Some(&event_topic0(FUNDS_IN_SIG)) {
+    if log.topics.first() != Some(&*FUNDS_IN_TOPIC0) {
         return Err(EnclaveError::CrossCheck(
             "log is not a FundsIn event".into(),
         ));
@@ -471,7 +479,7 @@ pub fn verify_rgb_funds_in(
     let log = select_unique_log(
         &receipt,
         funds_in_contract,
-        &event_topic0(FUNDS_IN_SIG),
+        &FUNDS_IN_TOPIC0,
         "FundsIn",
         evm_tx_hash,
     )?;

--- a/enclave/src/networks/evm/validation.rs
+++ b/enclave/src/networks/evm/validation.rs
@@ -421,7 +421,7 @@ mod tests {
             // EVM destinations never reach the send-RGB PSBT bind.
             #[cfg(feature = "rgb-validation")]
             self_owned_psbt_outputs: None,
-            #[cfg(feature = "bfa-mint")]
+            #[cfg(feature = "rgb-validation")]
             bridge_events: &[],
         };
         f(&ctx)

--- a/enclave/src/networks/mod.rs
+++ b/enclave/src/networks/mod.rs
@@ -45,8 +45,9 @@ pub struct ValidationContext<'a> {
         Option<crate::networks::rgb::psbt_validation::SelfOwnedOutpoint<'a>>,
     /// EVM lock events the enclave verified itself, handed to RGB consensus so
     /// the ether extension can re-check a BFA mint's amount. Empty on every
-    /// other path; a BFA consignment with an empty set is refused.
-    #[cfg(feature = "bfa-mint")]
+    /// other path (including every build without `bfa-mint`); a BFA consignment
+    /// with an empty set is refused.
+    #[cfg(feature = "rgb-validation")]
     pub bridge_events: &'a [rgbstd::vm::ether_extension::Event],
 }
 

--- a/enclave/src/networks/rgb/flow/mint_burn.rs
+++ b/enclave/src/networks/rgb/flow/mint_burn.rs
@@ -1,0 +1,103 @@
+//! Mint/burn flow rules. The bridge owns the contract's inflation rights: a
+//! deposit mints with an IFA `Inflation`, a withdrawal destroys units with an
+//! IFA `Burn`.
+//!
+//! See [`super`] for why this lives in its own file. Item names here mirror
+//! [`super::swap`] exactly.
+
+use crate::error::{EnclaveError, Result};
+use crate::networks::rgb::validation::{ifa, TransitionSummary};
+
+/// Human-readable flow name, used in rejection messages so an operator can
+/// tell "wrong shape" from "wrong enclave".
+pub const FLOW_NAME: &str = "mint/burn";
+
+/// Is this the transition type a deposit PSBT may finalize?
+///
+/// Also decides whether the consignment parser bothers extracting the last
+/// bundle's witness prevouts ([`crate::networks::rgb::validation`]).
+pub fn is_signing_transition(transition_type: u16) -> bool {
+    transition_type == ifa::TS_INFLATION
+}
+
+/// Gate on the consignment's last transition before the PSBT is bound to it.
+pub fn assert_signing_transition(last: &TransitionSummary) -> Result<()> {
+    if !is_signing_transition(last.transition_type) {
+        return Err(EnclaveError::CrossCheck(format!(
+            "mint-RGB PSBT requires an Inflation transition (last transition_type = {}, want {}) \
+             - this enclave is built for the {FLOW_NAME} flow",
+            last.transition_type,
+            ifa::TS_INFLATION
+        )));
+    }
+    Ok(())
+}
+
+/// Gate on every transition the signed tx commits, not just the last one: a
+/// Bitcoin tx commits a bundle, and a sibling of the wrong type would move
+/// value under a rule that was never applied to it. In particular a `Transfer`
+/// smuggled into a mint bundle would get the mint's equality rule, which does
+/// not account for change.
+pub fn assert_committed_group(committed: &[&TransitionSummary]) -> Result<()> {
+    for t in committed {
+        if !is_signing_transition(t.transition_type) {
+            return Err(EnclaveError::CrossCheck(format!(
+                "mint-RGB PSBT commits transition {} of type {} - the {FLOW_NAME} flow requires \
+                 Inflation ({})",
+                t.op_id,
+                t.transition_type,
+                ifa::TS_INFLATION
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Aggregate amount bind over the committed group.
+///
+/// Exact equality, unlike the send/receive floor: a mint has no pre-existing
+/// allocation to return as change, so every minted unit must be accounted for
+/// by the credit. Any surplus is an over-mint - free supply the bridge never
+/// received a deposit for.
+///
+/// `committed_asset_output` counts `OS_ASSET` only; the `OS_INFLATION`
+/// allowance riding along is remaining mint capacity, not minted value.
+pub fn assert_group_amount(
+    committed_asset_output: u64,
+    net_credited: u64,
+    source_amount: u64,
+    source_commission: u64,
+) -> Result<()> {
+    if committed_asset_output != net_credited {
+        return Err(EnclaveError::CrossCheck(format!(
+            "mint-RGB amount mismatch: consignment asset_output_amount \
+             ({committed_asset_output}) != net credited (source_amount {source_amount} - \
+             source_commission {source_commission} = {net_credited})"
+        )));
+    }
+    Ok(())
+}
+
+/// The asset amount a withdrawal (`fundsOut`) consignment proves was
+/// destroyed, and the shape gate that makes it meaningful.
+///
+/// A `Burn` has no output assignments carrying the destroyed value, so the
+/// figure comes from the IFA `MS_BURNED_ASSET` metadata that
+/// [`crate::networks::rgb::validation`] reads off the rgbstd `Transfer`.
+/// Missing metadata on a burn implies a schema mismatch - fail closed rather
+/// than release against an unknown amount.
+pub fn funds_out_source_amount(last: &TransitionSummary) -> Result<u64> {
+    if last.transition_type != ifa::TS_BURN {
+        return Err(EnclaveError::CrossCheck(format!(
+            "fundsOut requires a Burn transition (last transition_type = {}, want {}) - \
+             this enclave is built for the {FLOW_NAME} flow",
+            last.transition_type,
+            ifa::TS_BURN
+        )));
+    }
+    last.burned_asset_amount.ok_or_else(|| {
+        EnclaveError::CrossCheck(
+            "burn transition is missing MS_BURNED_ASSET metadata - cannot validate amount".into(),
+        )
+    })
+}

--- a/enclave/src/networks/rgb/flow/mint_burn.rs
+++ b/enclave/src/networks/rgb/flow/mint_burn.rs
@@ -2,8 +2,8 @@
 //! deposit mints with an IFA `Inflation`, a withdrawal destroys units with an
 //! IFA `Burn`.
 //!
-//! See [`super`] for why this lives in its own file. Item names here mirror
-//! [`super::swap`] exactly.
+//! See [`super`] for why this lives in its own file, and for the mirrored-name
+//! contract these items keep.
 
 use crate::error::{EnclaveError, Result};
 use crate::networks::rgb::validation::{ifa, TransitionSummary};

--- a/enclave/src/networks/rgb/flow/mint_burn.rs
+++ b/enclave/src/networks/rgb/flow/mint_burn.rs
@@ -6,9 +6,7 @@
 //! contract these items keep.
 
 use crate::error::{EnclaveError, Result};
-#[cfg(feature = "bfa-mint")]
-use crate::networks::rgb::validation::bfa;
-use crate::networks::rgb::validation::{ifa, TransitionSummary};
+use crate::networks::rgb::validation::{ifa, is_mint_transition, TransitionSummary};
 
 /// The mint shapes this build signs, spelled out for rejection messages.
 #[cfg(feature = "bfa-mint")]
@@ -25,19 +23,14 @@ pub const FLOW_NAME: &str = "mint/burn";
 /// Also decides whether the consignment parser bothers extracting the last
 /// bundle's witness prevouts ([`crate::networks::rgb::validation`]).
 ///
-/// BFA's `TS_BRIDGE` joins IFA `Inflation` only in a `bfa-mint` build. It is a
-/// mint in every way that matters here - it creates units against an EVM lock -
-/// so it takes the mint rules below, in particular the exact-equality amount
-/// bind that refuses an over-mint. A build without the feature has no code path
-/// that admits it at all.
+/// The signing shape of this flow *is* the mint shape, so this is
+/// [`is_mint_transition`] rather than a second list that could drift from it.
+/// In particular BFA's `TS_BRIDGE`, which joins IFA `Inflation` only in a
+/// `bfa-mint` build, takes the mint rules below - notably the exact-equality
+/// amount bind that refuses an over-mint. A build without the feature has no
+/// code path that admits it at all.
 pub fn is_signing_transition(transition_type: u16) -> bool {
-    #[cfg(feature = "bfa-mint")]
-    {
-        if transition_type == bfa::TS_BRIDGE {
-            return true;
-        }
-    }
-    transition_type == ifa::TS_INFLATION
+    is_mint_transition(transition_type)
 }
 
 /// Gate on the consignment's last transition before the PSBT is bound to it.

--- a/enclave/src/networks/rgb/flow/mint_burn.rs
+++ b/enclave/src/networks/rgb/flow/mint_burn.rs
@@ -64,10 +64,10 @@ pub fn assert_committed_group(committed: &[&TransitionSummary]) -> Result<()> {
 /// allowance riding along is remaining mint capacity, not minted value.
 pub fn assert_group_amount(
     committed_asset_output: u64,
-    net_credited: u64,
     source_amount: u64,
     source_commission: u64,
 ) -> Result<()> {
+    let net_credited = source_amount.saturating_sub(source_commission);
     if committed_asset_output != net_credited {
         return Err(EnclaveError::CrossCheck(format!(
             "mint-RGB amount mismatch: consignment asset_output_amount \

--- a/enclave/src/networks/rgb/flow/mod.rs
+++ b/enclave/src/networks/rgb/flow/mod.rs
@@ -1,0 +1,37 @@
+//! Per-flow RGB validation rules.
+//!
+//! The bridge runs two RGB flows, and each ships as its own enclave instance
+//! with its own PCR0:
+//!
+//!   * **send/receive** (`rgb-swap`) - the bridge holds a pool of the asset.
+//!     A deposit pays the user with an IFA `Transfer`; a withdrawal is a
+//!     `Transfer` back to the bridge.
+//!   * **mint/burn** (`rgb-mint-burn`) - the bridge owns the contract's
+//!     inflation rights. A deposit mints with an IFA `Inflation`; a withdrawal
+//!     destroys units with an IFA `Burn`.
+//!
+//! The two differ only in which transition types they accept and how the
+//! amounts bind, but those are exactly the checks that authorize value to
+//! move. Splitting them per file (rather than branching at runtime) means a
+//! send/receive enclave carries no mint rule at all: an attacker who gets a
+//! mint-shaped consignment past every other check still cannot reach a code
+//! path that would sign it.
+//!
+//! Exactly one of the two features must be enabled - see the `compile_error!`
+//! pair in `lib.rs`. Both files expose the same item names, so every caller
+//! writes `flow::...` and never a `cfg`.
+//!
+//! Everything NOT flow-specific stays shared: consignment parsing
+//! ([`super::validation`]), SPV anchoring, and the PSBT mechanics in
+//! [`super::psbt_validation`] (txid identity bind, prevout canary, sighash
+//! guard, recipient/change leg split, fee-rate bound).
+
+#[cfg(feature = "rgb-mint-burn")]
+mod mint_burn;
+#[cfg(feature = "rgb-swap")]
+mod swap;
+
+#[cfg(feature = "rgb-mint-burn")]
+pub use mint_burn::*;
+#[cfg(feature = "rgb-swap")]
+pub use swap::*;

--- a/enclave/src/networks/rgb/flow/swap.rs
+++ b/enclave/src/networks/rgb/flow/swap.rs
@@ -1,8 +1,8 @@
 //! Send/receive (pools) flow rules. The bridge holds an allocation of the
 //! asset and moves it with IFA `Transfer` transitions in both directions.
 //!
-//! See [`super`] for why this lives in its own file. Item names here mirror
-//! [`super::mint_burn`] exactly.
+//! See [`super`] for why this lives in its own file, and for the mirrored-name
+//! contract these items keep.
 
 use crate::error::{EnclaveError, Result};
 use crate::networks::rgb::validation::{ifa, TransitionSummary};

--- a/enclave/src/networks/rgb/flow/swap.rs
+++ b/enclave/src/networks/rgb/flow/swap.rs
@@ -58,10 +58,10 @@ pub fn assert_committed_group(committed: &[&TransitionSummary]) -> Result<()> {
 /// what pins the recipient leg exactly.
 pub fn assert_group_amount(
     committed_asset_output: u64,
-    net_credited: u64,
     source_amount: u64,
     source_commission: u64,
 ) -> Result<()> {
+    let net_credited = source_amount.saturating_sub(source_commission);
     if committed_asset_output < net_credited {
         return Err(EnclaveError::CrossCheck(format!(
             "send-RGB amount mismatch: consignment asset_output_amount \

--- a/enclave/src/networks/rgb/flow/swap.rs
+++ b/enclave/src/networks/rgb/flow/swap.rs
@@ -1,0 +1,91 @@
+//! Send/receive (pools) flow rules. The bridge holds an allocation of the
+//! asset and moves it with IFA `Transfer` transitions in both directions.
+//!
+//! See [`super`] for why this lives in its own file. Item names here mirror
+//! [`super::mint_burn`] exactly.
+
+use crate::error::{EnclaveError, Result};
+use crate::networks::rgb::validation::{ifa, TransitionSummary};
+
+/// Human-readable flow name, used in rejection messages so an operator can
+/// tell "wrong shape" from "wrong enclave".
+pub const FLOW_NAME: &str = "send/receive";
+
+/// Is this the transition type a deposit PSBT may finalize?
+///
+/// Also decides whether the consignment parser bothers extracting the last
+/// bundle's witness prevouts ([`crate::networks::rgb::validation`]).
+pub fn is_signing_transition(transition_type: u16) -> bool {
+    transition_type == ifa::TS_TRANSFER
+}
+
+/// Gate on the consignment's last transition before the PSBT is bound to it.
+pub fn assert_signing_transition(last: &TransitionSummary) -> Result<()> {
+    if !is_signing_transition(last.transition_type) {
+        return Err(EnclaveError::CrossCheck(format!(
+            "send-RGB PSBT requires a Transfer transition (last transition_type = {}, want {}) - \
+             this enclave is built for the {FLOW_NAME} flow",
+            last.transition_type,
+            ifa::TS_TRANSFER
+        )));
+    }
+    Ok(())
+}
+
+/// Gate on every transition the signed tx commits, not just the last one: a
+/// Bitcoin tx commits a bundle, and a sibling of the wrong type would move
+/// value under a rule that was never applied to it.
+pub fn assert_committed_group(committed: &[&TransitionSummary]) -> Result<()> {
+    for t in committed {
+        if !is_signing_transition(t.transition_type) {
+            return Err(EnclaveError::CrossCheck(format!(
+                "send-RGB PSBT commits transition {} of type {} - the {FLOW_NAME} flow requires \
+                 Transfer ({})",
+                t.op_id,
+                t.transition_type,
+                ifa::TS_TRANSFER
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Aggregate amount bind over the committed group.
+///
+/// A coverage lower bound, not equality: `asset_output_amount` on a Transfer
+/// is recipient + bridge change, and the change is legitimately ours. The
+/// per-output recipient bind in [`crate::networks::rgb::psbt_validation`] is
+/// what pins the recipient leg exactly.
+pub fn assert_group_amount(
+    committed_asset_output: u64,
+    net_credited: u64,
+    source_amount: u64,
+    source_commission: u64,
+) -> Result<()> {
+    if committed_asset_output < net_credited {
+        return Err(EnclaveError::CrossCheck(format!(
+            "send-RGB amount mismatch: consignment asset_output_amount \
+             ({committed_asset_output}) < net credited (source_amount {source_amount} - \
+             source_commission {source_commission} = {net_credited})"
+        )));
+    }
+    Ok(())
+}
+
+/// The asset amount a withdrawal (`fundsOut`) consignment proves moved to the
+/// bridge, and the shape gate that makes it meaningful.
+///
+/// A `Transfer` carries its value in the output assignments, so
+/// `total_output_amount` is the figure. Used both for the route proof and for
+/// the EVM calldata amount cross-check.
+pub fn funds_out_source_amount(last: &TransitionSummary) -> Result<u64> {
+    if last.transition_type != ifa::TS_TRANSFER {
+        return Err(EnclaveError::CrossCheck(format!(
+            "fundsOut requires a Transfer transition (last transition_type = {}, want {}) - \
+             this enclave is built for the {FLOW_NAME} flow",
+            last.transition_type,
+            ifa::TS_TRANSFER
+        )));
+    }
+    Ok(last.total_output_amount)
+}

--- a/enclave/src/networks/rgb/mod.rs
+++ b/enclave/src/networks/rgb/mod.rs
@@ -147,16 +147,9 @@ pub fn validate_destination_anchor(
                 .into(),
         ));
     }
-    // Aggregate size cap (operator-configurable via `MAX_CONSIGNMENT_BYTES`),
-    // before the keccak hash and the rgbstd parse below - the destination
-    // consignment is otherwise bounded only by the generic 4 MB wire frame.
-    if destination.consignment.len() > ctx.bridge_config.max_consignment_bytes {
-        return Err(EnclaveError::CrossCheck(format!(
-            "send-RGB consignment too large: {} bytes (max {})",
-            destination.consignment.len(),
-            ctx.bridge_config.max_consignment_bytes
-        )));
-    }
+    // The destination consignment is otherwise bounded only by the generic
+    // 4 MB wire frame.
+    validation::assert_consignment_size(&destination.consignment, ctx.bridge_config, "send-RGB")?;
     // Integrity, not authorization: the listener
     // controls both `consignment` and `consignment_hash`, so a match only
     // proves the wire copy is intact. Authorization is the rgbstd validation
@@ -185,10 +178,7 @@ pub fn validate_destination_anchor(
     })?;
     // A BFA mint cannot be validated at all without the event `cea` checks it
     // against, so the caller verified the EVM lock before reaching here.
-    #[cfg(feature = "bfa-mint")]
     let validated = validator.validate_consignment(&destination.consignment, ctx.bridge_events)?;
-    #[cfg(not(feature = "bfa-mint"))]
-    let validated = validator.validate_consignment(&destination.consignment, &[])?;
 
     if validated.contract_id != destination.asset_id {
         return Err(EnclaveError::CrossCheck(format!(
@@ -510,7 +500,6 @@ mod tests {
                 rgb_validator: Some(&validator),
                 header_chain: &chain,
                 self_owned_psbt_outputs: Some(&self_owned),
-                #[cfg(feature = "bfa-mint")]
                 bridge_events: &[],
             };
             validate_destination_anchor(destination, 0, 0, &ctx).map(|(amount, _)| amount)

--- a/enclave/src/networks/rgb/mod.rs
+++ b/enclave/src/networks/rgb/mod.rs
@@ -1,5 +1,7 @@
 pub mod btc_crosscheck;
 pub mod btc_ownership;
+#[cfg(feature = "rgb-validation")]
+pub mod flow;
 pub mod psbt_validation;
 pub mod signing;
 pub mod spv;
@@ -72,7 +74,6 @@ fn route_proof_from_validated_consignment(
     validated: &validation::ValidatedConsignment,
 ) -> Result<RouteProof> {
     use crate::error::EnclaveError;
-    use validation::ifa;
 
     let last = validated.last_transition.as_ref().ok_or_else(|| {
         EnclaveError::CrossCheck(
@@ -80,20 +81,10 @@ fn route_proof_from_validated_consignment(
         )
     })?;
 
-    let amount = match last.transition_type {
-        ifa::TS_TRANSFER => last.total_output_amount,
-        ifa::TS_BURN => last.burned_asset_amount.ok_or_else(|| {
-            EnclaveError::CrossCheck(
-                "burn transition is missing MS_BURNED_ASSET metadata - cannot validate amount"
-                    .into(),
-            )
-        })?,
-        other => {
-            return Err(EnclaveError::CrossCheck(format!(
-                "unsupported RGB transition_type for route proof: {other}"
-            )));
-        }
-    };
+    // Which transition proves how much left the source, and how to read its
+    // amount, is the flow's business: a Transfer carries it in the output
+    // assignments, a Burn in `MS_BURNED_ASSET` metadata. See `flow/`.
+    let amount = flow::funds_out_source_amount(last)?;
 
     Ok(RouteProof {
         amount,
@@ -279,6 +270,19 @@ mod tests {
         }
     }
 
+    /// A withdrawal consignment shaped for this build's flow, carrying
+    /// `amount` where that flow reads it.
+    #[cfg(feature = "rgb-swap")]
+    fn funds_out_consignment(amount: u64, op_id: &str) -> ValidatedConsignment {
+        validated_consignment(ifa::TS_TRANSFER, amount, None, op_id)
+    }
+
+    #[cfg(feature = "rgb-mint-burn")]
+    fn funds_out_consignment(amount: u64, op_id: &str) -> ValidatedConsignment {
+        validated_consignment(ifa::TS_BURN, 0, Some(amount), op_id)
+    }
+
+    #[cfg(feature = "rgb-swap")]
     #[test]
     fn route_proof_uses_transfer_output_amount() {
         let op_id = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
@@ -297,6 +301,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "rgb-mint-burn")]
     #[test]
     fn route_proof_uses_burn_metadata_amount() {
         let op_id = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
@@ -312,6 +317,7 @@ mod tests {
         assert_eq!(proof.operation_id.as_deref(), Some(op_id));
     }
 
+    #[cfg(feature = "rgb-mint-burn")]
     #[test]
     fn route_proof_rejects_burn_without_burned_amount() {
         let err = route_proof_from_validated_consignment(&validated_consignment(
@@ -327,15 +333,29 @@ mod tests {
 
     #[test]
     fn route_proof_rejects_non_hex_operation_id() {
-        let err = route_proof_from_validated_consignment(&validated_consignment(
-            ifa::TS_TRANSFER,
+        let err = route_proof_from_validated_consignment(&funds_out_consignment(
             100,
-            None,
             "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
         ))
         .unwrap_err();
 
         assert!(err.to_string().contains("not hex-decodable"));
+    }
+
+    /// The other flow's withdrawal shape must not authorize a release here.
+    #[test]
+    fn route_proof_rejects_the_other_flows_shape() {
+        let op_id = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+        #[cfg(feature = "rgb-swap")]
+        let wrong = validated_consignment(ifa::TS_BURN, 0, Some(700), op_id);
+        #[cfg(feature = "rgb-mint-burn")]
+        let wrong = validated_consignment(ifa::TS_TRANSFER, 700, None, op_id);
+
+        let err = route_proof_from_validated_consignment(&wrong).unwrap_err();
+        assert!(
+            err.to_string().contains("this enclave is built for the"),
+            "expected flow-shape rejection, got: {err}"
+        );
     }
 
     // Asset-identity binding, destination path. The legs are

--- a/enclave/src/networks/rgb/mod.rs
+++ b/enclave/src/networks/rgb/mod.rs
@@ -83,9 +83,8 @@ fn route_proof_from_validated_consignment(
         )
     })?;
 
-    // Which transition proves how much left the source, and how to read its
-    // amount, is the flow's business: a Transfer carries it in the output
-    // assignments, a Burn in `MS_BURNED_ASSET` metadata. See `flow/`.
+    // Which transition proves the withdrawal, and where its amount lives, is
+    // the flow's business - see `flow/`.
     let amount = flow::funds_out_source_amount(last)?;
 
     Ok(RouteProof {

--- a/enclave/src/networks/rgb/psbt_validation.rs
+++ b/enclave/src/networks/rgb/psbt_validation.rs
@@ -216,9 +216,6 @@ pub fn validate_psbt_anchors_transition(
             last.op_id
         )));
     }
-    // Every transition in the group must be the shape this flow's amount rule
-    // was written for. That also rules out a mixed bundle, which has no single
-    // aggregate rule (equality vs floor) and no known flow that produces one.
     flow::assert_committed_group(&committed)?;
 
     // `asset_output_amount`, not `total_output_amount`: `OS_INFLATION` outputs
@@ -233,7 +230,6 @@ pub fn validate_psbt_anchors_transition(
             )
         })?;
 
-    // Equality for a mint, a coverage floor for a transfer - see `flow/`.
     let net_credited = source_amount.saturating_sub(source_commission);
     flow::assert_group_amount(committed_asset_output, source_amount, source_commission)?;
 

--- a/enclave/src/networks/rgb/psbt_validation.rs
+++ b/enclave/src/networks/rgb/psbt_validation.rs
@@ -1,6 +1,8 @@
 use bitcoin::psbt::Psbt;
 
 #[cfg(feature = "rgb-validation")]
+use super::flow;
+#[cfg(feature = "rgb-validation")]
 use super::validation::{ifa, ValidatedConsignment};
 use crate::error::{EnclaveError, Result};
 
@@ -86,9 +88,13 @@ pub fn validate_psbt_bytes(psbt_bytes: &[u8]) -> Result<()> {
 /// [`crate::networks::rgb::validation::RgbValidator::validate_consignment`],
 /// which is what proves the commitment is genuinely anchored.
 ///
+/// The shape and amount rules (legs 1, 5, 6) belong to the build's RGB flow,
+/// [`crate::networks::rgb::flow`]. A `rgb-swap` enclave admits only IFA
+/// `Transfer`, a `rgb-mint-burn` enclave only IFA `Inflation`; everything else
+/// here is shared PSBT mechanics.
+///
 /// Enforces, fail-closed:
-///   1. The consignment's last transition is an IFA `Transfer`
-///      (`ifa::TS_TRANSFER`) or an IFA `Inflation` (`ifa::TS_INFLATION`).
+///   1. The consignment's last transition is the type this flow signs.
 ///   2. Identity bind: `psbt.unsigned_tx.compute_txid()` equals the
 ///      consignment's last witness txid. A segwit txid commits to every
 ///      non-witness field, so equality means signing this PSBT finalizes
@@ -100,13 +106,13 @@ pub fn validate_psbt_bytes(psbt_bytes: &[u8]) -> Result<()> {
 ///      signature into a different tx.
 ///   5. Whole-bundle scope: both amount binds run over every transition the
 ///      signed txid commits, not just the last one. The group must be
-///      non-empty, must contain that last transition, and must be all-Transfer
-///      or all-Inflation.
+///      non-empty, must contain that last transition, and every member must be
+///      the type this flow signs (which also rules out a mixed bundle).
 ///   6. Aggregate amount bind: the group's summed `asset_output_amount`
 ///      (`OS_ASSET` allocations only, excluding `OS_INFLATION` mint capacity)
-///      against `source_amount - source_commission`. Exact equality for an
-///      Inflation (any surplus is an over-mint), a coverage lower bound for a
-///      Transfer (whose total includes bridge change).
+///      against `source_amount - source_commission`, under the active flow's
+///      rule - exact equality for a mint, a coverage lower bound for a
+///      transfer (whose total includes bridge change).
 ///   7. Per-output recipient bind: each `OS_ASSET` output is
 ///      classified by its seal. A confidential (`utxob:`) seal is a recipient
 ///      leg; a revealed (`txid:vout`) seal counts as bridge change only if the
@@ -140,19 +146,11 @@ pub fn validate_psbt_anchors_transition(
             "send-RGB PSBT requires a consignment with at least one transition".into(),
         )
     })?;
-    if !matches!(last.transition_type, ifa::TS_TRANSFER | ifa::TS_INFLATION) {
-        return Err(EnclaveError::CrossCheck(format!(
-            "send-RGB PSBT requires a Transfer or Inflation transition (last transition_type = \
-             {}, want {} or {})",
-            last.transition_type,
-            ifa::TS_TRANSFER,
-            ifa::TS_INFLATION
-        )));
-    }
+    flow::assert_signing_transition(last)?;
 
     // Derive the txid from `unsigned_tx`, never a finalized/extracted tx
     // (a non-segwit input's scriptSig would change the txid post-signing).
-    // The Transfer/Inflation gate above is what makes this last-bundle txid the
+    // The flow's transition gate above is what makes this last-bundle txid the
     // transition's witness.
     let expected = validated.last_witness_txid.ok_or_else(|| {
         EnclaveError::CrossCheck(
@@ -218,19 +216,10 @@ pub fn validate_psbt_anchors_transition(
             last.op_id
         )));
     }
-    // The per-shape amount rules below cover only these two shapes.
-    for t in &committed {
-        if !matches!(t.transition_type, ifa::TS_TRANSFER | ifa::TS_INFLATION) {
-            return Err(EnclaveError::CrossCheck(format!(
-                "send-RGB PSBT commits transition {} of type {} - requires Transfer ({}) or \
-                 Inflation ({})",
-                t.op_id,
-                t.transition_type,
-                ifa::TS_TRANSFER,
-                ifa::TS_INFLATION
-            )));
-        }
-    }
+    // Every transition in the group must be the shape this flow's amount rule
+    // was written for. That also rules out a mixed bundle, which has no single
+    // aggregate rule (equality vs floor) and no known flow that produces one.
+    flow::assert_committed_group(&committed)?;
 
     // `asset_output_amount`, not `total_output_amount`: `OS_INFLATION` outputs
     // are mint capacity, not minted value. Summed across the whole group so a
@@ -244,57 +233,14 @@ pub fn validate_psbt_anchors_transition(
             )
         })?;
 
-    // A mixed mint/transfer group has no single aggregate rule (equality vs
-    // floor), and no known flow produces one. Refuse rather than guess.
-    let mints = committed
-        .iter()
-        .filter(|t| t.transition_type == ifa::TS_INFLATION)
-        .count();
-    let group_type = if mints == committed.len() {
-        ifa::TS_INFLATION
-    } else if mints == 0 {
-        ifa::TS_TRANSFER
-    } else {
-        return Err(EnclaveError::CrossCheck(format!(
-            "send-RGB PSBT commits a mixed bundle ({mints} Inflation of {} transitions) - \
-             refusing to sign a shape with no defined amount bind",
-            committed.len()
-        )));
-    };
-
+    // Equality for a mint, a coverage floor for a transfer - see `flow/`.
     let net_credited = source_amount.saturating_sub(source_commission);
-    match group_type {
-        // Inflation (mint-RGB): no pre-existing allocation to return as
-        // change, so minted units must equal the credit. Surplus = over-mint.
-        ifa::TS_INFLATION => {
-            if committed_asset_output != net_credited {
-                return Err(EnclaveError::CrossCheck(format!(
-                    "mint-RGB amount mismatch: consignment asset_output_amount \
-                     ({committed_asset_output}) != net credited (source_amount {source_amount} - \
-                     source_commission {source_commission} = {net_credited})"
-                )));
-            }
-        }
-        // Transfer (pools send): `asset_output_amount` is recipient + bridge
-        // change, so only a lower bound is meaningful here. The per-output bind
-        // below pins the recipient leg.
-        ifa::TS_TRANSFER => {
-            if committed_asset_output < net_credited {
-                return Err(EnclaveError::CrossCheck(format!(
-                    "send-RGB amount mismatch: consignment asset_output_amount \
-                     ({committed_asset_output}) < net credited (source_amount {source_amount} - \
-                     source_commission {source_commission} = {net_credited})"
-                )));
-            }
-        }
-        // Unreachable: the gate above admits only the two shapes. Spelled out
-        // so a new transition type cannot silently inherit the Transfer rule.
-        other => {
-            return Err(EnclaveError::CrossCheck(format!(
-                "send-RGB transition type {other} has no amount bind defined - refusing to sign"
-            )));
-        }
-    }
+    flow::assert_group_amount(
+        committed_asset_output,
+        net_credited,
+        source_amount,
+        source_commission,
+    )?;
 
     // Per-output recipient bind. Runs last: it is the only check
     // here that reaches for the enclave's keys.
@@ -836,12 +782,14 @@ mod tests {
         }
 
         /// Stand-in ownership oracles. Fn items coerce to `SelfOwnedOutpoint`.
+        #[cfg(feature = "rgb-swap")]
         fn owns_nothing(_: &Psbt, _: OutPoint) -> Result<bool> {
             Ok(false)
         }
         fn owns_vout_1(psbt: &Psbt, outpoint: OutPoint) -> Result<bool> {
             Ok(outpoint.txid == psbt.unsigned_tx.compute_txid() && outpoint.vout == 1)
         }
+        #[cfg(feature = "rgb-swap")]
         /// Owns vout 0 of [`OFF_TX_SEED`] - an existing wallet UTXO.
         fn owns_off_tx_outpoint(_: &Psbt, outpoint: OutPoint) -> Result<bool> {
             Ok(outpoint == off_tx_outpoint())
@@ -858,6 +806,7 @@ mod tests {
             }
         }
 
+        #[cfg(feature = "rgb-swap")]
         /// A change leg: revealed on `vout` of the witness tx being signed
         /// (`txid: None`, exactly as the in-tree transfer fixture encodes it).
         fn revealed(amount: u64, vout: u32) -> TransitionOutput {
@@ -868,9 +817,11 @@ mod tests {
             }
         }
 
+        #[cfg(feature = "rgb-swap")]
         /// Display-order seal bytes for the off-transaction change UTXO.
         const OFF_TX_SEED: [u8; 32] = [0x77; 32];
 
+        #[cfg(feature = "rgb-swap")]
         /// The same outpoint as a `bitcoin::OutPoint` (internal byte order).
         fn off_tx_outpoint() -> OutPoint {
             let mut internal = OFF_TX_SEED;
@@ -881,6 +832,7 @@ mod tests {
             }
         }
 
+        #[cfg(feature = "rgb-swap")]
         /// A change leg on an existing wallet UTXO: an explicit txid that is
         /// NOT the tx being signed. Emitted when there is no BTC change.
         fn revealed_off_tx(amount: u64) -> TransitionOutput {
@@ -894,8 +846,16 @@ mod tests {
             }
         }
 
+        /// The last-transition type this build's flow signs on a deposit.
+        /// Lets the shared PSBT-mechanics cases below (txid bind, prevout
+        /// canary, sighash, leg split) run unchanged under either flow.
+        #[cfg(feature = "rgb-swap")]
+        const SIGNING_TT: u16 = ifa::TS_TRANSFER;
+        #[cfg(feature = "rgb-mint-burn")]
+        const SIGNING_TT: u16 = ifa::TS_INFLATION;
+
         fn transfer_summary(outputs: Vec<TransitionOutput>) -> TransitionSummary {
-            summary("transfer-op", ifa::TS_TRANSFER, outputs)
+            summary("transfer-op", SIGNING_TT, outputs)
         }
 
         fn summary(
@@ -992,6 +952,12 @@ mod tests {
         /// allocation returns as change on a revealed seal pointing at an
         /// output we control. `asset_output_amount` (5_000) exceeding
         /// `net_credited` (900) is fine - the surplus is provably ours.
+        // Bridge-change shapes: only the send/receive flow has them.
+        // Every case below leans on an `asset_output_amount` surplus
+        // returning as change, which the mint rule rejects outright as
+        // an over-mint before the leg split is reached - see
+        // `rejects_mint_over_mint`.
+        #[cfg(feature = "rgb-swap")]
         #[test]
         fn passes_when_change_returns_to_a_bridge_owned_seal() {
             let psbt = psbt_with_two_inputs();
@@ -1009,6 +975,7 @@ mod tests {
         /// attacker controls. Every other leg of the cross-check passes; the
         /// aggregate bound (`asset_output_amount >= net_credited`) passes
         /// vacuously. Only the recipient bind catches it.
+        #[cfg(feature = "rgb-swap")]
         #[test]
         fn rejects_over_send_to_a_blinded_seal() {
             let psbt = psbt_with_two_inputs();
@@ -1024,6 +991,7 @@ mod tests {
         /// The same drain routed through a *revealed* seal instead of a blinded
         /// one. Counting revealed legs as change unconditionally would let this
         /// through, so a revealed output we cannot prove is ours is refused.
+        #[cfg(feature = "rgb-swap")]
         #[test]
         fn rejects_change_on_an_output_we_do_not_control() {
             let psbt = psbt_with_two_inputs();
@@ -1039,6 +1007,7 @@ mod tests {
 
         /// A revealed seal naming a vout that does not exist on this tx is
         /// equally unownable, and must be refused rather than ignored.
+        #[cfg(feature = "rgb-swap")]
         #[test]
         fn rejects_change_on_an_out_of_range_vout() {
             let psbt = psbt_with_two_inputs();
@@ -1053,6 +1022,7 @@ mod tests {
 
         /// With no BTC change, rgb-lib parks the RGB change on an existing
         /// UTXO. Legitimate, on the same terms: the outpoint must be ours.
+        #[cfg(feature = "rgb-swap")]
         #[test]
         fn passes_when_change_lands_on_an_existing_bridge_utxo() {
             let psbt = psbt_with_two_inputs();
@@ -1065,6 +1035,7 @@ mod tests {
 
         /// Same shape, outpoint we cannot prove. Accepting it unconditionally
         /// would hand the change to whoever the host names.
+        #[cfg(feature = "rgb-swap")]
         #[test]
         fn rejects_off_tx_change_on_an_outpoint_we_cannot_prove() {
             let psbt = psbt_with_two_inputs();
@@ -1079,6 +1050,7 @@ mod tests {
 
         /// A bundle naming more than [`MAX_OFF_TX_CHANGE_OUTPOINTS`] outpoints
         /// is refused before the egress, not after.
+        #[cfg(feature = "rgb-swap")]
         #[test]
         fn rejects_too_many_distinct_off_tx_outpoints() {
             let psbt = psbt_with_two_inputs();
@@ -1106,6 +1078,7 @@ mod tests {
         }
 
         /// Several change legs on one UTXO must hit the memo, not the indexer.
+        #[cfg(feature = "rgb-swap")]
         #[test]
         fn resolves_a_repeated_off_tx_outpoint_only_once() {
             use std::cell::Cell;
@@ -1131,12 +1104,12 @@ mod tests {
         /// At per-output granularity: an `OS_INFLATION` entry is mint
         /// *capacity*, not value delivered, so it must not be able to stand in
         /// for the recipient leg.
+        #[cfg(feature = "rgb-mint-burn")]
         #[test]
         fn inflation_allowance_output_is_not_a_recipient_leg() {
             let psbt = psbt_with_two_inputs();
             let mut validated = validated_with(&psbt, vec![confidential(1_000)]);
             edit_signing_transition(&mut validated, |t| {
-                t.transition_type = ifa::TS_INFLATION;
                 // Allowance rides along confidentially. It must be skipped by
                 // the recipient sum, leaving 1_000 == net credited.
                 t.outputs.push(TransitionOutput {
@@ -1176,14 +1149,15 @@ mod tests {
         /// perfectly sized (1_000 = the credit) while its sibling ships
         /// 10_000_000 to a blinded seal. Both are committed by the tx being
         /// signed, so both must be bound.
+        #[cfg(feature = "rgb-swap")]
         #[test]
         fn rejects_over_send_in_a_sibling_transition() {
             let psbt = psbt_with_two_inputs();
             let validated = validated_from(
                 &psbt,
                 vec![
-                    summary("drain-op", ifa::TS_TRANSFER, vec![confidential(10_000_000)]),
-                    summary("decoy-op", ifa::TS_TRANSFER, vec![confidential(1_000)]),
+                    summary("drain-op", SIGNING_TT, vec![confidential(10_000_000)]),
+                    summary("decoy-op", SIGNING_TT, vec![confidential(1_000)]),
                 ],
             );
             let err = validate_psbt_anchors_transition(&psbt, &validated, 1_000, 0, &owns_vout_1)
@@ -1197,6 +1171,7 @@ mod tests {
         /// The legitimate multi-transition shape: a send funded from two
         /// bridge UTXOs, so the bundle carries two transitions whose recipient
         /// legs sum to the credit and whose change returns to us.
+        #[cfg(feature = "rgb-swap")]
         #[test]
         fn passes_when_a_bundle_splits_the_payout_across_transitions() {
             let psbt = psbt_with_two_inputs();
@@ -1206,10 +1181,10 @@ mod tests {
                 vec![
                     summary(
                         "leg-a",
-                        ifa::TS_TRANSFER,
+                        SIGNING_TT,
                         vec![confidential(400), revealed(2_000, 1)],
                     ),
-                    summary("leg-b", ifa::TS_TRANSFER, vec![confidential(500)]),
+                    summary("leg-b", SIGNING_TT, vec![confidential(500)]),
                 ],
             );
             assert!(
@@ -1218,23 +1193,27 @@ mod tests {
             );
         }
 
-        /// A bundle mixing mint and transfer has no single correct aggregate
-        /// rule (equality vs floor), so it is refused rather than guessed at.
+        /// The group gate covers every member, not just the last transition:
+        /// a sibling of another shape would move value under an amount rule
+        /// that was never written for it. A mixed bundle also has no single
+        /// aggregate rule (equality vs floor), so it is refused rather than
+        /// guessed at.
         #[test]
-        fn rejects_mixed_mint_and_transfer_bundle() {
+        fn rejects_foreign_transition_type_in_the_bundle() {
             let psbt = psbt_with_two_inputs();
             let validated = validated_from(
                 &psbt,
                 vec![
-                    summary("mint-op", ifa::TS_INFLATION, vec![confidential(500)]),
-                    summary("send-op", ifa::TS_TRANSFER, vec![confidential(500)]),
+                    // Neither flow signs a Burn on a deposit.
+                    summary("foreign-op", ifa::TS_BURN, vec![confidential(500)]),
+                    summary("signing-op", SIGNING_TT, vec![confidential(500)]),
                 ],
             );
             let err = validate_psbt_anchors_transition(&psbt, &validated, 1_000, 0, &owns_vout_1)
                 .unwrap_err();
             assert!(
-                err.to_string().contains("mixed bundle"),
-                "expected mixed-bundle rejection, got: {err}"
+                err.to_string().contains("flow requires"),
+                "expected foreign-transition rejection, got: {err}"
             );
         }
 
@@ -1333,28 +1312,16 @@ mod tests {
             );
         }
 
-        /// The mint-RGB shape - an IFA Inflation last transition - binds
-        /// through the same anchor path as the pools-mode Transfer.
-        #[test]
-        fn accepts_inflation_shape() {
-            let psbt = psbt_with_two_inputs();
-            let mut validated = validated_for(&psbt, 1_000);
-            edit_signing_transition(&mut validated, |t| t.transition_type = ifa::TS_INFLATION);
-            assert!(
-                validate_psbt_anchors_transition(&psbt, &validated, 1_000, 0, &owns_vout_1).is_ok()
-            );
-        }
-
         /// For a mint, only `OS_ASSET`-typed outputs (the actually
         /// minted units) may cover the credited amount - the `OS_INFLATION`
         /// allowance (mint capacity) counted in `total_output_amount` must
         /// not.
+        #[cfg(feature = "rgb-mint-burn")]
         #[test]
         fn inflation_allowance_does_not_cover_credited_amount() {
             let psbt = psbt_with_two_inputs();
             let mut validated = validated_for(&psbt, 1_000);
             edit_signing_transition(&mut validated, |t| {
-                t.transition_type = ifa::TS_INFLATION;
                 // Minted 999 units; a large allowance rides along in the
                 // total. Net credited is 1_000 - must be rejected on the
                 // asset sum, not covered by the allowance-inflated total.
@@ -1373,12 +1340,12 @@ mod tests {
         /// over-mint and must be rejected. The old one-sided lower bound
         /// (`asset_output_amount < net_credited`) accepted this surplus; the
         /// inflation path now requires exact equality.
+        #[cfg(feature = "rgb-mint-burn")]
         #[test]
         fn rejects_mint_over_mint() {
             let psbt = psbt_with_two_inputs();
             let mut validated = validated_for(&psbt, 1_000);
             edit_signing_transition(&mut validated, |t| {
-                t.transition_type = ifa::TS_INFLATION;
                 // Minted 1_500 against a 1_000 credit -> 500 over-mint.
                 t.asset_output_amount = 1_500;
                 t.total_output_amount = 1_500;
@@ -1391,17 +1358,19 @@ mod tests {
             );
         }
 
+        /// A consignment shaped for a transition this build's flow does not
+        /// sign is refused up front. `TS_BURN` is a withdrawal shape in both
+        /// flows, so it is wrong on a deposit either way.
         #[test]
-        fn rejects_non_transfer_transition() {
+        fn rejects_transition_type_this_flow_does_not_sign() {
             let psbt = psbt_with_two_inputs();
             let mut validated = validated_for(&psbt, 1_000);
             edit_signing_transition(&mut validated, |t| t.transition_type = ifa::TS_BURN);
             let err = validate_psbt_anchors_transition(&psbt, &validated, 1_000, 0, &owns_vout_1)
                 .unwrap_err();
             assert!(
-                err.to_string()
-                    .contains("requires a Transfer or Inflation transition"),
-                "expected Transfer/Inflation-required rejection, got: {err}"
+                err.to_string().contains("this enclave is built for the"),
+                "expected flow-shape rejection, got: {err}"
             );
         }
 

--- a/enclave/src/networks/rgb/psbt_validation.rs
+++ b/enclave/src/networks/rgb/psbt_validation.rs
@@ -235,12 +235,7 @@ pub fn validate_psbt_anchors_transition(
 
     // Equality for a mint, a coverage floor for a transfer - see `flow/`.
     let net_credited = source_amount.saturating_sub(source_commission);
-    flow::assert_group_amount(
-        committed_asset_output,
-        net_credited,
-        source_amount,
-        source_commission,
-    )?;
+    flow::assert_group_amount(committed_asset_output, source_amount, source_commission)?;
 
     // Per-output recipient bind. Runs last: it is the only check
     // here that reaches for the enclave's keys.

--- a/enclave/src/networks/rgb/validation.rs
+++ b/enclave/src/networks/rgb/validation.rs
@@ -762,12 +762,11 @@ impl RgbValidator {
 
         // Rest of the send-RGB PSBT binding for that same bundle: its input
         // prevouts when the bundle embeds the full tx, plus the validated OpId.
-        // Gated on the last transition being a Transfer or an Inflation; the
-        // check inside asserts the transition type and the witness agree.
+        // Gated on the last transition being the type this build's flow signs
+        // (see `super::flow`); the check inside asserts the transition type and
+        // the witness agree.
         let (last_transfer_witness_prevouts, last_transfer_op_id) = match last_transition {
-            Some(ref last)
-                if matches!(last.transition_type, ifa::TS_TRANSFER | ifa::TS_INFLATION) =>
-            {
+            Some(ref last) if super::flow::is_signing_transition(last.transition_type) => {
                 read_last_transfer_witness(&transfer, last.transition_type)?
             }
             _ => (None, None),

--- a/enclave/src/networks/rgb/validation.rs
+++ b/enclave/src/networks/rgb/validation.rs
@@ -63,10 +63,7 @@ pub fn validate_source(
     // A burn consignment carries its whole mint ancestry, and every one of those
     // mint transitions ends in `cea` - consensus re-runs them, so it needs the
     // locks the enclave verified for itself.
-    #[cfg(feature = "bfa-mint")]
     let validated = validator.validate_consignment(&source.consignment, ctx.bridge_events)?;
-    #[cfg(not(feature = "bfa-mint"))]
-    let validated = validator.validate_consignment(&source.consignment, &[])?;
 
     if validated.contract_id.is_empty() {
         return Err(EnclaveError::CrossCheck(
@@ -122,6 +119,25 @@ pub fn validate_source(
     Ok(validated)
 }
 
+/// Aggregate size/compute cap (operator-configurable via
+/// `MAX_CONSIGNMENT_BYTES`), enforced before the keccak hash and the rgbstd
+/// parse so a request cannot force disproportionate work while staying under
+/// every per-field cap.
+///
+/// `label` names the direction in the rejection, e.g. `"RGB source"` or
+/// `"send-RGB"`. Shared so that lowering the cap cannot produce a different
+/// message depending on which caller happens to run first.
+pub fn assert_consignment_size(consignment: &[u8], cfg: &BridgeConfig, label: &str) -> Result<()> {
+    if consignment.len() > cfg.max_consignment_bytes {
+        return Err(EnclaveError::CrossCheck(format!(
+            "{label} consignment too large: {} bytes (max {})",
+            consignment.len(),
+            cfg.max_consignment_bytes
+        )));
+    }
+    Ok(())
+}
+
 fn validate_source_payload(source: &RgbSource, cfg: &BridgeConfig) -> Result<()> {
     if source.consignment.is_empty() {
         return Err(EnclaveError::CrossCheck(
@@ -129,16 +145,7 @@ fn validate_source_payload(source: &RgbSource, cfg: &BridgeConfig) -> Result<()>
                 .into(),
         ));
     }
-    // Aggregate size/compute caps, enforced before the keccak hash and the
-    // rgbstd parse so a request cannot force disproportionate work while
-    // staying under every per-field cap.
-    if source.consignment.len() > cfg.max_consignment_bytes {
-        return Err(EnclaveError::CrossCheck(format!(
-            "RGB source consignment too large: {} bytes (max {})",
-            source.consignment.len(),
-            cfg.max_consignment_bytes
-        )));
-    }
+    assert_consignment_size(&source.consignment, cfg, "RGB source")?;
     if source.merkle_proofs.len() > cfg.max_merkle_proofs {
         return Err(EnclaveError::CrossCheck(format!(
             "RGB source carries too many merkle proofs: {} (max {})",
@@ -252,27 +259,74 @@ fn decode_opid(hex_opid: &str) -> Result<[u8; 32]> {
 }
 
 /// What the enclave must verify on-chain before RGB consensus may see a BFA
-/// mint: which `FundsIn` logs to fetch, and which contract may have emitted
-/// them.
+/// operation: which `FundsIn` logs to fetch, and which contract may have
+/// emitted them.
+///
+/// Both directions read the same thing. A mint verifies one lock because it
+/// *is* one mint, but consensus re-runs the script of every transition in the
+/// consignment, so on either path every historical mint's `cea` needs its own
+/// verified event - and the burn path carries a whole ancestry of them. The
+/// mint direction additionally needs [`BfaBinding::terminal_opid`].
 #[cfg(feature = "bfa-mint")]
-pub struct BfaMintBinding {
+pub struct BfaBinding {
     /// Every `TS_BRIDGE` OpId in the consignment, in consignment order.
     /// Untrusted - each only selects the log to verify; the ether extension
     /// re-binds it to the operation inside consensus.
     pub mint_opids: Vec<[u8; 32]>,
-    /// The mint this request authorises: the OpId of the consignment's last
-    /// transition. It is the only one bound to the request's own deposit -
-    /// every other entry is an ancestor and must carry its own.
-    pub terminal_opid: [u8; 32],
-    /// `bridgeLocation` exactly as the asset's genesis writes it.
+    /// `bridgeLocation` exactly as the asset's genesis writes it, to compare
+    /// against the enclave's own `funds_in_contract` pin before any log is
+    /// trusted.
     pub bridge_location: String,
+    /// The consignment's last transition, or `None` when it has none. Only the
+    /// mint direction cares, via [`Self::terminal_opid`].
+    last_transition: Option<TransitionSummary>,
 }
 
-/// Read a BFA mint's binding out of raw consignment bytes, before validation.
-/// `Ok(None)` for every other schema, so the swap path is untouched.
 #[cfg(feature = "bfa-mint")]
-pub fn bfa_mint_binding(consignment_bytes: &[u8]) -> Result<Option<BfaMintBinding>> {
-    // Bytes that do not load are not a BFA mint as far as this stage is
+impl BfaBinding {
+    /// The mint this request authorises: the OpId of the consignment's last
+    /// transition. It is the only one bound to the request's own deposit -
+    /// every other entry in `mint_opids` is an ancestor and must carry its own.
+    ///
+    /// Mint-direction only, and every failure refuses the signature: a
+    /// consignment whose last transition is not a bridge mint, or whose last
+    /// transition is absent from the transition list, gives no answer to "which
+    /// deposit pays for this?" and must not be guessed at.
+    pub fn terminal_opid(&self) -> Result<[u8; 32]> {
+        let last = self
+            .last_transition
+            .as_ref()
+            .ok_or_else(|| EnclaveError::CrossCheck("BFA consignment has no transitions".into()))?;
+        if last.transition_type != bfa::TS_BRIDGE {
+            return Err(EnclaveError::CrossCheck(format!(
+                "BFA consignment's last transition is type {}, expected the bridge mint {}",
+                last.transition_type,
+                bfa::TS_BRIDGE
+            )));
+        }
+        let terminal_opid = decode_opid(&last.op_id)?;
+        // The terminal transition decides which deposit pays for this mint, so
+        // it must be one of the transitions actually in the consignment.
+        if !self.mint_opids.contains(&terminal_opid) {
+            return Err(EnclaveError::CrossCheck(
+                "BFA consignment's last transition is a bridge mint but is absent from the \
+                 transition list - refusing to guess which mint this request authorises"
+                    .into(),
+            ));
+        }
+        Ok(terminal_opid)
+    }
+}
+
+/// Read a BFA operation's binding out of raw consignment bytes, before
+/// validation. `Ok(None)` for every other schema, so the swap path is untouched.
+///
+/// A mint spends the bridge right its predecessor rolled forward, so mint N
+/// carries mints 1..N-1 in the history consensus re-runs `cea` over. Each one
+/// needs its own event, so each needs its own verified lock.
+#[cfg(feature = "bfa-mint")]
+pub fn bfa_binding(consignment_bytes: &[u8]) -> Result<Option<BfaBinding>> {
+    // Bytes that do not load are not a BFA operation as far as this stage is
     // concerned; `validate_consignment` reports the parse failure on the path
     // that owns it, so that ordering of error messages is preserved.
     let Ok(transfer) = Transfer::load(Cursor::new(consignment_bytes)) else {
@@ -284,85 +338,17 @@ pub fn bfa_mint_binding(consignment_bytes: &[u8]) -> Result<Option<BfaMintBindin
 
     // The flat parser, not `read_last_transfer_witness`: that one reports the
     // OpId rgbstd derived while walking a transfer it is about to validate, and
-    // here the OpId is needed *before* validation, to pick the log to verify.
+    // here the OpIds are needed *before* validation, to pick the logs to verify.
     let (_, mint_op_ids, last_transition, _) = extract_transition_summary(consignment_bytes)?;
 
-    let last = last_transition
-        .ok_or_else(|| EnclaveError::CrossCheck("BFA consignment has no transitions".into()))?;
-    if last.transition_type != bfa::TS_BRIDGE {
-        return Err(EnclaveError::CrossCheck(format!(
-            "BFA consignment's last transition is type {}, expected the bridge mint {}",
-            last.transition_type,
-            bfa::TS_BRIDGE
-        )));
-    }
-    let terminal_opid = decode_opid(&last.op_id)?;
-
-    // A mint spends the bridge right its predecessor rolled forward, so mint N
-    // carries mints 1..N-1 in the history consensus re-runs `cea` over. Each one
-    // needs its own event, so each needs its own verified lock.
-    let mut mint_opids = Vec::with_capacity(mint_op_ids.len());
-    for hex_opid in &mint_op_ids {
-        mint_opids.push(decode_opid(hex_opid)?);
-    }
-    // The terminal transition decides which deposit pays for this mint, so it
-    // must be one of the transitions actually in the consignment.
-    if !mint_opids.contains(&terminal_opid) {
-        return Err(EnclaveError::CrossCheck(
-            "BFA consignment's last transition is a bridge mint but is absent from the \
-             transition list - refusing to guess which mint this request authorises"
-                .into(),
-        ));
-    }
-
-    Ok(Some(BfaMintBinding {
-        mint_opids,
-        terminal_opid,
+    Ok(Some(BfaBinding {
+        mint_opids: mint_op_ids
+            .iter()
+            .map(|hex_opid| decode_opid(hex_opid))
+            .collect::<Result<Vec<_>>>()?,
         bridge_location: genesis_bridge_location(&transfer)?,
+        last_transition,
     }))
-}
-
-/// Every `TS_BRIDGE` transition a BFA consignment descends from, plus the
-/// asset's genesis `bridgeLocation`.
-///
-/// The mint direction verifies one lock because it *is* one mint. A burn is
-/// different: consensus re-runs the script of every transition in the
-/// consignment, so every historical mint's `cea` needs its own verified event.
-/// This is the flat parse, deliberately - the OpIds are needed *before*
-/// validation, to pick which logs to fetch.
-#[cfg(feature = "bfa-mint")]
-pub fn bfa_ancestry_binding(consignment_bytes: &[u8]) -> Result<Option<BfaAncestryBinding>> {
-    let Ok(transfer) = Transfer::load(Cursor::new(consignment_bytes)) else {
-        return Ok(None);
-    };
-    if transfer.genesis.schema_id != schemata::BFA_SCHEMA_ID {
-        return Ok(None);
-    }
-
-    let (_, mint_op_ids, _, _) = extract_transition_summary(consignment_bytes)?;
-
-    let mut opids = Vec::with_capacity(mint_op_ids.len());
-    for hex_opid in &mint_op_ids {
-        opids.push(decode_opid(hex_opid)?);
-    }
-
-    Ok(Some(BfaAncestryBinding {
-        mint_opids: opids,
-        bridge_location: genesis_bridge_location(&transfer)?,
-    }))
-}
-
-/// What the enclave must verify on-chain before RGB consensus may see a BFA
-/// burn: every mint in the consignment's ancestry, and the contract allowed to
-/// have emitted their `FundsIn` logs.
-#[cfg(feature = "bfa-mint")]
-pub struct BfaAncestryBinding {
-    /// OpIds of every `TS_BRIDGE` transition in the consignment. Untrusted -
-    /// they only select which logs to fetch; each one is then verified.
-    pub mint_opids: Vec<[u8; 32]>,
-    /// The asset's genesis `bridgeLocation`, to compare against the enclave's
-    /// own `funds_in_contract` pin before any log is trusted.
-    pub bridge_location: String,
 }
 
 /// Read the asset's `bridgeLocation` straight out of the genesis global state.
@@ -1228,7 +1214,7 @@ type LastTransferBinding = (Option<Vec<bitcoin::OutPoint>>, Option<[u8; 32]>);
 /// Mint transitions - the ones that map 1:1 to an EVM lock record. BFA's
 /// `TS_BRIDGE` counts only in a `bfa-mint` build, so a swap enclave classifies
 /// exactly what it classified before BFA existed.
-pub(super) fn is_mint_transition(transition_type: u16) -> bool {
+pub fn is_mint_transition(transition_type: u16) -> bool {
     #[cfg(feature = "bfa-mint")]
     {
         if transition_type == bfa::TS_BRIDGE {
@@ -1288,13 +1274,6 @@ fn extract_transition_summary(
         .map(|t: &TransitionInfo| t.op_id.clone())
         .collect();
 
-    let last_transition = transfer
-        .witnesses
-        .last()
-        .and_then(|w| w.transitions.last())
-        .map(transition_summary)
-        .transpose()?;
-
     // Every transition, grouped by the witness tx that commits it. One tx can
     // carry several, so reading only `last_transition` would leave the rest of
     // the value it moves unbound. The PSBT cross-check binds the whole group.
@@ -1306,6 +1285,13 @@ fn extract_transition_summary(
             w.transitions.iter().map(transition_summary).collect();
         transitions_by_witness.push((txid, summaries?));
     }
+
+    // Taken from the group rather than summarised a second time - it is the
+    // last witness's last transition either way.
+    let last_transition = transitions_by_witness
+        .last()
+        .and_then(|(_, summaries)| summaries.last())
+        .cloned();
 
     Ok((
         all_op_ids,
@@ -1382,72 +1368,71 @@ fn transition_summary(t: &TransitionInfo) -> Result<TransitionSummary> {
     })
 }
 
-/// Walk the rgbstd `Transfer` to the last witness bundle's last known
-/// transition and read the IFA `MS_BURNED_ASSET` value from its metadata. The
-/// flat parser drops `Transition.metadata`, so the unlock cross-check gets the
-/// destroyed amount from here.
+/// Raw metadata value `meta_type` carries on the last witness bundle's last
+/// known transition, if any. The flat parser drops `Transition.metadata`, so
+/// the cross-checks that need it walk the rgbstd `Transfer` through here.
+///
+/// `None` when the transfer has no bundle, that bundle no known transition, or
+/// the transition no value under that key - all three are "not declared" rather
+/// than errors, and each caller decides what a missing value means for it.
+fn last_transition_meta(transfer: &Transfer, meta_type: u16) -> Option<&[u8]> {
+    let known = transfer
+        .bundles
+        .iter()
+        .last()?
+        .bundle()
+        .known_transitions
+        .iter()
+        .last()?;
+    let key = MetaType::with(meta_type);
+    known
+        .transition
+        .metadata
+        .iter()
+        .find(|(mt, _)| **mt == key)
+        .map(|(_, mv)| mv.as_unconfined().as_slice())
+}
+
+/// The BFA `MS_BURN_RECIPIENT` metadata on the last transition - the 32 bytes
+/// naming where the redemption is owed.
+///
+/// `Ok(None)` when the key is absent (an IFA burn declares `burnedInflation`
+/// there instead), and `Err` when the blob is not exactly 32 bytes, because a
+/// release must never be pointed at a truncated or padded address.
+fn read_last_transition_burn_recipient(transfer: &Transfer) -> Result<Option<Vec<u8>>> {
+    let Some(raw) = last_transition_meta(transfer, bfa::MS_BURN_RECIPIENT) else {
+        return Ok(None);
+    };
+    if raw.len() != 32 {
+        return Err(EnclaveError::CrossCheck(format!(
+            "MS_BURN_RECIPIENT metadata is {} bytes, expected 32",
+            raw.len()
+        )));
+    }
+    Ok(Some(raw.to_vec()))
+}
+
+/// The IFA `MS_BURNED_ASSET` metadata on the last transition - the destroyed
+/// amount the unlock cross-check binds against.
 ///
 /// The value is a strict-encoded `rgbstd::Amount` (`u64`, 8 bytes,
 /// little-endian). Decoded manually rather than via
 /// `StrictDeserialize::from_strict_serialized`, to avoid threading the
 /// `rgb-strict-encoding`-as-`strict_encoding` rename through our deps.
 ///
-/// Returns `Ok(None)` when there is no last transition or the metadata key is
-/// absent (which for a `TS_BURN` implies a schema mismatch), and `Err` when the
-/// blob is the wrong size for a `u64`.
-/// Walk to the last known transition and read the BFA `MS_BURN_RECIPIENT`
-/// value from its metadata - the 32 bytes naming where the redemption is owed.
-///
-/// Returns `Ok(None)` when there is no last transition or the key is absent
-/// (an IFA burn declares `burnedInflation` there instead), and `Err` when the
-/// blob is not exactly 32 bytes, because a release must never be pointed at a
-/// truncated or padded address.
-fn read_last_transition_burn_recipient(transfer: &Transfer) -> Result<Option<Vec<u8>>> {
-    let Some(last_bundle) = transfer.bundles.iter().last() else {
-        return Ok(None);
-    };
-    let Some(known) = last_bundle.bundle().known_transitions.iter().last() else {
-        return Ok(None);
-    };
-    let recipient_meta_key = MetaType::with(bfa::MS_BURN_RECIPIENT);
-    for (mt, mv) in &known.transition.metadata {
-        if *mt != recipient_meta_key {
-            continue;
-        }
-        let raw: &[u8] = mv.as_unconfined().as_slice();
-        if raw.len() != 32 {
-            return Err(EnclaveError::CrossCheck(format!(
-                "MS_BURN_RECIPIENT metadata is {} bytes, expected 32",
-                raw.len()
-            )));
-        }
-        return Ok(Some(raw.to_vec()));
-    }
-    Ok(None)
-}
-
+/// `Ok(None)` when the key is absent (which for a `TS_BURN` implies a schema
+/// mismatch), and `Err` when the blob is the wrong size for a `u64`.
 fn read_last_transition_burned_asset(transfer: &Transfer) -> Result<Option<u64>> {
-    let Some(last_bundle) = transfer.bundles.iter().last() else {
+    let Some(raw) = last_transition_meta(transfer, ifa::MS_BURNED_ASSET) else {
         return Ok(None);
     };
-    let Some(known) = last_bundle.bundle().known_transitions.iter().last() else {
-        return Ok(None);
-    };
-    let burned_meta_key = MetaType::with(ifa::MS_BURNED_ASSET);
-    for (mt, mv) in &known.transition.metadata {
-        if *mt != burned_meta_key {
-            continue;
-        }
-        let raw: &[u8] = mv.as_unconfined().as_slice();
-        let bytes: [u8; 8] = raw.try_into().map_err(|_| {
-            EnclaveError::CrossCheck(format!(
-                "MS_BURNED_ASSET metadata is {} bytes, expected 8 (strict-encoded u64)",
-                raw.len()
-            ))
-        })?;
-        return Ok(Some(u64::from_le_bytes(bytes)));
-    }
-    Ok(None)
+    let bytes: [u8; 8] = raw.try_into().map_err(|_| {
+        EnclaveError::CrossCheck(format!(
+            "MS_BURNED_ASSET metadata is {} bytes, expected 8 (strict-encoded u64)",
+            raw.len()
+        ))
+    })?;
+    Ok(Some(u64::from_le_bytes(bytes)))
 }
 
 fn transition_output(assignment_type: u16, e: &FungibleEntry) -> Result<TransitionOutput> {
@@ -1847,38 +1832,73 @@ mod tests {
         assert!(decode_bridge_location(&[0, 1, 0xff]).is_err());
     }
 
-    /// The swap path must be untouched: a non-BFA consignment yields no binding
-    /// and so triggers no EVM lookup.
+    /// The schema gate the BFA pre-pass applies on both directions: an IFA or
+    /// swap consignment must trigger no EVM lookup and no ancestor requirement,
+    /// or every non-BFA mint and burn on the stand would start failing.
     #[cfg(feature = "bfa-mint")]
     #[test]
-    fn no_mint_binding_for_a_non_bfa_consignment() {
-        assert!(bfa_mint_binding(TRANSFER_FIXTURE).unwrap().is_none());
+    fn no_binding_for_a_non_bfa_consignment() {
+        assert!(bfa_binding(TRANSFER_FIXTURE).unwrap().is_none());
     }
 
     /// Undecodable bytes are left to `validate_consignment`, which owns that
-    /// error - reporting it from the mint pre-pass would reorder the messages
-    /// every other path already asserts on.
+    /// error - reporting it from the pre-pass would reorder the messages every
+    /// other path already asserts on.
     #[cfg(feature = "bfa-mint")]
     #[test]
-    fn mint_binding_defers_undecodable_bytes() {
-        assert!(bfa_mint_binding(b"not-a-consignment").unwrap().is_none());
+    fn binding_defers_undecodable_bytes() {
+        assert!(bfa_binding(b"not-a-consignment").unwrap().is_none());
     }
 
-    /// The burn ancestry pre-pass shares the mint pre-pass's schema gate: an
-    /// IFA or swap consignment must trigger no EVM lookup and no ancestor
-    /// requirement, or every non-BFA burn on the stand would start failing.
+    /// A `BfaBinding` whose last transition is `last`, over the given mint set.
     #[cfg(feature = "bfa-mint")]
-    #[test]
-    fn no_ancestry_binding_for_a_non_bfa_consignment() {
-        assert!(bfa_ancestry_binding(TRANSFER_FIXTURE).unwrap().is_none());
+    fn binding_with(mint_opids: Vec<[u8; 32]>, last: Option<(u16, [u8; 32])>) -> BfaBinding {
+        BfaBinding {
+            mint_opids,
+            bridge_location: "0x0".into(),
+            last_transition: last.map(|(transition_type, opid)| TransitionSummary {
+                op_id: hex::encode(opid),
+                transition_type,
+                total_output_amount: 0,
+                asset_output_amount: 0,
+                outputs: vec![],
+                burned_asset_amount: None,
+                burn_recipient: None,
+            }),
+        }
     }
 
+    /// The happy path: the last transition is a bridge mint that is also in the
+    /// mint list, so it names the deposit this request authorises.
     #[cfg(feature = "bfa-mint")]
     #[test]
-    fn ancestry_binding_defers_undecodable_bytes() {
-        assert!(bfa_ancestry_binding(b"not-a-consignment")
-            .unwrap()
-            .is_none());
+    fn terminal_opid_is_the_last_bridge_mint() {
+        let b = binding_with(vec![[1; 32], [2; 32]], Some((bfa::TS_BRIDGE, [2; 32])));
+        assert_eq!(b.terminal_opid().unwrap(), [2; 32]);
+    }
+
+    /// No transitions means no answer to "which deposit pays for this?".
+    #[cfg(feature = "bfa-mint")]
+    #[test]
+    fn terminal_opid_refuses_an_empty_consignment() {
+        assert!(binding_with(vec![], None).terminal_opid().is_err());
+    }
+
+    /// A BFA consignment ending in a non-bridge transition is not a mint request.
+    #[cfg(feature = "bfa-mint")]
+    #[test]
+    fn terminal_opid_refuses_a_non_bridge_last_transition() {
+        let b = binding_with(vec![[1; 32]], Some((ifa::TS_BURN, [1; 32])));
+        assert!(b.terminal_opid().is_err());
+    }
+
+    /// The last transition is a bridge mint, but the flat parser did not list it
+    /// among the mints - refuse rather than guess.
+    #[cfg(feature = "bfa-mint")]
+    #[test]
+    fn terminal_opid_refuses_a_last_mint_absent_from_the_list() {
+        let b = binding_with(vec![[1; 32]], Some((bfa::TS_BRIDGE, [9; 32])));
+        assert!(b.terminal_opid().is_err());
     }
 
     #[cfg(feature = "bfa-mint")]
@@ -2346,7 +2366,6 @@ mod tests {
                 header_chain: &chain,
                 // Source validation never reaches the destination PSBT bind.
                 self_owned_psbt_outputs: None,
-                #[cfg(feature = "bfa-mint")]
                 bridge_events: &[],
             };
             validate_source(source, &ctx)

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -602,13 +602,14 @@ fn apply_funds_out_binding(
     #[cfg(not(feature = "spv"))]
     let _ = (ctx, merkle_proofs);
 
-    // Consignment-bound release amount (transfer flow).
-    crosscheck::validate_funds_out_transfer(params, validated)?;
+    // Consignment-bound release amount, under this build's RGB flow
+    // (`rgb-swap` = Transfer, `rgb-mint-burn` = Burn).
+    crosscheck::validate_funds_out_amount(params, validated)?;
 
-    // Swap / send-receive only for now. The backend-provided burnId and
-    // settlement fundsInIds are preserved; the EVM connector already selected
-    // the latter against the on-chain remaining balance. Mint/burn needs a
-    // network-id-routed path before its RGB OpId binding can be enabled.
+    // The backend-provided burnId and settlement fundsInIds are preserved; the
+    // EVM connector already selected the latter against the on-chain remaining
+    // balance. Mint/burn still needs a network-id-routed path before its RGB
+    // OpId binding can be enabled.
 
     Ok(())
 }

--- a/enclave/src/server.rs
+++ b/enclave/src/server.rs
@@ -315,16 +315,6 @@ fn dispatch(request: EnclaveRequest, ctx: &ServerContext) -> EnclaveResponse {
     }
 }
 
-/// Verify the EVM lock a BFA mint commits to and return it as the one-element
-/// event set RGB consensus checks the minted amount against.
-///
-/// The OpId parsed out of the consignment is untrusted: it only selects which
-/// `FundsIn` log must exist. That log is verified through the same Helios-backed
-/// path the swap flow uses, against the contract pinned in config *and* named by
-/// the asset's genesis, and consensus re-binds both OpId and amount when `cea`
-/// runs. Empty vec when the consignment is not a BFA one, so the swap path is
-/// unaffected; every failure refuses the signature.
-#[cfg(feature = "bfa-mint")]
 /// The EVM tx hash the listener claims backs `mint_opid`.
 ///
 /// Fails closed: an unlisted mint, or one listed with a malformed hash, aborts
@@ -392,123 +382,137 @@ fn mint_lock_plan(
         .collect()
 }
 
+/// Verify the `FundsIn` lock paired with every mint in `plan` and return one
+/// `cea` event per mint, in plan order.
+///
+/// `plan` is `(mint OpId, EVM tx hash)`: the OpId is untrusted and only selects
+/// which log must exist, and the tx hash is a listener hint. Both are checked
+/// here against the enclave's own contract pin, through the same Helios-backed
+/// path the swap flow uses, and consensus re-binds OpId and amount when `cea`
+/// runs. Every failure refuses the signature.
+///
+/// `unavailable` names, in the rejection, what the missing EVM client would
+/// have been used to authorise.
+#[cfg(feature = "bfa-mint")]
+fn verify_mint_locks(
+    ctx: &ServerContext,
+    plan: &[([u8; 32], [u8; 32])],
+    unavailable: &str,
+) -> Result<Vec<rgbstd::vm::ether_extension::Event>> {
+    use crate::networks::evm::evm_event::verify_rgb_funds_in;
+    use rgbstd::vm::ether_extension::Event;
+    use rgbstd::{OpId, RevealedValue};
+
+    if plan.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let client = ctx
+        .evm_rpc_client
+        .as_ref()
+        .ok_or_else(|| EnclaveError::CrossCheck(unavailable.into()))?;
+
+    plan.iter()
+        .map(|(mint_opid, lock)| {
+            let amount = verify_rgb_funds_in(
+                &**client,
+                &ctx.bridge_config.funds_in_contract,
+                ctx.evm_rpc_config.min_confirmations,
+                lock,
+                mint_opid,
+            )?;
+            Ok(Event::new(
+                OpId::from(*mint_opid),
+                RevealedValue::from(amount),
+            ))
+        })
+        .collect()
+}
+
+/// The contract pin both directions apply before any log is trusted: the
+/// extension never checks which contract an event came from, so this is the
+/// only thing between a mint or a redemption and an attacker's contract.
+#[cfg(feature = "bfa-mint")]
+fn bfa_binding_for(
+    ctx: &ServerContext,
+    consignment: &[u8],
+    label: &str,
+) -> Result<Option<crate::networks::rgb::validation::BfaBinding>> {
+    use crate::networks::evm::evm_event::check_bridge_location;
+    use crate::networks::rgb::validation::{assert_consignment_size, bfa_binding};
+
+    // The same cap the anchor validation applies, repeated because that check
+    // now runs after this parse rather than before it.
+    assert_consignment_size(consignment, &ctx.bridge_config, label)?;
+
+    // Not a BFA consignment: the other schemas run no extension opcode, so an
+    // empty event set is correct rather than merely tolerated.
+    let Some(binding) = bfa_binding(consignment)? else {
+        return Ok(None);
+    };
+    check_bridge_location(
+        &binding.bridge_location,
+        &ctx.bridge_config.funds_in_contract,
+    )?;
+    Ok(Some(binding))
+}
+
 /// Verify the `FundsIn` lock behind every mint a burn consignment descends
 /// from, and return one `cea` event per mint.
 ///
 /// The listener supplies `(op_id, tx_hash)` pairs because only it can search
-/// the chain; they are hints. Every pair is fetched and checked here against
-/// the enclave's own contract pin, and a mint with no pair - or with one whose
-/// log does not bind to it - fails the whole validation. That is the point: a
-/// burn may only release funds that a real, verified lock once created.
+/// the chain; they are hints. Every pair is fetched and checked by
+/// [`verify_mint_locks`], and a mint with no pair - or with one whose log does
+/// not bind to it - fails the whole validation. That is the point: a burn may
+/// only release funds that a real, verified lock once created.
 #[cfg(feature = "bfa-mint")]
 fn bfa_burn_ancestry_events(
     ctx: &ServerContext,
     source: &enclave_proto::RgbSource,
 ) -> Result<Vec<rgbstd::vm::ether_extension::Event>> {
-    use crate::networks::evm::evm_event::{check_bridge_location, verify_rgb_funds_in};
-    use crate::networks::rgb::validation::bfa_ancestry_binding;
-    use rgbstd::vm::ether_extension::Event;
-    use rgbstd::{OpId, RevealedValue};
-
     if cfg!(feature = "dev-mode") {
         return Ok(Vec::new());
     }
-    if source.consignment.len() > ctx.bridge_config.max_consignment_bytes {
-        return Err(EnclaveError::CrossCheck(format!(
-            "RGB source consignment too large: {} bytes (max {})",
-            source.consignment.len(),
-            ctx.bridge_config.max_consignment_bytes
-        )));
-    }
 
-    let Some(binding) = bfa_ancestry_binding(&source.consignment)? else {
-        // Not a BFA consignment: the other schemas run no extension opcode, so
-        // an empty event set is correct rather than merely tolerated.
+    let Some(binding) = bfa_binding_for(ctx, &source.consignment, "RGB source")? else {
         return Ok(Vec::new());
     };
 
-    // The extension never checks which contract an event came from, so this is
-    // the only thing between a redemption and logs from an attacker's contract.
-    check_bridge_location(
-        &binding.bridge_location,
-        &ctx.bridge_config.funds_in_contract,
-    )?;
+    let plan = binding
+        .mint_opids
+        .iter()
+        .map(|opid| Ok((*opid, ancestor_tx_hash(opid, &source.mint_ancestors)?)))
+        .collect::<Result<Vec<_>>>()?;
 
-    if binding.mint_opids.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let client = ctx.evm_rpc_client.as_ref().ok_or_else(|| {
-        EnclaveError::CrossCheck(
-            "bfa-mint build but the EVM RPC client is unavailable - refusing to validate a burn \
-             without independently verifying the locks behind its mints"
-                .into(),
-        )
-    })?;
-
-    let mut events = Vec::with_capacity(binding.mint_opids.len());
-    for mint_opid in &binding.mint_opids {
-        let tx_hash = ancestor_tx_hash(mint_opid, &source.mint_ancestors)?;
-
-        let amount = verify_rgb_funds_in(
-            &**client,
-            &ctx.bridge_config.funds_in_contract,
-            ctx.evm_rpc_config.min_confirmations,
-            &tx_hash,
-            mint_opid,
-        )?;
-
-        events.push(Event::new(
-            OpId::from(*mint_opid),
-            RevealedValue::from(amount),
-        ));
-    }
-
-    Ok(events)
+    verify_mint_locks(
+        ctx,
+        &plan,
+        "bfa-mint build but the EVM RPC client is unavailable - refusing to validate a burn \
+         without independently verifying the locks behind its mints",
+    )
 }
 
+/// Verify the EVM lock a BFA mint commits to, plus the lock behind each of its
+/// ancestors, and return them as the event set RGB consensus checks the minted
+/// amounts against.
+///
+/// Empty vec when this is not an EVM-to-RGB request or the consignment is not a
+/// BFA one, so the swap path is unaffected.
 #[cfg(feature = "bfa-mint")]
 fn bfa_mint_events(
     ctx: &ServerContext,
-    source: &SourceNetwork,
-    destination: &DestinationNetwork,
+    source: &enclave_proto::EvmSource,
+    destination: &enclave_proto::RgbDestination,
 ) -> Result<Vec<rgbstd::vm::ether_extension::Event>> {
-    use crate::networks::evm::evm_event::{check_bridge_location, verify_rgb_funds_in};
-    use crate::networks::rgb::validation::bfa_mint_binding;
-    use rgbstd::vm::ether_extension::Event;
-    use rgbstd::{OpId, RevealedValue};
-
     // dev-mode compiles no destination-anchor validation, so these events would
     // have no consumer and the RPC call would be pure cost.
     if cfg!(feature = "dev-mode") {
         return Ok(Vec::new());
     }
 
-    let (SourceNetwork::EvmSource(source), DestinationNetwork::RgbDestination(destination)) =
-        (source, destination)
-    else {
+    let Some(binding) = bfa_binding_for(ctx, &destination.consignment, "send-RGB")? else {
         return Ok(Vec::new());
     };
-
-    // The same cap `validate_destination_anchor` applies, repeated because that
-    // check now runs after this parse rather than before it.
-    if destination.consignment.len() > ctx.bridge_config.max_consignment_bytes {
-        return Err(EnclaveError::CrossCheck(format!(
-            "send-RGB consignment too large: {} bytes (max {})",
-            destination.consignment.len(),
-            ctx.bridge_config.max_consignment_bytes
-        )));
-    }
-    let Some(binding) = bfa_mint_binding(&destination.consignment)? else {
-        return Ok(Vec::new());
-    };
-
-    // The extension never checks which contract an event came from, so this is
-    // the only thing between a mint and a log from an attacker's contract.
-    check_bridge_location(
-        &binding.bridge_location,
-        &ctx.bridge_config.funds_in_contract,
-    )?;
 
     let tx_hash: [u8; 32] = source.tx_hash.as_slice().try_into().map_err(|_| {
         EnclaveError::CrossCheck(format!(
@@ -516,36 +520,19 @@ fn bfa_mint_events(
             source.tx_hash.len()
         ))
     })?;
-    let client = ctx.evm_rpc_client.as_ref().ok_or_else(|| {
-        EnclaveError::CrossCheck(
-            "bfa-mint build but the EVM RPC client is unavailable - refusing to sign a mint \
-             without independently verifying its FundsIn lock"
-                .into(),
-        )
-    })?;
     let plan = mint_lock_plan(
         &binding.mint_opids,
-        &binding.terminal_opid,
+        &binding.terminal_opid()?,
         &tx_hash,
         &destination.mint_ancestors,
     )?;
 
-    let mut events = Vec::with_capacity(plan.len());
-    for (mint_opid, lock) in plan {
-        let amount = verify_rgb_funds_in(
-            &**client,
-            &ctx.bridge_config.funds_in_contract,
-            ctx.evm_rpc_config.min_confirmations,
-            &lock,
-            &mint_opid,
-        )?;
-        events.push(Event::new(
-            OpId::from(mint_opid),
-            RevealedValue::from(amount),
-        ));
-    }
-
-    Ok(events)
+    verify_mint_locks(
+        ctx,
+        &plan,
+        "bfa-mint build but the EVM RPC client is unavailable - refusing to sign a mint \
+         without independently verifying its FundsIn lock",
+    )
 }
 
 fn handle_sign(ctx: &ServerContext, req: SignRequest) -> Result<EnclaveResponse> {
@@ -605,12 +592,22 @@ fn handle_sign(ctx: &ServerContext, req: SignRequest) -> Result<EnclaveResponse>
     // Before destination validation, not after: a BFA mint's consignment cannot
     // be validated at all until the lock it commits to has been verified.
     #[cfg(feature = "bfa-mint")]
-    let bfa_bridge_events = match source_ref {
+    let bfa_bridge_events = match (source_ref, destination_ref) {
         // A burn: the events prove the locks behind the mints it descends from.
-        SourceNetwork::RgbSource(rgb) => bfa_burn_ancestry_events(ctx, rgb)?,
-        // A mint: the event proves the one lock it is being minted against.
-        _ => bfa_mint_events(ctx, source_ref, destination_ref)?,
+        (SourceNetwork::RgbSource(rgb), _) => bfa_burn_ancestry_events(ctx, rgb)?,
+        // A mint: the events prove the locks it and its ancestry were minted
+        // against.
+        (SourceNetwork::EvmSource(evm), DestinationNetwork::RgbDestination(rgb)) => {
+            bfa_mint_events(ctx, evm, rgb)?
+        }
+        // No BFA consignment on either side, so nothing for `cea` to check.
+        _ => Vec::new(),
     };
+    // Not gated on `bfa-mint`: `validate_consignment` takes the events
+    // unconditionally, so an empty set is already how "no BFA here" is spelled
+    // and every call site is spared a `#[cfg]` pair.
+    #[cfg(all(feature = "rgb-validation", not(feature = "bfa-mint")))]
+    let bfa_bridge_events: Vec<rgbstd::vm::ether_extension::Event> = Vec::new();
 
     let validation_ctx = ValidationContext {
         bridge_config: &ctx.bridge_config,
@@ -620,7 +617,7 @@ fn handle_sign(ctx: &ServerContext, req: SignRequest) -> Result<EnclaveResponse>
         header_chain: &ctx.header_chain,
         #[cfg(feature = "rgb-validation")]
         self_owned_psbt_outputs: Some(&self_owned_psbt_outputs),
-        #[cfg(feature = "bfa-mint")]
+        #[cfg(feature = "rgb-validation")]
         bridge_events: &bfa_bridge_events,
     };
     let source_validated = validate_source(req.amount, source_ref, &validation_ctx)?;

--- a/parent/src/grpc_server.rs
+++ b/parent/src/grpc_server.rs
@@ -151,6 +151,13 @@ impl ParentAdapterService {
         }
     }
 
+    fn enclave_mint_ancestor(ancestor: grpc_proto::MintAncestor) -> enclave_proto::MintAncestor {
+        enclave_proto::MintAncestor {
+            op_id: ancestor.op_id,
+            tx_hash: ancestor.tx_hash,
+        }
+    }
+
     fn enclave_source_network(
         source: SourceProof,
     ) -> Result<enclave_proto::sign_request::SourceNetwork, Status> {
@@ -194,10 +201,7 @@ impl ParentAdapterService {
                     mint_ancestors: rgb
                         .mint_ancestors
                         .into_iter()
-                        .map(|a| enclave_proto::MintAncestor {
-                            op_id: a.op_id,
-                            tx_hash: a.tx_hash,
-                        })
+                        .map(Self::enclave_mint_ancestor)
                         .collect(),
                 }),
             ),
@@ -252,10 +256,7 @@ impl ParentAdapterService {
                         mint_ancestors: payload
                             .mint_ancestors
                             .into_iter()
-                            .map(|a| enclave_proto::MintAncestor {
-                                op_id: a.op_id,
-                                tx_hash: a.tx_hash,
-                            })
+                            .map(Self::enclave_mint_ancestor)
                             .collect(),
                     },
                 )

--- a/parent/tests/test_grpc_bridge.rs
+++ b/parent/tests/test_grpc_bridge.rs
@@ -518,7 +518,6 @@ async fn grpc_sign_psbt_roundtrip() {
         psbt_output_amount: 0,
         rgb_asset_id: String::new(),
         consignment: vec![],
-        mint_ancestors: vec![],
         consignment_hash: vec![],
         // Plain PSBT roundtrip - no bridged mint, so no ancestors to prove.
         mint_ancestors: vec![],


### PR DESCRIPTION
# Split RGB validation into two exclusive flows

## What

RGB validation rules are now split into two flows. Each flow is a cargo
feature, and exactly one must be on:

- **`rgb-swap`** (send/receive) — the bridge holds a pool. Deposits and
  withdrawals both use IFA `Transfer`.
- **`rgb-mint-burn`** — the bridge owns inflation rights. Deposits mint with
  IFA `Inflation`; withdrawals destroy with IFA `Burn`.

Before this PR one binary held both rule sets and accepted either shape.

## Why

The two flows ship as two enclave instances with two PCR0s. A send/receive
enclave now carries no mint rule at all. If a mint-shaped consignment gets
past every other check, there is no code path left that would sign it.

## How

- New `enclave/src/networks/rgb/flow/` — `mod.rs`, `swap.rs`, `mint_burn.rs`.
  Both flow files export the same item names, so every caller writes
  `flow::...` and never a `cfg`.
- Shared code (PSBT mechanics, consignment parsing, SPV) is unchanged and
  holds no flow `cfg`.
- Two `compile_error!` guards in `lib.rs`: both flows on is an error, and
  `rgb-validation` with no flow is an error. CI asserts both fire.
- New `build/Dockerfile.enclave.mint-burn` and a `rgb-mint-burn` EIF variant
  in `build-eif.yml`.
- New CI lane builds, lints and tests the mint/burn flow.

## Deployment impact — please read

`cd-dev.yml`, `cd-stage.yml` and `cd-prod.yml` all build the same image from
`build/Dockerfile.enclave-dev`. This PR adds `rgb-swap` to that build.

So **dev, stage and prod all become send/receive only**:

| Request | Before | After |
| --- | --- | --- |
| Deposit, IFA `Transfer` | accepted | accepted |
| Deposit, IFA `Inflation` | accepted | **refused** |
| Withdrawal, IFA `Transfer` | accepted | accepted |
| Withdrawal, IFA `Burn` | accepted | **refused** |

A refusal says `this enclave is built for the send/receive flow`.

**Action needed:** if anything on dev exercises mint or burn, it stops
working after this merges.

**No mint/burn instance is deployed anywhere yet.** Dev still runs one
enclave. Adding a second one needs: a mint/burn dev Dockerfile, a second
build-matrix entry and dispatch step in `cd-reusable.yml`, and a deploy
target in `UTEXO-Protocol/devops`. None of that is in this PR.

The mint/burn EIF is built and uploaded to S3 (`eif/<sha>/rgb-mint-burn/`),
but nothing deploys it.

**PCR0 changes** for every EIF variant, because the binary changed.

## Build commands

| Image | Command |
| --- | --- |
| Combined | `cargo build --features vsock,rgb,rgb-swap,ccd,evm-rpc,helios` |
| RGB send/receive | `cargo build --no-default-features --features vsock,rgb,rgb-swap,evm-rpc,helios` |
| RGB mint/burn | `cargo build --no-default-features --features vsock,rgb,rgb-mint-burn,evm-rpc,helios` |
| Concordium | `cargo build --no-default-features --features vsock,ccd` |