### PR TITLE
feat(deploy): CloudWatch metrics/observability host-prep + SNS->Slack…

### DIFF
--- a/deploy/host-prep-metrics.sh
+++ b/deploy/host-prep-metrics.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Host-prep for enclave-host LIVENESS METRICS (run as root, e.g. via SSM).
+#
+# TODO §7a Track 2. Track 1 (host-prep-observability.sh) ships journald logs;
+# this ships the "is it alive?" SIGNAL that actually drives alarms. A systemd
+# timer runs a tiny reporter every 60s and publishes 3 custom CloudWatch metrics
+# per CID (namespace `Utexo/EnclaveHost`, dims Host=<instance-id>, Cid=<16|18|20>):
+#
+#   EnclaveRunning     nitro-cli describe-enclaves has this CID in State=RUNNING   (1/0)
+#   ParentListening    the parent gRPC port (16->50051,18->50052,20->50053) listens (1/0)
+#   EnclaveResponsive  cli `get-keys` over vsock returns OK = enclave initialized  (1/0)
+#                      + not wedged (catches "process up but empty" — a port check
+#                      alone would miss this).
+#
+# All HOST-SIDE (describe-enclaves + a port check + a read-only get-keys over
+# vsock straight to the enclave — does NOT touch the parent or the EIF). PCR0
+# unchanged, no rebuild. Reboot-safe (systemd timer enabled).
+#
+# ── IAM (attach ONCE to the hosts' instance role `ec2-ssm-role`) ──────────────
+# Least-privilege policy `utexo-stage-enclave-metrics-put` (PutMetricData cannot
+# be resource-scoped, so it is constrained by the metric namespace condition):
+#   {
+#     "Version": "2012-10-17",
+#     "Statement": [{
+#       "Sid": "EnclaveHostMetricsPut",
+#       "Effect": "Allow",
+#       "Action": "cloudwatch:PutMetricData",
+#       "Resource": "*",
+#       "Condition": { "StringEquals": { "cloudwatch:namespace": "Utexo/EnclaveHost" } }
+#     }]
+#   }
+#
+# Usage (root):  AWS_REGION=eu-central-1 bash host-prep-metrics.sh
+set -euo pipefail
+
+REGION="${AWS_REGION:-eu-central-1}"
+NS="${METRIC_NAMESPACE:-Utexo/EnclaveHost}"
+INTERVAL_SEC="${INTERVAL_SEC:-60}"
+REPORTER=/usr/local/bin/utexo-enclave-metrics.sh
+
+log(){ echo "[host-prep-metrics $(date -u +%H:%M:%S)] $*"; }
+
+# --- 1. install the reporter script ----------------------------------------
+log "writing $REPORTER"
+cat > "$REPORTER" <<'REPORTER_EOF'
+#!/usr/bin/env bash
+# Emit enclave/parent liveness metrics to CloudWatch. Installed by
+# deploy/host-prep-metrics.sh; run by utexo-enclave-metrics.timer every 60s.
+set -uo pipefail
+REGION="${AWS_REGION:-eu-central-1}"
+NS="${METRIC_NAMESPACE:-Utexo/EnclaveHost}"
+CIDS=(16 18 20)
+declare -A PORT=([16]=50051 [18]=50052 [20]=50053)
+
+# instance-id via IMDSv2 (dimension Host)
+TOK=$(curl -sS -X PUT "http://169.254.169.254/latest/api/token" \
+        -H "X-aws-ec2-metadata-token-ttl-seconds: 120" 2>/dev/null || true)
+IID=$(curl -sS -H "X-aws-ec2-metadata-token: $TOK" \
+        "http://169.254.169.254/latest/meta-data/instance-id" 2>/dev/null || true)
+IID="${IID:-unknown}"
+
+# cluster dir holds the cli binary (read from a parent env, fallback to default)
+CLUSTER_DIR=$(sed -n 's/^CLUSTER_DIR=//p' /etc/utexo/parent-16.env 2>/dev/null | head -1)
+CLUSTER_DIR="${CLUSTER_DIR:-/home/ubuntu/clone-stage}"
+CLI="$CLUSTER_DIR/utexo-bridge-parent-cli"
+
+DESC=$(nitro-cli describe-enclaves 2>/dev/null || echo '[]')
+SS=$(ss -ltnH 2>/dev/null || true)
+
+METRICS=()
+for CID in "${CIDS[@]}"; do
+  RUN=$(printf '%s' "$DESC" | jq -r --argjson c "$CID" \
+        'if any(.[]?; .EnclaveCID==$c and .State=="RUNNING") then 1 else 0 end' 2>/dev/null)
+  [ "$RUN" = "1" ] || RUN=0
+
+  P=${PORT[$CID]}
+  if printf '%s' "$SS" | grep -qE ":${P}([^0-9]|$)"; then LIS=1; else LIS=0; fi
+
+  RESP=0
+  if [ "$RUN" = "1" ] && [ -x "$CLI" ]; then
+    if "$CLI" --addr "vsock://${CID}:5000" get-keys >/dev/null 2>&1; then RESP=1; fi
+  fi
+
+  D="Dimensions=[{Name=Host,Value=${IID}},{Name=Cid,Value=${CID}}]"
+  METRICS+=( "MetricName=EnclaveRunning,${D},Value=${RUN},Unit=Count" )
+  METRICS+=( "MetricName=ParentListening,${D},Value=${LIS},Unit=Count" )
+  METRICS+=( "MetricName=EnclaveResponsive,${D},Value=${RESP},Unit=Count" )
+done
+
+# vsock-proxy liveness (egress: electrs 8001, evm-rpc 8002). vsock ports are NOT
+# TCP so `ss -ltn` can't see them — use systemctl. Dimension Proxy=electrs|evmrpc.
+declare -A PROXY=([electrs]=vsock-proxy-electrs [evmrpc]=vsock-proxy-evmrpc)
+for PNAME in "${!PROXY[@]}"; do
+  if systemctl is-active --quiet "${PROXY[$PNAME]}"; then UP=1; else UP=0; fi
+  DP="Dimensions=[{Name=Host,Value=${IID}},{Name=Proxy,Value=${PNAME}}]"
+  METRICS+=( "MetricName=VsockProxyUp,${DP},Value=${UP},Unit=Count" )
+done
+
+aws cloudwatch put-metric-data --namespace "$NS" --region "$REGION" \
+  --metric-data "${METRICS[@]}"
+REPORTER_EOF
+chmod 755 "$REPORTER"
+
+# --- 2. systemd service + timer --------------------------------------------
+log "writing utexo-enclave-metrics.service + .timer (every ${INTERVAL_SEC}s)"
+cat > /etc/systemd/system/utexo-enclave-metrics.service <<EOF
+[Unit]
+Description=Publish enclave/parent liveness metrics to CloudWatch (Utexo/EnclaveHost)
+After=network-online.target nitro-enclaves-allocator.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+Environment=AWS_REGION=${REGION}
+Environment=METRIC_NAMESPACE=${NS}
+ExecStart=${REPORTER}
+EOF
+
+cat > /etc/systemd/system/utexo-enclave-metrics.timer <<EOF
+[Unit]
+Description=Run utexo-enclave-metrics every ${INTERVAL_SEC}s
+
+[Timer]
+OnBootSec=${INTERVAL_SEC}
+OnUnitActiveSec=${INTERVAL_SEC}
+AccuracySec=5s
+
+[Install]
+WantedBy=timers.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now utexo-enclave-metrics.timer >/dev/null 2>&1 || true
+
+# --- 3. run once now + show what would be published ------------------------
+log "running the reporter once (foreground)"
+if AWS_REGION="$REGION" METRIC_NAMESPACE="$NS" "$REPORTER"; then
+  log "put-metric-data OK"
+else
+  log "NOTE: reporter run failed — if it is 'AccessDenied', attach utexo-stage-enclave-metrics-put to the instance role, then: systemctl start utexo-enclave-metrics.service"
+fi
+
+log "timer status:"
+systemctl --no-pager --lines=0 status utexo-enclave-metrics.timer 2>/dev/null | grep -E 'Active:|Trigger:' || true
+log "host-prep-metrics DONE — metrics -> namespace $NS (Host/Cid dims)"

--- a/deploy/host-prep-observability.sh
+++ b/deploy/host-prep-observability.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Host-prep for enclave-host observability (run as root, e.g. via SSM).
+#
+# PROBLEM (2026-08-27): today there is NO signal when a `parent` or `enclave`
+# process dies. Parents log only to journald (local, invisible off-host); the
+# enclave itself is opaque in prod (no `nitro-cli console` under non-debug = TEE
+# isolation). Listeners already ship to CloudWatch (`/utexo/stage/listeners`, via
+# the docker `awslogs` driver) — parents/enclaves have nothing.
+#
+# This stands up, idempotently and reboot-safe, the host side of LOG collection
+# (TODO §7a Track 1). It installs the amazon-cloudwatch-agent and ships the
+# relevant journald units to CloudWatch Logs:
+#
+#   journald unit                 -> log group `/utexo/stage/enclave-hosts`
+#   ---------------------------      stream `{instance_id}/<role>`
+#   utexo-parent@{16,18,20}       -> {instance_id}/parent    (gRPC adapter — the noisy one)
+#   utexo-enclave@{16,18,20}      -> {instance_id}/enclave   (host-side run/terminate lifecycle)
+#   nitro-enclaves-allocator      -> {instance_id}/nitro     (CPU/mem pool)
+#   vsock-proxy-*                 -> {instance_id}/nitro     (electrs / evm-rpc egress)
+#
+# ⚠️ SCOPE / TEE NOTE: this collects the HOST-SIDE `utexo-enclave@` unit (the
+# systemd wrapper that runs/terminates the enclave) + the allocator + vsock
+# proxies — NOT in-enclave application log lines, which are unreachable in prod
+# by design. For an in-enclave post-mortem you need a temporary `--debug-mode`
+# EIF (PCRs zeroed). The enclave/EIF is UNTOUCHED here → PCR0 unchanged, no
+# rebuild, same trust posture as the listener awslogs.
+#
+# ⚠️ Parents ≠ listeners mechanically: listeners are docker (`awslogs` driver);
+# parents/enclaves are systemd/journald, so awslogs does not apply. We use the
+# CloudWatch Agent journald collector with a `units` selector (supports the
+# `utexo-parent@*` wildcard). Requires a recent agent (journald support was added
+# to amazon-cloudwatch-agent); this script installs `latest`.
+#
+# ── IAM (attach ONCE to the hosts' instance role `ec2-ssm-role`) ──────────────
+# Least-privilege WRITE policy `utexo-stage-enclave-hosts-logs-write`:
+#   {
+#     "Version": "2012-10-17",
+#     "Statement": [{
+#       "Sid": "EnclaveHostsLogsWrite",
+#       "Effect": "Allow",
+#       "Action": [
+#         "logs:CreateLogGroup",
+#         "logs:CreateLogStream",
+#         "logs:PutLogEvents",
+#         "logs:PutRetentionPolicy",
+#         "logs:DescribeLogStreams",
+#         "logs:DescribeLogGroups"
+#       ],
+#       "Resource": [
+#         "arn:aws:logs:eu-central-1:867958227014:log-group:/utexo/stage/enclave-hosts",
+#         "arn:aws:logs:eu-central-1:867958227014:log-group:/utexo/stage/enclave-hosts:*"
+#       ]
+#     }]
+#   }
+# (Mirror of the listener logging IAM. A dev READ policy — like
+#  `utexo-stage-listener-logs-read` — can be added later for console access.)
+#
+# Usage (root):
+#   AWS_REGION=eu-central-1 LOG_GROUP=/utexo/stage/enclave-hosts \
+#   bash host-prep-observability.sh
+set -euo pipefail
+
+REGION="${AWS_REGION:-eu-central-1}"
+LOG_GROUP="${LOG_GROUP:-/utexo/stage/enclave-hosts}"
+RETENTION_DAYS="${RETENTION_DAYS:-30}"
+CWA_DIR=/opt/aws/amazon-cloudwatch-agent
+CWA_CTL="$CWA_DIR/bin/amazon-cloudwatch-agent-ctl"
+CWA_CONF="$CWA_DIR/etc/utexo-enclave-hosts.json"
+
+log(){ echo "[host-prep-obs $(date -u +%H:%M:%S)] $*"; }
+
+# --- 1. install amazon-cloudwatch-agent if absent --------------------------
+if [ ! -x "$CWA_CTL" ]; then
+  log "installing amazon-cloudwatch-agent (latest .deb) from S3 $REGION"
+  DEB=/tmp/amazon-cloudwatch-agent.deb
+  curl -fsSL -o "$DEB" \
+    "https://amazoncloudwatch-agent-${REGION}.s3.${REGION}.amazonaws.com/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb"
+  export DEBIAN_FRONTEND=noninteractive
+  dpkg -i -E "$DEB" || { apt-get -f install -y -qq; dpkg -i -E "$DEB"; }
+  rm -f "$DEB"
+else
+  log "amazon-cloudwatch-agent already present"
+fi
+# journald collection requires a recent agent — surface the version for the log.
+"$CWA_CTL" -version 2>/dev/null | sed 's/^/[host-prep-obs] cwagent /' || true
+
+# --- 2. render the agent config (journald -> CloudWatch Logs) --------------
+# `units` accepts wildcards; `priority` omitted => default `info` and above
+# (drops debug spam). One entry per role so streams stay readable.
+log "writing $CWA_CONF (log group $LOG_GROUP, retention ${RETENTION_DAYS}d)"
+install -d "$(dirname "$CWA_CONF")"
+umask 022
+cat > "$CWA_CONF" <<EOF
+{
+  "agent": { "run_as_user": "root" },
+  "logs": {
+    "logs_collected": {
+      "journald": {
+        "collect_list": [
+          {
+            "log_group_name": "${LOG_GROUP}",
+            "log_stream_name": "{instance_id}/parent",
+            "units": ["utexo-parent@*"],
+            "retention_in_days": ${RETENTION_DAYS}
+          },
+          {
+            "log_group_name": "${LOG_GROUP}",
+            "log_stream_name": "{instance_id}/enclave",
+            "units": ["utexo-enclave@*"],
+            "retention_in_days": ${RETENTION_DAYS}
+          },
+          {
+            "log_group_name": "${LOG_GROUP}",
+            "log_stream_name": "{instance_id}/nitro",
+            "units": ["nitro-enclaves-allocator", "vsock-proxy-*"],
+            "retention_in_days": ${RETENTION_DAYS}
+          }
+        ]
+      }
+    }
+  }
+}
+EOF
+
+# --- 3. load config + (re)start the agent ----------------------------------
+# `fetch-config -s` appends this config and starts/reloads the agent. The
+# systemd unit `amazon-cloudwatch-agent` is enabled by the package (survives
+# reboot). `-a append-config` keeps any pre-existing agent config intact.
+log "applying config via amazon-cloudwatch-agent-ctl (append + start)"
+"$CWA_CTL" -a append-config -m ec2 -s -c "file:$CWA_CONF"
+systemctl enable amazon-cloudwatch-agent >/dev/null 2>&1 || true
+
+# --- 4. self-test ----------------------------------------------------------
+sleep 3
+log "agent status:"
+"$CWA_CTL" -a status -m ec2 2>/dev/null | grep -E '"status"|"version"|"starttime"' || true
+
+# Confirm the target units actually exist on this host (so we know the selector
+# matches something). Non-fatal: a requester with fewer CIDs is still valid.
+FOUND=$(systemctl list-units --type=service --all --no-legend \
+          'utexo-parent@*' 'utexo-enclave@*' 'nitro-enclaves-allocator.service' 'vsock-proxy-*' 2>/dev/null \
+          | awk '{print $1}' | paste -sd' ' -)
+log "matched units on this host: ${FOUND:-<none — check unit names>}"
+
+# Optional (needs the IAM write policy above): confirm the stream landed.
+if command -v aws >/dev/null 2>&1; then
+  log "checking CloudWatch for streams under $LOG_GROUP (needs logs:DescribeLogStreams)"
+  aws logs describe-log-streams --log-group-name "$LOG_GROUP" \
+      --order-by LastEventTime --descending --max-items 5 --region "$REGION" \
+      --query 'logStreams[].logStreamName' --output text 2>&1 \
+    | sed 's/^/[host-prep-obs] stream: /' || \
+    log "NOTE: describe-log-streams failed — attach utexo-stage-enclave-hosts-logs-write to the instance role, then re-run."
+fi
+
+log "host-prep-observability DONE — parents/enclave/nitro journald -> $LOG_GROUP"

--- a/deploy/lambda/sns-to-slack/lambda_function.py
+++ b/deploy/lambda/sns-to-slack/lambda_function.py
@@ -1,0 +1,70 @@
+"""SNS -> Slack relay for enclave-host alerts (TODO §7a Track 2).
+
+Subscribed to the SNS topic `utexo-stage-enclave-alerts`; CloudWatch alarms
+publish here. Formats CloudWatch alarm notifications into a compact Slack
+message and POSTs to a Slack incoming webhook.
+
+The webhook URL is a SECRET and is NOT baked in: it is read at runtime from an
+SSM SecureString whose name is passed via the `SLACK_WEBHOOK_SSM_PARAM` env var
+(the Lambda role has `ssm:GetParameter` + `kms:Decrypt` on it only).
+"""
+import json
+import os
+import urllib.request
+
+import boto3
+
+_ssm = boto3.client("ssm")
+_webhook_cache = None
+
+_EMOJI = {
+    "ALARM": ":red_circle:",
+    "OK": ":large_green_circle:",
+    "INSUFFICIENT_DATA": ":white_circle:",
+}
+
+
+def _webhook():
+    global _webhook_cache
+    if _webhook_cache is None:
+        name = os.environ["SLACK_WEBHOOK_SSM_PARAM"]
+        _webhook_cache = _ssm.get_parameter(Name=name, WithDecryption=True)["Parameter"]["Value"]
+    return _webhook_cache
+
+
+def _format(sns) -> str:
+    subject = sns.get("Subject") or "CloudWatch notification"
+    message = sns.get("Message", "")
+    try:
+        alarm = json.loads(message)
+    except (ValueError, TypeError):
+        alarm = None
+
+    if isinstance(alarm, dict) and "AlarmName" in alarm:
+        state = alarm.get("NewStateValue", "?")
+        emoji = _EMOJI.get(state, ":grey_question:")
+        dims = ""
+        try:
+            dd = alarm.get("Trigger", {}).get("Dimensions", [])
+            dims = "  ".join(f"`{d['name']}={d['value']}`" for d in dd)
+        except (KeyError, TypeError):
+            pass
+        return (
+            f"{emoji} *{alarm.get('AlarmName')}* → *{state}*\n"
+            f"{alarm.get('NewStateReason', '')}\n"
+            f"{dims}  ·  {alarm.get('Region', '')}"
+        )
+    return f"*{subject}*\n{message}"
+
+
+def handler(event, _context):
+    url = _webhook()
+    for record in event.get("Records", []):
+        text = _format(record.get("Sns", {}))
+        payload = json.dumps({"text": text}).encode("utf-8")
+        req = urllib.request.Request(
+            url, data=payload, headers={"Content-Type": "application/json"}
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            resp.read()
+    return {"ok": True}


### PR DESCRIPTION
… lambda

Host-side observability for the TEE hosts (separate from the deploy-guide repo):
- deploy/host-prep-metrics.sh: install/configure CloudWatch agent for metrics.
- deploy/host-prep-observability.sh: logs/agent observability host prep.
- deploy/lambda/sns-to-slack: forward CloudWatch alarm SNS notifications to Slack.