### PR TITLE
chore: use Dockerfile.enclave-dev.bfa for dev enclave build

### DIFF
--- a/.github/workflows/cd-reusable.yml
+++ b/.github/workflows/cd-reusable.yml
@@ -63,7 +63,7 @@ jobs:
             float: ${{ needs.prepare.outputs.float_parent }}
           - name: enclave
             image: utexo-bridge-enclave
-            dockerfile: ./build/Dockerfile.enclave-dev
+            dockerfile: ./build/Dockerfile.enclave-dev.bfa
             tag: ${{ needs.prepare.outputs.tag_enclave }}
             float: ${{ needs.prepare.outputs.float_enclave }}
       fail-fast: false


### PR DESCRIPTION
Switch the dev enclave matrix entry to `Dockerfile.enclave-dev.bfa`.

One-line change — no build args added, `RGB_ASSET_ID` is not a build argument in the dev image.